### PR TITLE
fix(hooks): scope quality-gates to a named diff base, not the branch tip

### DIFF
--- a/scripts/hooks/check_gate_relaxation.py
+++ b/scripts/hooks/check_gate_relaxation.py
@@ -1,7 +1,8 @@
 """Pre-commit hook: anti-relaxation + tach-soundness gate (BLUEPRINT §17.6, #850).
 
-Refuses a commit whose STAGED diff relaxes a lint/coverage constraint or a tach
-module boundary without the sanctioned relax marker — a new unjustified
+Refuses a commit whose staged diff — read against a base this hook names rather
+than inherits, :mod:`teatree.quality.diff_base` — relaxes a lint/coverage
+constraint or a tach module boundary without the sanctioned relax marker — a new unjustified
 ``# noqa``, a new ``per-file-ignores`` / coverage ``omit`` entry, a lowered
 ``fail_under``, a committed ``--no-verify``, a new empty ``interfaces = []``, or
 a new ``ignore_type_checking_imports`` with no justifying comment. Findings key off
@@ -25,13 +26,13 @@ commit.
 """
 
 import os
-import subprocess
 import sys
 
 # Importable because prek runs this as ``uv run python`` with teatree installed;
 # the scan engine is pure and lives in the teatree package (single source of
 # truth shared with ``t3 tool gate-relaxation``).
-from teatree.quality.gate_relaxation import BLOCK, WARN, scan_relaxation
+from teatree.quality import diff_base
+from teatree.quality.gate_relaxation import BLOCK, WARN, RelaxationFinding, scan_relaxation
 
 _ALLOW_ENV = "ALLOW_GATE_RELAX"
 
@@ -54,18 +55,21 @@ def _gate_enabled() -> bool:
     return bool(get_effective_settings().gate_relaxation_gate_enabled)
 
 
-def _staged_diff() -> str:
-    result = subprocess.run(
-        ["git", "diff", "--cached", "--src-prefix=a/", "--dst-prefix=b/"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    return result.stdout if result.returncode == 0 else ""
+def _staged_diff(base: diff_base.DiffBase) -> str:
+    return diff_base.staged_diff(base, "--src-prefix=a/", "--dst-prefix=b/")
 
 
-def _scan_and_decide(diff: str) -> int:
-    findings = scan_relaxation(diff)
+def _authored_findings() -> list[RelaxationFinding]:
+    """Relaxations THIS commit's author introduced, not ones a merge brought in.
+
+    Findings are frozen dataclasses carrying the offending path and line text and
+    no diff-relative offset, so they compare directly across the two bases — no
+    key function needed.
+    """
+    return diff_base.authored_findings(scan_relaxation, _staged_diff)
+
+
+def _scan_and_decide(findings: list[RelaxationFinding]) -> int:
     if not findings:
         return 0
     if not _gate_enabled():
@@ -93,11 +97,8 @@ def _scan_and_decide(diff: str) -> int:
 
 
 def main() -> int:
-    diff = _staged_diff()
-    if not diff.strip():
-        return 0
     try:
-        return _scan_and_decide(diff)
+        return _scan_and_decide(_authored_findings())
     except Exception as exc:  # noqa: BLE001 — fail-open: a scan bug must never wedge commits repo-wide.
         print(f"WARN: anti-relaxation gate errored — failing open: {exc}", file=sys.stderr)
         return 0

--- a/scripts/hooks/check_gate_relaxation.py
+++ b/scripts/hooks/check_gate_relaxation.py
@@ -59,18 +59,25 @@ def _gate_enabled() -> bool:
     return bool(get_effective_settings().gate_relaxation_gate_enabled)
 
 
-def _staged_diff(base: diff_base.DiffBase) -> str:
+def _staged_diff(base: diff_base.DiffBase) -> str | None:
+    """The staged diff against *base*, or ``None`` when git could not produce it."""
     return diff_base.staged_diff(base, "--src-prefix=a/", "--dst-prefix=b/")
 
 
 def _authored_findings() -> list[RelaxationFinding]:
     """Relaxations THIS commit's author introduced, not ones a merge brought in.
 
-    Findings are frozen dataclasses carrying the offending path and line text and
-    no diff-relative offset, so they compare directly across the two bases — no
-    key function needed.
+    Keyed on ``(kind, path, line)`` — the fields that identify the relaxation
+    itself. ``message`` is deliberately excluded because it can quote the base
+    it was measured against (``fail_under`` lowered "from 90" against the branch
+    tip but "from 95" against the incoming side), which would make the two scans
+    disagree and silently drop a floor the operator really did lower.
     """
-    return diff_base.authored_findings(scan_relaxation, _staged_diff)
+    return diff_base.authored_findings(
+        scan_relaxation,
+        _staged_diff,
+        key=lambda finding: (finding.kind, finding.path, finding.line),
+    )
 
 
 def _scan_and_decide(findings: list[RelaxationFinding]) -> int:

--- a/scripts/hooks/check_gate_relaxation.py
+++ b/scripts/hooks/check_gate_relaxation.py
@@ -1,8 +1,7 @@
 """Pre-commit hook: anti-relaxation + tach-soundness gate (BLUEPRINT §17.6, #850).
 
-Refuses a commit whose staged diff — read against a base this hook names rather
-than inherits, :mod:`teatree.quality.diff_base` — relaxes a lint/coverage
-constraint or a tach module boundary without the sanctioned relax marker — a new unjustified
+Refuses a commit whose STAGED diff relaxes a lint/coverage constraint or a tach
+module boundary without the sanctioned relax marker — a new unjustified
 ``# noqa``, a new ``per-file-ignores`` / coverage ``omit`` entry, a lowered
 ``fail_under``, a committed ``--no-verify``, a new empty ``interfaces = []``, or
 a new ``ignore_type_checking_imports`` with no justifying comment. Findings key off
@@ -10,6 +9,11 @@ the diff's ADDED lines, so the boilerplate baseline present before the gate was
 deployed is exempt for free; ``# noqa`` findings are additionally diff-aware — a
 code already suppressed on a line at base is not flagged when it reappears
 because sibling codes were stripped, only a genuinely-new suppression is.
+
+The staged diff is read against a base this hook NAMES rather than inherits
+(:mod:`teatree.quality.diff_base`). Mid-merge a bare ``git diff --cached`` shows
+the incoming side's changes as this commit's, so the gate charged whoever
+resolved a merge for suppressions they did not write (#3899).
 
 Enforcement (§17.6.5 WARN-not-hardfail): a BLOCK finding refuses the commit; a
 WARN finding (possible test vacuity — a fuzzy heuristic) prints advisory-only

--- a/scripts/hooks/check_quality_gates.py
+++ b/scripts/hooks/check_quality_gates.py
@@ -52,10 +52,13 @@ _RULE_CODE_RE = re.compile(r'^\s*"[A-Z]+\d+[A-Z]?\d*"')
 
 
 # The scan's shape, held in one place so the two bases are compared like for like.
-_DIFF_ARGS: tuple[str, ...] = ("--diff-filter=ACMR", "-U0")
+# The prefixes are pinned because ``_added_lines`` strips a literal "b/": a repo
+# with ``diff.mnemonicPrefix`` or ``diff.noPrefix`` set would otherwise hand it
+# paths it cannot normalise, and every violation would name the wrong file.
+_DIFF_ARGS: tuple[str, ...] = ("--diff-filter=ACMR", "-U0", "--src-prefix=a/", "--dst-prefix=b/")
 
 
-def _staged_diff(path_filter: str = "", base: diff_base.DiffBase | None = None) -> str:
+def _staged_diff(path_filter: str = "", base: diff_base.DiffBase | None = None) -> str | None:
     """The staged diff against *base*, defaulting to the branch tip ("ours").
 
     The single place this hook talks to git, so both sides of a merge are
@@ -160,10 +163,12 @@ def main() -> int:
         # the same file) cancel out. Build a counter of removed markers per
         # file, then decrement as we encounter matching adds.
         # Removals are read against the branch tip only. Mid-merge that set also
-        # holds removals the incoming side made, so a marker it dropped could
-        # cancel an identical one added here. That errs toward reporting less,
-        # which is the safe direction for a cancellation rule; the additions
-        # themselves are still scoped to this author.
+        # holds removals the incoming side made, so a marker it dropped can
+        # cancel an identical one the operator added while resolving. That is a
+        # narrow FALSE-NEGATIVE window, not a "safe" simplification — named
+        # plainly here because this gate has no escape hatch and a reader
+        # deserves to know where it under-reports. The additions themselves are
+        # correctly scoped to this author.
         removed_markers: Counter[tuple[str, str]] = Counter()
         for filename, line in _removed_lines(code_diff):
             marker = _suppression_marker(line)

--- a/scripts/hooks/check_quality_gates.py
+++ b/scripts/hooks/check_quality_gates.py
@@ -159,6 +159,11 @@ def main() -> int:
         # Renamed-in-place suppressions (same marker removed and re-added in
         # the same file) cancel out. Build a counter of removed markers per
         # file, then decrement as we encounter matching adds.
+        # Removals are read against the branch tip only. Mid-merge that set also
+        # holds removals the incoming side made, so a marker it dropped could
+        # cancel an identical one added here. That errs toward reporting less,
+        # which is the safe direction for a cancellation rule; the additions
+        # themselves are still scoped to this author.
         removed_markers: Counter[tuple[str, str]] = Counter()
         for filename, line in _removed_lines(code_diff):
             marker = _suppression_marker(line)

--- a/scripts/hooks/check_quality_gates.py
+++ b/scripts/hooks/check_quality_gates.py
@@ -7,12 +7,23 @@ when relaxations are found — there is no bypass. Refactor instead.
 Suppressions that are renamed-in-place (same marker added and removed within
 the same file) net to zero and are not flagged.
 
-See: souliane/teatree#17
+Scope is the operator's OWN work, against a base this hook names rather than
+inherits: :func:`teatree.quality.diff_base.authored_findings`. A bare
+``git diff --cached`` is right for an ordinary commit and wrong mid-merge, where
+the index holds the merged result and every line the incoming side brought in
+reads as an addition by whoever is resolving. That made this gate — which has no
+escape hatch, by design (#525) — refuse any merge of a branch older than the
+most recent relaxation on the incoming side, over code its author never wrote
+(#3899).
+
+See: souliane/teatree#17, souliane/teatree#3899
 """
 
 import re
-import subprocess
 from collections import Counter
+from operator import itemgetter
+
+from teatree.quality import diff_base
 
 # Patterns in pyproject.toml that indicate structural config relaxation.
 _PYPROJECT_KEYWORD_PATTERNS: list[str] = [
@@ -40,12 +51,32 @@ _CODE_RELAXATION_PATTERNS: list[str] = [
 _RULE_CODE_RE = re.compile(r'^\s*"[A-Z]+\d+[A-Z]?\d*"')
 
 
-def _staged_diff(path_filter: str = "") -> str:
-    cmd = ["git", "diff", "--cached", "--diff-filter=ACMR", "-U0"]
-    if path_filter:
-        cmd.extend(["--", path_filter])
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    return result.stdout
+# The scan's shape, held in one place so the two bases are compared like for like.
+_DIFF_ARGS: tuple[str, ...] = ("--diff-filter=ACMR", "-U0")
+
+
+def _staged_diff(path_filter: str = "", base: diff_base.DiffBase | None = None) -> str:
+    """The staged diff against *base*, defaulting to the branch tip ("ours").
+
+    The single place this hook talks to git, so both sides of a merge are
+    rendered by the same command and differ only in the base.
+    """
+    path_args = ("--", path_filter) if path_filter else ()
+    return diff_base.staged_diff(base or diff_base.branch_tip(), *_DIFF_ARGS, *path_args)
+
+
+def _authored_added_lines(path_filter: str = "") -> list[tuple[str, int, str]]:
+    """Added lines THIS commit's author wrote, excluding a merge's incoming side.
+
+    Keyed on ``(filename, text)`` rather than the whole tuple: the same authored
+    line lands at different offsets in the two diffs, so the line number cannot
+    take part in the comparison.
+    """
+    return diff_base.authored_findings(
+        _added_lines,
+        lambda base: _staged_diff(path_filter, base),
+        key=itemgetter(0, 2),
+    )
 
 
 def _added_lines(diff: str) -> list[tuple[str, int, str]]:
@@ -119,11 +150,9 @@ def _is_pyproject_relaxation(line: str) -> bool:
 def main() -> int:
     violations: list[str] = []
 
-    pyproject_diff = _staged_diff("pyproject.toml")
-    if pyproject_diff:
-        for filename, line_num, line in _added_lines(pyproject_diff):
-            if _is_pyproject_relaxation(line):
-                violations.append(f"  {filename}:{line_num}: {line.strip()}")
+    for filename, line_num, line in _authored_added_lines("pyproject.toml"):
+        if _is_pyproject_relaxation(line):
+            violations.append(f"  {filename}:{line_num}: {line.strip()}")
 
     code_diff = _staged_diff()
     if code_diff:
@@ -137,7 +166,7 @@ def main() -> int:
                 removed_markers[filename, marker] += 1
 
         skip_prefixes = ("tests/", "scripts/hooks/", "e2e/", "skills/", "docs/")
-        for filename, line_num, line in _added_lines(code_diff):
+        for filename, line_num, line in _authored_added_lines():
             if filename == "pyproject.toml" or filename.startswith(skip_prefixes):
                 continue
             marker = _suppression_marker(line)

--- a/src/teatree/quality/diff_base.py
+++ b/src/teatree/quality/diff_base.py
@@ -66,25 +66,36 @@ def merge_incoming() -> DiffBase | None:
     ``MERGE_HEAD`` exists only between ``git merge`` and the commit that
     concludes it — precisely the window in which the staged diff stops being a
     faithful record of what this commit's author wrote.
+
+    Not every merge-shaped operation has one. ``git merge --squash`` records no
+    ref for the incoming side, and rebase / cherry-pick / revert set their own
+    refs instead. Those all fall back to the branch tip. For rebase and friends
+    that is right — there the staged diff IS the operator's own change — but a
+    squash merge is a genuine blind spot git gives us no ref to close.
     """
     if _rev_exists("MERGE_HEAD"):
         return DiffBase(ref="MERGE_HEAD", label="the incoming side (theirs)")
     return None
 
 
-def staged_diff(base: DiffBase, *args: str) -> str:
-    """The staged diff against *base*, or ``""`` when git refuses.
+def staged_diff(base: DiffBase, *args: str) -> str | None:
+    """The staged diff against *base*, or ``None`` when git could not produce it.
+
+    ``None`` is deliberately NOT ``""``. An empty diff means "nothing changed
+    against this base"; a git failure means "unknown". Collapsing the two is how
+    a fail-safe primitive becomes a false green in a caller that reads emptiness
+    as an answer — so the distinction is carried in the type.
 
     *args* are appended verbatim, so a caller keeps its own ``--diff-filter`` /
     ``-U0`` / pathspec choices; only the base is decided here.
     """
     result = run_allowed_to_fail(["git", "diff", "--cached", base.ref, *args], expected_codes=None)
-    return result.stdout if result.returncode == 0 else ""
+    return result.stdout if result.returncode == 0 else None
 
 
 def authored_findings[T](
     scan: Callable[[str], Iterable[T]],
-    diff_for: Callable[[DiffBase], str],
+    diff_for: Callable[[DiffBase], str | None],
     *,
     key: Callable[[T], Hashable] = lambda finding: finding,
 ) -> list[T]:
@@ -102,13 +113,24 @@ def authored_findings[T](
     the same command — two bases compared like for like. :func:`staged_diff` is
     the obvious thing to build it from.
 
-    *key* exists because a finding usually carries a line NUMBER, and the same
-    authored line sits at different offsets in the two diffs. Key on the parts
-    that identify the change (path and text), not on where it happens to land.
+    *key* must be BASE-INVARIANT, and choosing it is the subtle part. A finding
+    usually carries a line NUMBER, and the same authored line sits at different
+    offsets in the two diffs. Worse, a finding's prose can quote the base it was
+    measured against (``lowered from 90 to 80`` vs ``from 95 to 80``). Key only
+    on the parts that identify the change itself — kind, path, offending text.
+    A key that varies with the base makes the intersection empty and SILENTLY
+    drops real findings, which is the failure this whole module exists to avoid.
+
+    If the incoming side cannot be read, every finding is reported unfiltered
+    rather than dropped: over-reporting is recoverable by a human, a false green
+    is not.
     """
-    ours = list(scan(diff_for(branch_tip())))
+    ours = list(scan(diff_for(branch_tip()) or ""))
     theirs = merge_incoming()
     if theirs is None:
         return ours
-    authored = {key(finding) for finding in scan(diff_for(theirs))}
+    theirs_diff = diff_for(theirs)
+    if theirs_diff is None:
+        return ours
+    authored = {key(finding) for finding in scan(theirs_diff)}
     return [finding for finding in ours if key(finding) in authored]

--- a/src/teatree/quality/diff_base.py
+++ b/src/teatree/quality/diff_base.py
@@ -1,0 +1,114 @@
+"""Named diff bases for the staged-diff gates (souliane/teatree#3899).
+
+A gate that shells out to a bare ``git diff --cached`` never says which
+comparison it wants; it inherits whatever git defaults to. Outside a merge that
+default is right — ``--cached`` compares the index against ``HEAD``, which is
+exactly the commit being authored. Mid-merge it is wrong, and wrong in the
+direction that costs the most: the index holds the merged result, so every line
+the *incoming* side contributes reads as a line this commit introduces. The gate
+then judges a diff nobody in this commit wrote and refuses the merge over code
+the operator inherited.
+
+The fix is not a different bare invocation, it is a *named* one. A commit has one
+side outside a merge (:func:`branch_tip`) and two during one (:func:`branch_tip`
+plus :func:`merge_incoming`). The operator's own work is what is new against
+**both**: a line already present on the incoming side was written by whoever put
+it there, whatever the index now says. :func:`authored_findings` is that rule,
+expressed once, so each caller states the comparison it intends rather than
+leaving the next reader to infer it from an argument list.
+
+Direction of failure: a base that cannot be resolved degrades to scanning
+against the branch tip alone — the pre-#3899 behaviour. A gate whose base
+resolution breaks must fall back to over-reporting, never to a silent pass.
+"""
+
+from collections.abc import Callable, Hashable, Iterable
+from dataclasses import dataclass
+
+from teatree.utils.run import run_allowed_to_fail
+
+# git's canonical empty tree. The base for a commit with no parent, where
+# ``HEAD`` does not resolve and every staged line is by definition authored here.
+EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+
+@dataclass(frozen=True)
+class DiffBase:
+    """One side of the history a staged diff is compared against.
+
+    ``ref`` is what git is handed; ``label`` is what a human is told when the
+    gate explains which changes it looked at.
+    """
+
+    ref: str
+    label: str
+
+
+def _rev_exists(ref: str) -> bool:
+    result = run_allowed_to_fail(["git", "rev-parse", "-q", "--verify", ref], expected_codes=None)
+    return result.returncode == 0
+
+
+def branch_tip() -> DiffBase:
+    """The side the operator already had — "ours", the commit being extended.
+
+    Falls back to the empty tree on an unborn ``HEAD`` (the initial commit), so
+    the very first commit is still scanned rather than erroring out.
+    """
+    if _rev_exists("HEAD"):
+        return DiffBase(ref="HEAD", label="the branch tip (ours)")
+    return DiffBase(ref=EMPTY_TREE, label="the empty tree (no commit yet)")
+
+
+def merge_incoming() -> DiffBase | None:
+    """The incoming side of an in-progress merge, or ``None`` when not merging.
+
+    ``MERGE_HEAD`` exists only between ``git merge`` and the commit that
+    concludes it — precisely the window in which the staged diff stops being a
+    faithful record of what this commit's author wrote.
+    """
+    if _rev_exists("MERGE_HEAD"):
+        return DiffBase(ref="MERGE_HEAD", label="the incoming side (theirs)")
+    return None
+
+
+def staged_diff(base: DiffBase, *args: str) -> str:
+    """The staged diff against *base*, or ``""`` when git refuses.
+
+    *args* are appended verbatim, so a caller keeps its own ``--diff-filter`` /
+    ``-U0`` / pathspec choices; only the base is decided here.
+    """
+    result = run_allowed_to_fail(["git", "diff", "--cached", base.ref, *args], expected_codes=None)
+    return result.stdout if result.returncode == 0 else ""
+
+
+def authored_findings[T](
+    scan: Callable[[str], Iterable[T]],
+    diff_for: Callable[[DiffBase], str],
+    *,
+    key: Callable[[T], Hashable] = lambda finding: finding,
+) -> list[T]:
+    """Run *scan* over the staged diff, keeping only what this commit's author wrote.
+
+    Outside a merge there is one side, so this is the plain staged scan. During a
+    merge the scan is repeated against the incoming side and the two are
+    intersected on *key*: a finding that survives the comparison against the
+    incoming side is new to that side too, i.e. the operator produced it while
+    resolving. One that disappears was already on the incoming side and arrived
+    with the merge — inherited, not authored.
+
+    *diff_for* is injected rather than built here so a caller keeps its own diff
+    shape (``--diff-filter``, ``-U0``, pathspec) and gets both sides rendered by
+    the same command — two bases compared like for like. :func:`staged_diff` is
+    the obvious thing to build it from.
+
+    *key* exists because a finding usually carries a line NUMBER, and the same
+    authored line sits at different offsets in the two diffs. Key on the parts
+    that identify the change (path and text), not on where it happens to land.
+    """
+    ours = list(scan(diff_for(branch_tip())))
+    theirs = merge_incoming()
+    if theirs is None:
+        return ours
+    authored = {key(finding) for finding in scan(diff_for(theirs))}
+    return [finding for finding in ours if key(finding) in authored]

--- a/tests/teatree_quality/test_diff_base.py
+++ b/tests/teatree_quality/test_diff_base.py
@@ -20,6 +20,7 @@ import pytest
 
 from scripts.hooks import check_gate_relaxation, check_quality_gates
 from teatree.quality import diff_base
+from teatree.quality.diff_base import EMPTY_TREE, DiffBase, authored_findings, branch_tip, merge_incoming, staged_diff
 from tests._git_repo import git_identity_env, make_git_repo, run_git
 
 _INHERITED_RELAXATION = '  "S999",  # added on main, not by this author'
@@ -75,9 +76,12 @@ def merging_cwd(merging_repo: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 class TestBaseResolution:
     def test_merge_incoming_is_named_only_during_a_merge(self, merging_cwd: Path) -> None:
-        incoming = diff_base.merge_incoming()
-        assert incoming is not None
+        incoming = merge_incoming()
+        assert isinstance(incoming, DiffBase)
         assert incoming.ref == "MERGE_HEAD"
+        # The label is what a gate prints when it explains which changes it read,
+        # so it has to name the side a human would recognise.
+        assert "incoming" in incoming.label
 
     def test_merge_incoming_is_none_on_an_ordinary_commit(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -86,8 +90,8 @@ class TestBaseResolution:
         monkeypatch.chdir(repo)
         for var, value in git_identity_env().items():
             monkeypatch.setenv(var, value)
-        assert diff_base.merge_incoming() is None
-        assert diff_base.branch_tip().ref == "HEAD"
+        assert merge_incoming() is None
+        assert branch_tip().ref == "HEAD"
 
     def test_branch_tip_falls_back_to_the_empty_tree_before_the_first_commit(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -96,15 +100,15 @@ class TestBaseResolution:
         monkeypatch.chdir(repo)
         for var, value in git_identity_env().items():
             monkeypatch.setenv(var, value)
-        assert diff_base.branch_tip().ref == diff_base.EMPTY_TREE
+        assert branch_tip().ref == EMPTY_TREE
 
 
 class TestAuthoredFindings:
     def test_a_line_the_incoming_side_already_had_is_not_this_author_s(self, merging_cwd: Path) -> None:
         """The merge case. A naive one-branch test never reaches this."""
-        found = diff_base.authored_findings(
+        found = authored_findings(
             lambda diff: [line for line in diff.splitlines() if line.startswith("+")],
-            lambda base: diff_base.staged_diff(base, "--diff-filter=ACMR", "-U0", "--", "pyproject.toml"),
+            lambda base: staged_diff(base, "--diff-filter=ACMR", "-U0", "--", "pyproject.toml"),
         )
         assert not [line for line in found if "S999" in line], (
             "main's own relaxation was attributed to the merging author"
@@ -119,9 +123,9 @@ class TestAuthoredFindings:
         )
         run_git(merging_cwd, "add", "pyproject.toml")
 
-        found = diff_base.authored_findings(
+        found = authored_findings(
             lambda diff: [line for line in diff.splitlines() if line.startswith("+")],
-            lambda base: diff_base.staged_diff(base, "--diff-filter=ACMR", "-U0", "--", "pyproject.toml"),
+            lambda base: staged_diff(base, "--diff-filter=ACMR", "-U0", "--", "pyproject.toml"),
         )
         assert [line for line in found if "E501" in line], (
             "the author's own relaxation was suppressed along with the inherited one"
@@ -259,8 +263,8 @@ class TestIntersectionCannotSilenceRealFindings:
 
         monkeypatch.setattr(diff_base, "run_allowed_to_fail", fail_on_incoming)
 
-        found = diff_base.authored_findings(
+        found = authored_findings(
             lambda diff: [line for line in diff.splitlines() if line.startswith("+")],
-            lambda base: diff_base.staged_diff(base, "--diff-filter=ACMR", "-U0", "--", "pyproject.toml"),
+            lambda base: staged_diff(base, "--diff-filter=ACMR", "-U0", "--", "pyproject.toml"),
         )
         assert [line for line in found if "S999" in line], "an unreadable incoming side silently cleared every finding"

--- a/tests/teatree_quality/test_diff_base.py
+++ b/tests/teatree_quality/test_diff_base.py
@@ -13,6 +13,7 @@ branch, one commit, no merge — passes both before and after the fix, which is
 exactly why the merge case is the one that has to be written.
 """
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -192,3 +193,74 @@ class TestGateRelaxationHookOnAMerge:
             monkeypatch.setenv(var, value)
 
         assert not [f.path for f in check_gate_relaxation._authored_findings()]
+
+
+class TestIntersectionCannotSilenceRealFindings:
+    """The intersection must never turn a finding into silence.
+
+    Both cases below made the gate pass a relaxation the operator authored — the
+    exact false green the named base exists to prevent, arrived at from the
+    opposite direction.
+    """
+
+    def test_a_base_relative_finding_field_does_not_drop_the_finding(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A key that varies with the base empties the intersection.
+
+        `fail_under` findings quote the value they were measured against, so the
+        two scans disagree on `message` for one and the same lowering.
+        """
+        repo = make_git_repo(tmp_path / "floor")
+        coveragerc = repo / ".coveragerc"
+        coveragerc.write_text("[report]\nfail_under = 90\n", encoding="utf-8")
+        run_git(repo, "add", "-A")
+        run_git(repo, "commit", "-q", "-m", "base")
+
+        run_git(repo, "checkout", "-q", "-b", "feature")
+        (repo / "unrelated.py").write_text("VALUE = 1\n", encoding="utf-8")
+        run_git(repo, "add", "-A")
+        run_git(repo, "commit", "-q", "-m", "branch work")
+
+        run_git(repo, "checkout", "-q", "main")
+        coveragerc.write_text("[report]\nfail_under = 95\n", encoding="utf-8")
+        run_git(repo, "add", "-A")
+        run_git(repo, "commit", "-q", "-m", "main raises the floor")
+
+        run_git(repo, "checkout", "-q", "feature")
+        run_git(repo, "merge", "--no-commit", "--no-ff", "main", check=False)
+
+        # The operator lowers the floor themselves while resolving.
+        coveragerc.write_text("[report]\nfail_under = 80\n", encoding="utf-8")
+        run_git(repo, "add", ".coveragerc")
+
+        monkeypatch.chdir(repo)
+        for var, value in git_identity_env().items():
+            monkeypatch.setenv(var, value)
+
+        kinds = [f.kind for f in check_gate_relaxation._authored_findings()]
+        assert "coverage_floor_lowered" in kinds, "a floor the operator lowered during the merge was silently dropped"
+
+    def test_an_unreadable_incoming_side_reports_everything(
+        self, merging_cwd: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A git failure on the incoming side must not read as 'authored nothing'.
+
+        Faked at the subprocess seam, so the gate sees exactly what a real
+        mid-merge git failure produces: a non-zero exit on the second diff only.
+        """
+        real_run = diff_base.run_allowed_to_fail
+
+        def fail_on_incoming(cmd: list[str], **kwargs: object) -> object:
+            result = real_run(cmd, **kwargs)
+            if "MERGE_HEAD" in cmd and "diff" in cmd:
+                return subprocess.CompletedProcess(cmd, 128, "", "fatal: bad object")
+            return result
+
+        monkeypatch.setattr(diff_base, "run_allowed_to_fail", fail_on_incoming)
+
+        found = diff_base.authored_findings(
+            lambda diff: [line for line in diff.splitlines() if line.startswith("+")],
+            lambda base: diff_base.staged_diff(base, "--diff-filter=ACMR", "-U0", "--", "pyproject.toml"),
+        )
+        assert [line for line in found if "S999" in line], "an unreadable incoming side silently cleared every finding"

--- a/tests/teatree_quality/test_diff_base.py
+++ b/tests/teatree_quality/test_diff_base.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.hooks import check_quality_gates
+from scripts.hooks import check_gate_relaxation, check_quality_gates
 from teatree.quality import diff_base
 from tests._git_repo import git_identity_env, make_git_repo, run_git
 
@@ -156,3 +156,39 @@ class TestQualityGatesHookOnAMerge:
         for var, value in git_identity_env().items():
             monkeypatch.setenv(var, value)
         assert check_quality_gates.main() == 1
+
+
+class TestGateRelaxationHookOnAMerge:
+    """The sibling gate #3899 names: same bare base, same misattribution.
+
+    It survived in the field only because its ``ALLOW_GATE_RELAX`` escape lets a
+    truthful reason through — an escape is not a reason to keep scanning the
+    wrong changes.
+    """
+
+    def test_an_inherited_noqa_is_not_charged_to_the_merging_author(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = make_git_repo(tmp_path / "relax")
+        (repo / "mod.py").write_text("VALUE = 1\n", encoding="utf-8")
+        run_git(repo, "add", "-A")
+        run_git(repo, "commit", "-q", "-m", "base")
+
+        run_git(repo, "checkout", "-q", "-b", "feature")
+        (repo / "other.py").write_text("OTHER = 2\n", encoding="utf-8")
+        run_git(repo, "add", "-A")
+        run_git(repo, "commit", "-q", "-m", "branch work")
+
+        run_git(repo, "checkout", "-q", "main")
+        (repo / "mod.py").write_text("VALUE = 1  # noqa\n", encoding="utf-8")
+        run_git(repo, "add", "-A")
+        run_git(repo, "commit", "-q", "-m", "main suppresses")
+
+        run_git(repo, "checkout", "-q", "feature")
+        run_git(repo, "merge", "--no-commit", "--no-ff", "main", check=False)
+
+        monkeypatch.chdir(repo)
+        for var, value in git_identity_env().items():
+            monkeypatch.setenv(var, value)
+
+        assert not [f.path for f in check_gate_relaxation._authored_findings()]

--- a/tests/teatree_quality/test_diff_base.py
+++ b/tests/teatree_quality/test_diff_base.py
@@ -1,0 +1,158 @@
+"""Regression: the staged-diff gates must scan a NAMED base (souliane/teatree#3899).
+
+The defect these pin is not "the scan is noisy" — it is that mid-merge the scan
+answers a different question than its caller asks. ``git diff --cached`` with no
+base named compares the index to ``HEAD``, and during a merge the index holds
+the merged result, so everything the incoming side contributed is presented as
+this commit's work.
+
+Every test here drives a REAL merge through real git rather than feeding a
+hand-written diff to a parser: the bug lives entirely in which two commits git
+is asked to compare, so a fixture diff cannot reproduce it. The naive test — one
+branch, one commit, no merge — passes both before and after the fix, which is
+exactly why the merge case is the one that has to be written.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.hooks import check_quality_gates
+from teatree.quality import diff_base
+from tests._git_repo import git_identity_env, make_git_repo, run_git
+
+_INHERITED_RELAXATION = '  "S999",  # added on main, not by this author'
+_AUTHORED_RELAXATION = '  "E501",  # added while resolving'
+
+
+def _commit(repo: Path, message: str) -> None:
+    run_git(repo, "add", "-A")
+    run_git(repo, "commit", "-q", "-m", message)
+
+
+@pytest.fixture
+def merging_repo(tmp_path: Path) -> Path:
+    """A repo stopped mid-merge, `main` carrying a relaxation the branch author never wrote.
+
+    Shape (the #3899 report's shape, minimised):
+
+        main:   pyproject.toml gains ``_INHERITED_RELAXATION``
+        branch: forked BEFORE that, touches an unrelated file
+        then:   ``git merge main`` on the branch, committed by nobody yet
+
+    At that point the index contains main's relaxation, so a scan against the
+    branch tip alone sees it as this commit's addition.
+    """
+    repo = make_git_repo(tmp_path / "repo")
+    (repo / "pyproject.toml").write_text("[tool.ruff.lint]\nignore = [\n]\n", encoding="utf-8")
+    _commit(repo, "base")
+
+    run_git(repo, "checkout", "-q", "-b", "feature")
+    (repo / "unrelated.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _commit(repo, "branch work")
+
+    run_git(repo, "checkout", "-q", "main")
+    (repo / "pyproject.toml").write_text(
+        f"[tool.ruff.lint]\nignore = [\n{_INHERITED_RELAXATION}\n]\n", encoding="utf-8"
+    )
+    _commit(repo, "main adds an ignore")
+
+    run_git(repo, "checkout", "-q", "feature")
+    # --no-commit stops exactly where the commit-msg hook would run. check=False:
+    # a conflicted merge exits non-zero and that is still the state under test.
+    run_git(repo, "merge", "--no-commit", "--no-ff", "main", check=False)
+    return repo
+
+
+@pytest.fixture
+def merging_cwd(merging_repo: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.chdir(merging_repo)
+    for var, value in git_identity_env().items():
+        monkeypatch.setenv(var, value)
+    return merging_repo
+
+
+class TestBaseResolution:
+    def test_merge_incoming_is_named_only_during_a_merge(self, merging_cwd: Path) -> None:
+        incoming = diff_base.merge_incoming()
+        assert incoming is not None
+        assert incoming.ref == "MERGE_HEAD"
+
+    def test_merge_incoming_is_none_on_an_ordinary_commit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = make_git_repo(tmp_path / "plain")
+        monkeypatch.chdir(repo)
+        for var, value in git_identity_env().items():
+            monkeypatch.setenv(var, value)
+        assert diff_base.merge_incoming() is None
+        assert diff_base.branch_tip().ref == "HEAD"
+
+    def test_branch_tip_falls_back_to_the_empty_tree_before_the_first_commit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = make_git_repo(tmp_path / "unborn", initial_commit=False)
+        monkeypatch.chdir(repo)
+        for var, value in git_identity_env().items():
+            monkeypatch.setenv(var, value)
+        assert diff_base.branch_tip().ref == diff_base.EMPTY_TREE
+
+
+class TestAuthoredFindings:
+    def test_a_line_the_incoming_side_already_had_is_not_this_author_s(self, merging_cwd: Path) -> None:
+        """The merge case. A naive one-branch test never reaches this."""
+        found = diff_base.authored_findings(
+            lambda diff: [line for line in diff.splitlines() if line.startswith("+")],
+            lambda base: diff_base.staged_diff(base, "--diff-filter=ACMR", "-U0", "--", "pyproject.toml"),
+        )
+        assert not [line for line in found if "S999" in line], (
+            "main's own relaxation was attributed to the merging author"
+        )
+
+    def test_a_line_written_while_resolving_is_still_reported(self, merging_cwd: Path) -> None:
+        """The fix must not buy silence by exempting merges wholesale."""
+        pyproject = merging_cwd / "pyproject.toml"
+        pyproject.write_text(
+            pyproject.read_text(encoding="utf-8").replace("]", f"{_AUTHORED_RELAXATION}\n]"),
+            encoding="utf-8",
+        )
+        run_git(merging_cwd, "add", "pyproject.toml")
+
+        found = diff_base.authored_findings(
+            lambda diff: [line for line in diff.splitlines() if line.startswith("+")],
+            lambda base: diff_base.staged_diff(base, "--diff-filter=ACMR", "-U0", "--", "pyproject.toml"),
+        )
+        assert [line for line in found if "E501" in line], (
+            "the author's own relaxation was suppressed along with the inherited one"
+        )
+        assert not [line for line in found if "S999" in line]
+
+
+class TestQualityGatesHookOnAMerge:
+    def test_the_hook_does_not_block_a_merge_over_inherited_relaxations(self, merging_cwd: Path) -> None:
+        """#3899 verbatim: resolving a merge of main must not be refused."""
+        assert check_quality_gates.main() == 0
+
+    def test_the_hook_still_blocks_a_relaxation_authored_during_the_merge(self, merging_cwd: Path) -> None:
+        pyproject = merging_cwd / "pyproject.toml"
+        pyproject.write_text(
+            pyproject.read_text(encoding="utf-8").replace("]", f"{_AUTHORED_RELAXATION}\n]"),
+            encoding="utf-8",
+        )
+        run_git(merging_cwd, "add", "pyproject.toml")
+        assert check_quality_gates.main() == 1
+
+    def test_an_ordinary_commit_is_unaffected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Outside a merge the base is still the branch tip — no behaviour change."""
+        repo = make_git_repo(tmp_path / "plain")
+        (repo / "pyproject.toml").write_text("[tool.ruff.lint]\nignore = [\n]\n", encoding="utf-8")
+        _commit(repo, "base")
+        (repo / "pyproject.toml").write_text(
+            f"[tool.ruff.lint]\nignore = [\n{_AUTHORED_RELAXATION}\n]\n", encoding="utf-8"
+        )
+        run_git(repo, "add", "pyproject.toml")
+
+        monkeypatch.chdir(repo)
+        for var, value in git_identity_env().items():
+            monkeypatch.setenv(var, value)
+        assert check_quality_gates.main() == 1

--- a/tests/test_quality_gates_hook.py
+++ b/tests/test_quality_gates_hook.py
@@ -80,13 +80,13 @@ class TestMainDetection:
     def test_returns_zero_when_no_relaxations(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import scripts.hooks.check_quality_gates as mod  # noqa: PLC0415
 
-        monkeypatch.setattr(mod, "_staged_diff", lambda path_filter="": "")
+        monkeypatch.setattr(mod, "_staged_diff", lambda path_filter="", base=None: "")
         assert mod.main() == 0
 
     def test_detects_pyproject_relaxation(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import scripts.hooks.check_quality_gates as mod  # noqa: PLC0415
 
-        def fake_diff(path_filter: str = "") -> str:
+        def fake_diff(path_filter: str = "", base: object = None) -> str:
             if path_filter == "pyproject.toml":
                 return _PYPROJECT_DIFF
             return ""
@@ -104,7 +104,7 @@ class TestMainDetection:
         """
         import scripts.hooks.check_quality_gates as mod  # noqa: PLC0415
 
-        def fake_diff(path_filter: str = "") -> str:
+        def fake_diff(path_filter: str = "", base: object = None) -> str:
             if path_filter == "pyproject.toml":
                 return ""
             return _NOQA_DIFF
@@ -116,7 +116,7 @@ class TestMainDetection:
     def test_detects_pragma_in_code(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import scripts.hooks.check_quality_gates as mod  # noqa: PLC0415
 
-        def fake_diff(path_filter: str = "") -> str:
+        def fake_diff(path_filter: str = "", base: object = None) -> str:
             if path_filter == "pyproject.toml":
                 return ""
             return _PRAGMA_DIFF
@@ -133,7 +133,7 @@ class TestMainDetection:
         """A ``relax:`` commit subject must NOT bypass the gate (regression for #525)."""
         import scripts.hooks.check_quality_gates as mod  # noqa: PLC0415
 
-        def fake_diff(path_filter: str = "") -> str:
+        def fake_diff(path_filter: str = "", base: object = None) -> str:
             if path_filter == "pyproject.toml":
                 return _PYPROJECT_DIFF
             return ""


### PR DESCRIPTION
## What

Gives the two staged-diff commit gates an explicit, **named** diff base instead of the one they inherited from a bare `git diff --cached`.

New `src/teatree/quality/diff_base.py`:

- `branch_tip()` — "ours", the commit being extended. Falls back to the empty tree on an unborn `HEAD`.
- `merge_incoming()` — "theirs", present only between `git merge` and the commit that concludes it.
- `staged_diff(base, *args)` — returns `str | None`; the caller keeps its own `--diff-filter` / `-U0` / pathspec, only the base is decided here.
- `authored_findings(scan, diff_for, key=...)` — runs the caller's scan against the branch tip and, during a merge, again against the incoming side, keeping only findings new to **both**.

Wired into both gates:

- `scripts/hooks/check_quality_gates.py` — additions go through `_authored_added_lines`, keyed on `(path, text)` because the same authored line sits at different offsets in the two diffs.
- `scripts/hooks/check_gate_relaxation.py` — `_scan_and_decide` takes findings rather than a diff string, keyed on `(kind, path, line)`.

Closes #3899.

## Why

`_staged_diff` shelled out to a bare `git diff --cached`, which never states which comparison it wants — it takes git's default. Outside a merge that default is exactly right: `--cached` compares the index against `HEAD`, which is the commit being authored. Mid-merge it is wrong, and wrong in the expensive direction. The index holds the merged result, so every line the incoming side contributed reads as a line this commit introduces. The gate then judged a diff nobody in this commit wrote.

The cost is concentrated because `quality-gates` has **no escape hatch, by design** (#525). The options at the point of failure were to abandon the merge or to bypass every other gate along with it. That makes the documented merge-not-rebase maintenance workflow un-committable for any branch older than the most recent relaxation on the incoming side — a plausible contributor to branches going stale rather than being refreshed.

The fix is deliberately not a merge-commit exemption. Exempting merges wholesale would buy quiet by giving up the gate exactly where a suppression is easiest to slip in unnoticed. Scoping to what is new against both parents keeps the gate live during a merge while charging the author only for what they wrote.

Two design notes worth the reader's time:

- **Named, not just corrected.** A gate scanning the wrong base is the same failure family as one that reports success while failing, or one that fires on correct behaviour: the signal stops meaning what its reader thinks it means, and a bare `git diff` hides which comparison was intended. `DiffBase` carries a human `label` beside the ref so the intent is legible at the call site.
- **Direction of failure.** An unresolvable base degrades to reporting everything — never to a silent pass.

## Tests

`tests/teatree_quality/test_diff_base.py` drives **real merges through real git** rather than feeding fixture diffs to a parser: the defect lives entirely in which two commits git is asked to compare, so a hand-written diff cannot reproduce it. The naive shape — one branch, one commit, no merge — passes both before and after, which is precisely why the merge case had to be written.

Observed RED before the fix on `TestQualityGatesHookOnAMerge::test_the_hook_does_not_block_a_merge_over_inherited_relaxations`, failing with the reported symptom (`Quality gate relaxation detected: pyproject.toml:3: "S999"` — a line added on the incoming side). GREEN after.

Four of the behavioural tests are genuine regression pins (verified RED on pre-fix code). Two more — "a relaxation authored *while* resolving is still blocked" and "an ordinary non-merge commit is unaffected" — are guard tests: they pass pre-fix by construction and exist to falsify the wrong fix, not to pin this bug.

Local: 3,797 passed across `tests/teatree_quality`, `tests/teatree_hooks`, `tests/quality`, `tests/conformance` and both hook suites. Full `dev/ci-parity-fast.sh`: 34,934 passed / 1 failed — the failure is `test_migration_squash.py::test_fresh_install_squashed_matches_unsquashed_chain`, a pre-existing environment-dependent unraisable-exception flake that this diff does not touch (no migrations changed).

## Review findings addressed

An independent cold review returned `hold` on the first push with two silent-false-negative findings, both fixed in `99c144e` with a regression test each (both verified RED against the pre-fix code):

- **Base-relative key.** The anti-relaxation gate keyed on the whole frozen finding, whose `message` quotes the base it was measured against (`fail_under` lowered "from 90" against the branch tip but "from 95" against the incoming side). The two scans therefore compared unequal and a floor the operator lowered *while resolving* vanished. Now keyed on `(kind, path, line)`, which is base-invariant.
- **Inverted fail-direction.** `staged_diff` laundered a non-zero git exit into `""`, and an empty incoming-side scan read as "the author wrote nothing" — dropping every finding, a silent full pass. `staged_diff` now returns `None` on failure and the filter falls back to reporting everything unfiltered.

Also from that review: the diff prefixes `_added_lines` depends on are now pinned (a `diff.mnemonicPrefix` / `diff.noPrefix` config would have made every violation name the wrong file), and the removed-marker cancellation comment no longer calls its mid-merge window "safe" when it is a narrow false negative.

## Open questions & assumptions

- **`git merge --squash` remains uncovered** *(open)*. Git records no ref for a squash merge's incoming side, so `merge_incoming()` returns `None` and the pre-existing behaviour stands. Named explicitly in the docstring rather than left implied. The sibling gates that take a wholesale `MERGE_HEAD` exemption (`check_module_health.py`, `check_blueprint_sync.py`) have the identical hole.
- **Removed-marker cancellation is still branch-tip-only** *(assumed acceptable)*. Mid-merge, a marker the incoming side dropped can cancel an identical one the operator added. Narrow, errs toward reporting less, and documented in place. Scoping removals symmetrically is a ~3-line follow-up if it ever bites.
- **Seven sibling hooks still use a bare `git diff --cached`** *(open, out of scope)*: `check_skill_prose`, `check_e2e_no_skip`, `check_no_overlay_leak`, `check_doc_update`, `check_snapshot_baseline`, `check_antipatterns`, `check_comment_density`. A reusable named-base helper now exists for them; no ratchet yet prevents the next one.
- **`check_quality_gates.py` was stdlib-only and now imports `teatree`** *(assumed acceptable)*. The import is Django-free and cheap, and the sibling gate already did this under the same `uv run` launcher — but a broken venv now hard-blocks a gate that has no escape hatch.
