### PR TITLE
fix(worktree): require proof, not a record, before a self-healing pass skips (#3943)

### DIFF
--- a/src/teatree/cli/doctor/checks_worktree_health.py
+++ b/src/teatree/cli/doctor/checks_worktree_health.py
@@ -20,9 +20,10 @@ import typer
 def _check_registered_worktrees_are_checkouts() -> bool:
     """FAIL on a registered worktree dir PROVED not to be a checkout; WARN when it could not be judged.
 
-    A missing dir is NOT a failure here — that is an ordinary reaped worktree
-    whose row the done-reaper releases. The failure is a dir that EXISTS and never
-    claimed to be a checkout at all.
+    A missing dir is NOT a failure here: absence is not proof of anything one
+    context can act on, so no destructive remedy follows from it — ``workspace
+    release-dead-rows`` reports such a row as unverifiable and keeps it. The
+    failure is a dir that EXISTS and never claimed to be a checkout at all.
 
     The three-valued probe is shared with the reaper on purpose, and so is the
     clone it consults. FAILing on a merely-inconclusive probe would print a

--- a/src/teatree/core/cleanup/cleanup.py
+++ b/src/teatree/core/cleanup/cleanup.py
@@ -21,10 +21,10 @@ from django.core.exceptions import ImproperlyConfigured
 from teatree.config import clone_root
 from teatree.core import prek_hook
 from teatree.core.cleanup.cleanup_busy_guards import WorktreeBusyError, guard_live_worktree
+from teatree.core.cleanup.cleanup_dirt_guard import guard_or_warn_dirty_worktree
 from teatree.core.cleanup.cleanup_orphan_ref import raise_or_reap_orphan_ref
 from teatree.core.cleanup.cleanup_result import CleanupResult
 from teatree.core.cleanup.unshipped_work import capture_unshipped_work
-from teatree.core.cleanup.working_tree_dirt import real_uncommitted_reasons
 from teatree.core.models import Worktree
 from teatree.core.overlay_loader import get_overlay_for_worktree
 from teatree.core.worktree._overlay_teardown import reap_external_resources, run_overlay_cleanup_steps
@@ -423,40 +423,6 @@ def _remove_git_worktree(repo_main: Path, wt_path: str, target: _EffectiveTarget
     return errors
 
 
-def _guard_or_warn_dirty_worktree(
-    worktree: Worktree, wt_path: str, target: _EffectiveTarget, *, keep_if_dirty: bool, force: bool
-) -> None:
-    """KEEP a dirty worktree when ``keep_if_dirty`` (the fail-closed default), else warn-and-proceed.
-
-    A worktree with uncommitted changes may be a live one an agent is mid-task
-    in, and those edits are on no remote — a board "Done" event or an unattended
-    teardown would wipe them with no salvage. ``keep_if_dirty`` defaults ``True``
-    (fail-closed): a dirty worktree raises ``RuntimeError`` before any destructive
-    step, which the reaper / sync backend routes to a KEEP-with-warning. Only an
-    explicit ``keep_if_dirty=False`` caller warns-and-proceeds, and ``force=True``
-    (the proven-redundant reaper / explicit abandon) overrides the guard entirely.
-
-    "Dirty" is REAL uncommitted work — :func:`real_uncommitted_reasons` ignores the
-    regenerable env cache every provisioned worktree carries and the "every tracked
-    file reads as a staged add" noise of a dangling-HEAD (post-merge branch-ref
-    deletion) worktree. A raw ``git status --porcelain`` would false-positive on
-    both, refusing teardown of every normally-provisioned worktree and every
-    legitimate post-merge orphan; the shared probe fails CLOSED only on GENUINE
-    edits.
-    """
-    reasons = real_uncommitted_reasons(wt_path, target)
-    if not reasons:
-        return
-    if keep_if_dirty and not force:
-        msg = (
-            f"{worktree.repo_path} ({worktree.branch}): "
-            f"refused cleanup — worktree has uncommitted changes (possibly in use): {'; '.join(reasons)}. "
-            f"Kept it on disk at {wt_path}; commit or discard the changes, then re-run cleanup."
-        )
-        raise RuntimeError(msg)
-    logger.warning("%s has uncommitted changes — cleaning anyway (PR merged)", worktree.repo_path)
-
-
 def _resolve_overlay_or_none(worktree: Worktree) -> "OverlayBase | None":
     """Resolve the worktree's overlay, or ``None`` when it is no longer registered.
 
@@ -546,7 +512,8 @@ def cleanup_worktree(
     Dirty-worktree guard (``keep_if_dirty``, default ON — fail-closed): a
     worktree with uncommitted changes is KEPT — ``RuntimeError`` is raised before
     any destructive step rather than reaping it — see
-    :func:`_guard_or_warn_dirty_worktree`. Uncommitted edits are on no remote, so
+    :func:`~teatree.core.cleanup.cleanup_dirt_guard.guard_or_warn_dirty_worktree`.
+    Uncommitted edits are on no remote, so
     an unattended teardown (sync-backend "Done" cleanup, FSM teardown) must never
     wipe them by default. Only an explicit ``keep_if_dirty=False`` caller
     warns-and-proceeds; ``force=True`` (the proven-redundant reaper / explicit
@@ -585,7 +552,7 @@ def cleanup_worktree(
     # Ahead of the guards, so it also covers the ``force=True`` hard-delete they
     # do not protect — the one path where unshipped work leaves no trace.
     capture_unshipped_work(Path(wt_path), branch=worktree.branch, overlay=worktree.overlay)
-    _guard_or_warn_dirty_worktree(worktree, wt_path, target, keep_if_dirty=keep_if_dirty, force=force)
+    guard_or_warn_dirty_worktree(worktree, wt_path, target, keep_if_dirty=keep_if_dirty, force=force)
     _run_data_loss_guards(repo_main, worktree, target, force=force, strict_hygiene=strict_hygiene)
 
     # Stop the docker compose project so containers don't leak when this path is

--- a/src/teatree/core/cleanup/cleanup_dirt_guard.py
+++ b/src/teatree/core/cleanup/cleanup_dirt_guard.py
@@ -1,0 +1,78 @@
+"""The dirty-worktree KEEP guard, split out of :mod:`teatree.core.cleanup.cleanup`.
+
+Lives in its own module so the teardown orchestrator stays under the module-health
+LOC cap (mirrors ``cleanup_busy_guards`` and ``cleanup_orphan_ref``). The probe it
+consults is :mod:`teatree.core.cleanup.working_tree_dirt`; what this module adds is
+the DECISION — keep or proceed — and the sentence the operator reads for it.
+
+Two outcomes keep the worktree and they are reported differently, because they are
+different findings: files that are modified, and a probe that could not read the
+working tree at all. Rendering the second as the first sends an operator hunting
+for edits nothing ever saw.
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+from teatree.core.cleanup.working_tree_dirt import WorkingTreeDirt, working_tree_dirt
+from teatree.core.models import Worktree
+
+if TYPE_CHECKING:
+    from teatree.core.cleanup.cleanup import _EffectiveTarget
+
+logger = logging.getLogger(__name__)
+
+
+def guard_or_warn_dirty_worktree(
+    worktree: Worktree, wt_path: str, target: "_EffectiveTarget", *, keep_if_dirty: bool, force: bool
+) -> None:
+    """KEEP a dirty worktree when ``keep_if_dirty`` (the fail-closed default), else warn-and-proceed.
+
+    A worktree with uncommitted changes may be a live one an agent is mid-task
+    in, and those edits are on no remote — a board "Done" event or an unattended
+    teardown would wipe them with no salvage. ``keep_if_dirty`` defaults ``True``
+    (fail-closed): a dirty worktree raises ``RuntimeError`` before any destructive
+    step, which the reaper / sync backend routes to a KEEP-with-warning. Only an
+    explicit ``keep_if_dirty=False`` caller warns-and-proceeds, and ``force=True``
+    (the proven-redundant reaper / explicit abandon) overrides the guard entirely.
+
+    "Dirty" is REAL uncommitted work — :func:`working_tree_dirt` ignores the
+    regenerable env cache every provisioned worktree carries and the "every tracked
+    file reads as a staged add" noise of a dangling-HEAD (post-merge branch-ref
+    deletion) worktree. A raw ``git status --porcelain`` would false-positive on
+    both, refusing teardown of every normally-provisioned worktree and every
+    legitimate post-merge orphan; the shared probe fails CLOSED only on GENUINE
+    edits.
+    """
+    dirt = working_tree_dirt(wt_path, target)
+    if not dirt.reasons:
+        return
+    if keep_if_dirty and not force:
+        raise RuntimeError(kept_worktree_message(worktree, wt_path, dirt))
+    if dirt.proven:
+        logger.warning("%s has uncommitted changes — cleaning anyway (PR merged)", worktree.repo_path)
+    else:
+        logger.warning(
+            "%s: the working-tree probe could not answer (%s) — cleaning anyway (PR merged)",
+            worktree.repo_path,
+            "; ".join(dirt.reasons),
+        )
+
+
+def kept_worktree_message(worktree: Worktree, wt_path: str, dirt: WorkingTreeDirt) -> str:
+    """The refusal an operator reads — proven dirt and an unanswerable probe say different things."""
+    head = f"{worktree.repo_path} ({worktree.branch}): "
+    if dirt.proven:
+        return (
+            f"{head}refused cleanup — worktree has uncommitted changes (possibly in use): "
+            f"{'; '.join(dirt.reasons)}. Kept it on disk at {wt_path}; commit or discard the changes, "
+            "then re-run cleanup."
+        )
+    return (
+        f"{head}kept, unverified — the working-tree probe could not answer: {'; '.join(dirt.reasons)}. "
+        f"This is not proof of uncommitted work, so nothing was destroyed and nothing was concluded about "
+        f"{wt_path}; re-run once the probe can answer, or force the teardown to override it."
+    )
+
+
+__all__ = ["guard_or_warn_dirty_worktree", "kept_worktree_message"]

--- a/src/teatree/core/cleanup/working_tree_dirt.py
+++ b/src/teatree/core/cleanup/working_tree_dirt.py
@@ -19,11 +19,18 @@ Fails CLOSED: an inconclusive ``git status`` (corrupt index, lock contention) or
 an unrecoverable HEAD is treated as dirty so the worktree is KEPT — a guard that
 guessed "clean" on an error could let a force-wipe destroy real edits.
 
+Failing closed is not the same finding as finding dirt, and
+:class:`WorkingTreeDirt` keeps the two apart: ``proven`` is ``False`` exactly when
+the reasons describe a probe that could not answer rather than files that are
+modified. Both keep the worktree; only one of them is evidence, and a caller that
+renders them identically tells its operator about uncommitted work nothing saw.
+
 Imports ``_EffectiveTarget`` only under :data:`TYPE_CHECKING` so there is no
 runtime import cycle with :mod:`teatree.core.cleanup.cleanup`, which imports this
 module for its dirty-worktree guard.
 """
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -58,36 +65,61 @@ def _porcelain_path(line: str) -> str:
         return ""
 
 
+@dataclass(frozen=True, slots=True)
+class WorkingTreeDirt:
+    """What the dirt probe found — and whether it found anything at all.
+
+    ``reasons`` is what keeps the worktree, empty when nothing does. ``proven``
+    says which kind of finding it is: ``True`` for an answered probe (the reasons,
+    if any, name modified files), ``False`` for one that could not answer, where
+    the reasons name the obstacle instead. A ``False`` verdict is never evidence of
+    uncommitted work, only the absence of evidence either way.
+    """
+
+    reasons: tuple[str, ...]
+    proven: bool
+
+
 def real_uncommitted_reasons(wt_path: str, target: "_EffectiveTarget") -> list[str]:
     """Kept-reasons for real (non-regenerable) uncommitted changes; empty when clean.
 
+    The reasons alone, for callers that keep the worktree on any of them and do not
+    distinguish proven dirt from an unanswerable probe. Callers that report the
+    reason to an operator want :func:`working_tree_dirt`.
+    """
+    return list(working_tree_dirt(wt_path, target).reasons)
+
+
+def working_tree_dirt(wt_path: str, target: "_EffectiveTarget") -> WorkingTreeDirt:
+    """The full dirt verdict for *wt_path* — reasons plus whether the probe answered.
+
     Fails CLOSED: an inconclusive ``git status`` (corrupt index, lock contention)
-    is treated as dirty so the worktree is kept. A dangling-HEAD worktree (its
+    keeps the worktree, reported as unproven. A dangling-HEAD worktree (its
     branch ref deleted post-merge) has no resolvable HEAD, so ``git status``
     reports EVERY tracked file as a staged addition — noise, not real uncommitted
     work. Rather than skipping the dirt check entirely there (which would let a
     force-wipe destroy genuine uncommitted follow-up edits), the working tree is
     diffed against the RECOVERED last-HEAD SHA plus an untracked-file scan —
-    :func:`_dangling_head_dirty_reasons`.
+    :func:`_dangling_head_dirt`.
     """
     if not Path(wt_path).is_dir():
-        return []
+        return WorkingTreeDirt(reasons=(), proven=True)
     if not git.check(repo=wt_path, args=["rev-parse", "--verify", "--quiet", "HEAD"]):
-        return _dangling_head_dirty_reasons(wt_path, target)
+        return _dangling_head_dirt(wt_path, target)
     try:
         porcelain = git.status_porcelain_strict(wt_path)
     except CommandFailedError as exc:
-        return [f"could not read working-tree status ({exc}) — keeping"]
+        return WorkingTreeDirt(reasons=(f"could not read working-tree status ({exc}) — keeping",), proven=False)
     dirty = [
         path
         for line in porcelain.splitlines()
         if (path := _porcelain_path(line)) and not path.startswith(_REGENERABLE_WORKTREE_PATHS)
     ]
-    return _dirt_reasons(dirty)
+    return _dirt_verdict(dirty)
 
 
-def _dangling_head_dirty_reasons(wt_path: str, target: "_EffectiveTarget") -> list[str]:
-    """Kept-reasons for real uncommitted edits in a dangling-HEAD worktree; empty when clean.
+def _dangling_head_dirt(wt_path: str, target: "_EffectiveTarget") -> WorkingTreeDirt:
+    """The dirt verdict for a dangling-HEAD worktree, diffed against the recovered SHA.
 
     A post-merge branch-ref deletion leaves HEAD unresolvable, so ``git status``
     is useless (everything reads as a staged add). The recovered last-HEAD SHA is
@@ -95,27 +127,32 @@ def _dangling_head_dirty_reasons(wt_path: str, target: "_EffectiveTarget") -> li
     (``git diff --name-only <sha>`` — tracked modifications) plus an untracked-file
     scan (``git ls-files --others --exclude-standard``), ignoring the regenerable
     env cache. Fails CLOSED: an unrecoverable HEAD or an erroring diff keeps the
-    worktree rather than letting a force-wipe destroy unexamined edits.
+    worktree — as UNPROVEN — rather than letting a force-wipe destroy unexamined
+    edits.
     """
     sha = classify_orphan_ref(target).recovered_sha
     if sha is None:
-        return ["could not recover HEAD to check working-tree changes — keeping"]
+        return WorkingTreeDirt(
+            reasons=("could not recover HEAD to check working-tree changes — keeping",), proven=False
+        )
     try:
         changed = git.run_strict(repo=wt_path, args=["diff", "--name-only", sha])
         untracked = git.run_strict(repo=wt_path, args=["ls-files", "--others", "--exclude-standard"])
     except CommandFailedError as exc:
-        return [f"could not diff working tree against recovered HEAD ({exc}) — keeping"]
+        return WorkingTreeDirt(
+            reasons=(f"could not diff working tree against recovered HEAD ({exc}) — keeping",), proven=False
+        )
     dirty = [
         stripped
         for raw in (*changed.splitlines(), *untracked.splitlines())
         if (stripped := raw.strip()) and not stripped.startswith(_REGENERABLE_WORKTREE_PATHS)
     ]
-    return _dirt_reasons(dirty)
+    return _dirt_verdict(dirty)
 
 
-def _dirt_reasons(dirty: list[str]) -> list[str]:
-    """Format a single kept-reason for a non-empty ``dirty`` file list; empty when clean."""
+def _dirt_verdict(dirty: list[str]) -> WorkingTreeDirt:
+    """The answered-probe verdict for a list of genuinely modified paths."""
     if not dirty:
-        return []
+        return WorkingTreeDirt(reasons=(), proven=True)
     preview = ", ".join(dirty[:_PREVIEW_LIMIT]) + (", …" if len(dirty) > _PREVIEW_LIMIT else "")
-    return [f"{len(dirty)} uncommitted change(s) not on any remote: {preview}"]
+    return WorkingTreeDirt(reasons=(f"{len(dirty)} uncommitted change(s) not on any remote: {preview}",), proven=True)

--- a/src/teatree/core/runners/provision.py
+++ b/src/teatree/core/runners/provision.py
@@ -11,6 +11,7 @@ from teatree.core.public_identity import is_public_github_remote, set_local_nore
 from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.core.worktree.clone_paths import find_clone_path
 from teatree.core.worktree.worktree_paths import paths_match, ticket_dir_for
+from teatree.core.worktree.worktree_roots import CheckoutState, probe_checkout
 from teatree.utils import git
 from teatree.utils.git_guard import guard_repo_remote_slug, is_github_slug
 from teatree.utils.run import CommandFailedError
@@ -37,6 +38,25 @@ def _clone_dir_from_worktree(worktree_path: str) -> Path | None:
     if not common_path.is_absolute():
         common_path = (Path(worktree_path) / common_path).resolve()
     return common_path.parent
+
+
+def _recorded_checkout_is_live(recorded: str, *, clone: Path | None) -> bool:
+    """Is the checkout a row records still THERE? Positive proof only.
+
+    The provisioning half of the liveness question the reaper asks in
+    :mod:`teatree.core.worktree.checkout_liveness`, and the answer it needs is the
+    opposite one. A reaper deletes, so it may act only on proof of DEATH; this
+    short-circuit skips the work that would re-materialise a checkout, so it may
+    act only on proof of LIFE. Anything less falls through and re-provisions, which
+    adds a checkout and removes nothing.
+
+    *clone* is the source clone as THIS context reaches it, and it is what makes the
+    conservative half work: a checkout records its admin dir as an absolute path
+    written by whatever context created it, so git answers "not a git repository"
+    here for a checkout that is alive elsewhere. The clone's own admin entry, looked
+    up by name, proves that checkout live and keeps the short-circuit.
+    """
+    return probe_checkout(Path(recorded), clone=clone) is CheckoutState.CHECKOUT
 
 
 @dataclass(frozen=True, slots=True)
@@ -290,14 +310,20 @@ class WorktreeProvisioner(RunnerBase):
     ) -> str | None:
         """Materialise one repo's ``Worktree`` row + checkout; return its path or ``None``.
 
-        Idempotent: a repo whose worktree_path is already recorded is a no-op. In
-        adopt mode (*adopt_path* set) the existing checkout is recorded verbatim —
-        see :meth:`_create`. On a failed ``git worktree add`` the just-created row
-        is rolled back so the ticket carries no half-provisioned repo.
+        Idempotent: a repo whose recorded worktree_path still holds a LIVE checkout
+        is a no-op, and one whose checkout this context cannot prove is there falls
+        through to re-provision onto the same row — a recorded path is a claim, not
+        a checkout, and trusting the claim alone is what turns a vanished checkout
+        into a provision that can never succeed again. Proof of life is
+        :func:`_recorded_checkout_is_live`. In adopt mode (*adopt_path* set) the
+        existing checkout is recorded verbatim — see :meth:`_create`. On a failed
+        ``git worktree add`` the just-created row is rolled back so the ticket
+        carries no half-provisioned repo.
         """
         existing = Worktree.objects.filter(ticket=self.ticket, repo_path=repo_name).first()
-        if existing and (existing.extra or {}).get("worktree_path"):
-            return (existing.extra or {})["worktree_path"]
+        recorded = (existing.extra or {}).get("worktree_path", "") if existing else ""
+        if recorded and _recorded_checkout_is_live(recorded, clone=find_clone_path(clones_root, repo_name)):
+            return recorded
 
         worktree = existing or Worktree.objects.create(
             ticket=self.ticket,

--- a/src/teatree/core/worktree/dead_row_release.py
+++ b/src/teatree/core/worktree/dead_row_release.py
@@ -77,21 +77,50 @@ class DeadRowVerdict:
 
 
 def plan_dead_row_release(workspace: Path) -> list[DeadRowVerdict]:
-    """Classify every registered row whose checkout is dead. Read-only.
+    """Classify every registered row whose checkout is not a working one. Read-only.
 
-    A row with a LIVE checkout — or no directory at all — is not this pass's
-    business and is omitted entirely rather than reported as a non-candidate: the
-    output is the set of rows the doctor's finding is about. The classifier decides
-    that SCOPE question; :func:`_verdict_for` then decides the row's disposition.
+    A row with a LIVE checkout is not this pass's business and is omitted entirely
+    rather than reported as a non-candidate: the output is the set of rows an
+    operator reached this command for. A row whose directory is ABSENT is in that
+    set — see :func:`_absent_directory_verdict` — even though nothing here can
+    release it. The classifier decides that SCOPE question; :func:`_verdict_for`
+    then decides the row's disposition.
     """
     refresh = RemoteRefresh()
     verdicts: list[DeadRowVerdict] = []
     for row in Worktree.objects.select_related("ticket").order_by("pk"):
-        checkout = classify_broken_checkout(row, workspace=workspace, refresh=refresh)
+        checkout = _absent_directory_verdict(row, workspace=workspace) or classify_broken_checkout(
+            row, workspace=workspace, refresh=refresh
+        )
         if checkout.state is BrokenCheckout.LIVE_CHECKOUT:
             continue
         verdicts.append(_verdict_for(row, workspace=workspace, checkout=checkout))
     return verdicts
+
+
+def _absent_directory_verdict(row: Worktree, *, workspace: Path) -> BrokenCheckoutVerdict | None:
+    """An UNVERIFIABLE verdict for a row with no directory here; ``None`` when there is one.
+
+    The classifier answers ``LIVE_CHECKOUT`` for an absent directory, which is the
+    right answer for the reapers that own an ordinary reaped worktree and the wrong
+    one here: it silently empties the plan of the rows this command is reached for,
+    so an operator staring at a row whose checkout went missing is told there is
+    nothing to look at.
+
+    The verdict is UNVERIFIABLE and never RELEASABLE. An absent directory is not
+    evidence of death — a checkout created in another execution context is absent
+    from here in exactly that way — and the row is the registry's only handle on the
+    branch. Provisioning re-materialises the checkout on the next pass, which is the
+    remedy the reason names.
+    """
+    path = Path(_resolve_worktree_path(workspace, row))
+    if path.is_dir():
+        return None
+    return BrokenCheckoutVerdict(
+        BrokenCheckout.UNVERIFIABLE,
+        f"nothing exists at {path} in this execution context, which a checkout created elsewhere looks "
+        "exactly like — so the row is kept. Re-run provisioning for the ticket to re-materialise the checkout.",
+    )
 
 
 def _verdict_for(row: Worktree, *, workspace: Path, checkout: BrokenCheckoutVerdict) -> DeadRowVerdict:

--- a/tests/teatree_core/cleanup/_shared.py
+++ b/tests/teatree_core/cleanup/_shared.py
@@ -29,3 +29,24 @@ def _clean_env() -> dict[str, str]:
 
 def _run_git(*args: str, cwd: Path) -> None:
     subprocess.run([_GIT, "-C", str(cwd), *args], check=True, capture_output=True, env=_clean_env())
+
+
+def corrupt_index(wt_dir: Path) -> None:
+    """Corrupt the real on-disk index for a worktree so ``git status`` itself fails.
+
+    The unanswerable-probe fixture, with no mocking: a ``git worktree add``
+    checkout's ``.git`` is a gitdir POINTER file, and its index lives under the main
+    repo's ``.git/worktrees/<name>/index`` rather than ``<wt_dir>/.git/index``, so
+    the real git dir is resolved through ``rev-parse`` first.
+    """
+    result = subprocess.run(
+        [_GIT, "-C", str(wt_dir), "rev-parse", "--git-dir"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+    )
+    git_dir = Path(result.stdout.strip())
+    if not git_dir.is_absolute():
+        git_dir = wt_dir / git_dir
+    (git_dir / "index").write_bytes(b"not a real git index")

--- a/tests/teatree_core/cleanup/test_cleanup_dirt_guard.py
+++ b/tests/teatree_core/cleanup/test_cleanup_dirt_guard.py
@@ -1,0 +1,81 @@
+"""The dirty-worktree KEEP guard at its own seam — what it keeps, and what it says.
+
+Both a modified file and an unreadable working tree keep the worktree; only one of
+them is evidence. These pin that the guard's sentence says which it is, so an
+inconclusive probe is never read as proven uncommitted work.
+
+Real git under ``tmp_path``.
+"""
+
+from pathlib import Path
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.cleanup.cleanup import _EffectiveTarget
+from teatree.core.cleanup.cleanup_dirt_guard import guard_or_warn_dirty_worktree, kept_worktree_message
+from teatree.core.cleanup.working_tree_dirt import WorkingTreeDirt
+from teatree.core.models import Ticket, Worktree
+from tests.teatree_core.cleanup._shared import _run_git, corrupt_index
+
+
+class DirtGuardTest(TestCase):
+    @pytest.fixture(autouse=True)
+    def _tmp(self, tmp_path: Path) -> None:
+        self.tmp = tmp_path
+
+    def _worktree(self) -> tuple[Path, Worktree, _EffectiveTarget]:
+        repo = self.tmp / "repo"
+        repo.mkdir()
+        _run_git("init", "-q", "-b", "main", cwd=repo)
+        _run_git("config", "user.email", "t@t", cwd=repo)
+        _run_git("config", "user.name", "t", cwd=repo)
+        (repo / "tracked.py").write_text("x = 1\n", encoding="utf-8")
+        _run_git("add", "-A", cwd=repo)
+        _run_git("commit", "-q", "-m", "initial", cwd=repo)
+
+        wt_dir = self.tmp / "wt"
+        _run_git("worktree", "add", "-q", "-b", "feat", str(wt_dir), cwd=repo)
+
+        ticket = Ticket.objects.create(issue_url="https://example.invalid/org/repo/issues/1")
+        row = Worktree.objects.create(
+            overlay="", ticket=ticket, repo_path="org/repo", branch="feat", extra={"worktree_path": str(wt_dir)}
+        )
+        target = _EffectiveTarget(ref="HEAD", probe_repo=str(wt_dir), branch_to_delete="feat", label="feat")
+        return wt_dir, row, target
+
+    def test_a_clean_worktree_is_not_guarded(self) -> None:
+        wt_dir, row, target = self._worktree()
+
+        guard_or_warn_dirty_worktree(row, str(wt_dir), target, keep_if_dirty=True, force=False)
+
+    def test_a_modified_file_refuses_as_uncommitted_changes(self) -> None:
+        wt_dir, row, target = self._worktree()
+        (wt_dir / "tracked.py").write_text("x = 2\n", encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="uncommitted changes"):
+            guard_or_warn_dirty_worktree(row, str(wt_dir), target, keep_if_dirty=True, force=False)
+
+    def test_an_unreadable_working_tree_keeps_without_claiming_dirt(self) -> None:
+        wt_dir, row, target = self._worktree()
+        corrupt_index(wt_dir)
+
+        with pytest.raises(RuntimeError) as refusal:
+            guard_or_warn_dirty_worktree(row, str(wt_dir), target, keep_if_dirty=True, force=False)
+
+        assert "uncommitted changes" not in str(refusal.value)
+        assert "could not answer" in str(refusal.value)
+
+    def test_force_overrides_both_outcomes(self) -> None:
+        wt_dir, row, target = self._worktree()
+        corrupt_index(wt_dir)
+
+        guard_or_warn_dirty_worktree(row, str(wt_dir), target, keep_if_dirty=True, force=True)
+
+    def test_the_message_names_the_worktree_in_both_shapes(self) -> None:
+        _wt_dir, row, _target = self._worktree()
+        proven = WorkingTreeDirt(reasons=("1 uncommitted change(s) not on any remote: a.py",), proven=True)
+        unproven = WorkingTreeDirt(reasons=("could not read working-tree status (boom) — keeping",), proven=False)
+
+        assert "refused cleanup" in kept_worktree_message(row, "/wt", proven)
+        assert "kept, unverified" in kept_worktree_message(row, "/wt", unproven)

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -21,7 +21,7 @@ from teatree.core.models.external_delivery import mark_external_delivery
 from teatree.core.overlay import OverlayBase, OverlayRuntime, ProvisionStep, RunCommands
 from teatree.utils.run import CommandFailedError
 from tests.teatree_core._provision_timebox_stub import provision_timebox_unimportable
-from tests.teatree_core.cleanup._shared import _run_git
+from tests.teatree_core.cleanup._shared import _run_git, corrupt_index
 
 _patch_config = patch("teatree.core.cleanup.cleanup.clone_root")
 _patch_git = patch("teatree.core.cleanup.cleanup.git")
@@ -1323,6 +1323,33 @@ class TestCleanupWorktreeRefuseBeforeDestroy(TestCase):
         mock_down.assert_not_called()
         assert wt_dir.is_dir(), "a dirty worktree must be left intact on disk"
         assert Worktree.objects.filter(pk=wt_id).exists()
+
+    @_patch_overlay
+    def test_an_unanswerable_dirt_probe_is_not_reported_as_uncommitted_changes(self, mock_overlay: MagicMock) -> None:
+        """A probe that could not answer keeps the worktree, and says exactly that.
+
+        The refusal is right — nothing may be destroyed on evidence nobody has. What
+        it must not do is assert uncommitted changes, sending the caller to look for
+        work to commit or discard that no probe ever saw.
+        """
+        mock_overlay.return_value.provisioning.cleanup_steps.return_value = []
+        workspace, wt_dir, wt = self._dirty_worktree()
+        (wt_dir / "app" / "models.py").write_text("x = 1\n", encoding="utf-8")
+        corrupt_index(wt_dir)
+
+        with (
+            patch("teatree.core.cleanup.cleanup.clone_root", return_value=workspace),
+            patch("teatree.core.runners.worktree_start.docker_compose_down") as mock_down,
+            pytest.raises(RuntimeError) as refusal,
+        ):
+            cleanup_worktree(wt)
+
+        message = str(refusal.value)
+        assert "uncommitted changes" not in message, "an unanswerable probe was reported as proven dirt"
+        assert "could not" in message
+        mock_down.assert_not_called()
+        assert wt_dir.is_dir()
+        assert Worktree.objects.filter(pk=wt.pk).exists()
 
     @_patch_overlay
     def test_force_overrides_dirty_guard(self, mock_overlay: MagicMock) -> None:

--- a/tests/teatree_core/cleanup/test_working_tree_dirt.py
+++ b/tests/teatree_core/cleanup/test_working_tree_dirt.py
@@ -10,36 +10,15 @@ Happy paths run against real git under ``tmp_path``; the fail-closed error
 branches inject a ``CommandFailedError`` from the (unstoppable) git subprocess.
 """
 
-import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
 from teatree.core.cleanup.cleanup import _EffectiveTarget
 from teatree.core.cleanup.cleanup_orphan_ref import OrphanRefDecision
-from teatree.core.cleanup.working_tree_dirt import real_uncommitted_reasons
+from teatree.core.cleanup.working_tree_dirt import real_uncommitted_reasons, working_tree_dirt
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError
-from tests.teatree_core.cleanup._shared import _GIT, _run_git
-
-
-def _corrupt_index(wt_dir: Path) -> None:
-    """Corrupt the real on-disk index for a worktree so ``git status`` itself fails.
-
-    A ``git worktree add`` checkout's ``.git`` is a *file* (a gitdir pointer),
-    not a directory, and each worktree has its own per-worktree index living
-    under the main repo's ``.git/worktrees/<name>/index`` — not
-    ``<wt_dir>/.git/index``. Resolve the real git-dir via ``rev-parse`` first.
-    """
-    result = subprocess.run(
-        [_GIT, "-C", str(wt_dir), "rev-parse", "--git-dir"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    git_dir = Path(result.stdout.strip())
-    if not git_dir.is_absolute():
-        git_dir = wt_dir / git_dir
-    (git_dir / "index").write_bytes(b"not a real git index")
+from tests.teatree_core.cleanup._shared import _run_git, corrupt_index
 
 
 def _committed_worktree(tmp_path: Path) -> tuple[Path, _EffectiveTarget]:
@@ -140,7 +119,7 @@ class TestRealUncommittedReasons:
         under real lock contention or disk corruption.
         """
         wt_dir, target = _committed_worktree(tmp_path)
-        _corrupt_index(wt_dir)
+        corrupt_index(wt_dir)
         reasons = real_uncommitted_reasons(str(wt_dir), target)
         assert reasons != []
         assert "keeping" in reasons[0]
@@ -152,6 +131,51 @@ class TestRealUncommittedReasons:
         reasons = real_uncommitted_reasons(str(wt_dir), target)
         assert reasons[0].startswith("4 uncommitted change(s)")
         assert reasons[0].endswith("…")
+
+
+class TestDirtIsDistinguishedFromAnUnanswerableProbe:
+    """``proven`` separates "these files are modified" from "the probe could not say".
+
+    Both keep the worktree, and they are not the same finding: one is evidence about
+    the working tree, the other is the absence of evidence. A caller that renders
+    them identically reports uncommitted work that may not exist.
+    """
+
+    def test_real_edits_are_proven(self, tmp_path: Path) -> None:
+        wt_dir, target = _committed_worktree(tmp_path)
+        (wt_dir / "tracked.py").write_text("x = 2\n", encoding="utf-8")
+
+        dirt = working_tree_dirt(str(wt_dir), target)
+
+        assert dirt.proven is True
+        assert "tracked.py" in dirt.reasons[0]
+
+    def test_a_clean_tree_is_proven_clean(self, tmp_path: Path) -> None:
+        wt_dir, target = _committed_worktree(tmp_path)
+
+        dirt = working_tree_dirt(str(wt_dir), target)
+
+        assert dirt.proven is True
+        assert dirt.reasons == ()
+
+    def test_an_unreadable_status_is_not_proven(self, tmp_path: Path) -> None:
+        wt_dir, target = _committed_worktree(tmp_path)
+        corrupt_index(wt_dir)
+
+        dirt = working_tree_dirt(str(wt_dir), target)
+
+        assert dirt.proven is False
+        assert dirt.reasons != (), "an unanswerable probe must still keep the worktree"
+
+    def test_an_unrecoverable_dangling_head_is_not_proven(self, tmp_path: Path) -> None:
+        wt_dir, target = _dangling_head_worktree(tmp_path)
+        undecided = OrphanRefDecision(recovered_sha=None, in_remote=False, unsynced=[])
+
+        with patch("teatree.core.cleanup.working_tree_dirt.classify_orphan_ref", return_value=undecided):
+            dirt = working_tree_dirt(str(wt_dir), target)
+
+        assert dirt.proven is False
+        assert dirt.reasons != ()
 
 
 class TestDanglingHeadDirtReasons:
@@ -196,7 +220,7 @@ class TestDanglingHeadDirtReasons:
         to move to :func:`teatree.utils.git.run_strict`.
         """
         wt_dir, target = _dangling_head_worktree(tmp_path)
-        _corrupt_index(wt_dir)
+        corrupt_index(wt_dir)
         reasons = real_uncommitted_reasons(str(wt_dir), target)
         assert reasons != []
         assert "keeping" in reasons[0]

--- a/tests/teatree_core/test_runners_provision.py
+++ b/tests/teatree_core/test_runners_provision.py
@@ -18,6 +18,7 @@ from django.test import TestCase
 
 from teatree.core.models import Ticket, Worktree
 from teatree.core.runners import WorktreeProvisioner
+from teatree.core.runners.provision import _recorded_checkout_is_live
 from teatree.utils import git
 from tests._git_repo import make_git_repo
 from tests.teatree_core.conftest import CommandOverlay
@@ -96,7 +97,7 @@ class TestWorktreeProvisioner(TestCase):
         assert worktrees[0].branch == "ac-repo-a-77-x"
         assert (worktrees[0].extra or {}).get("worktree_path") == str(wt_path)
 
-    def test_idempotent_when_worktree_already_exists(self) -> None:
+    def test_recorded_path_with_no_checkout_reprovisions_onto_the_same_row(self) -> None:
         repo_dir = self.workspace / "repo-a"
         repo_dir.mkdir()
         (repo_dir / ".git").mkdir()
@@ -116,13 +117,14 @@ class TestWorktreeProvisioner(TestCase):
         with (
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
             self._patch_workspace_dir(),
-            patch("teatree.core.runners.provision.git.worktree_add") as worktree_add,
+            patch("teatree.core.runners.provision.git.worktree_add", return_value=True) as worktree_add,
+            patch("teatree.core.runners.provision.git.pull_ff_only", return_value=True),
         ):
             result = WorktreeProvisioner(ticket).run()
 
         assert result.ok is True
-        worktree_add.assert_not_called()
-        assert Worktree.objects.filter(ticket=ticket).count() == 1
+        worktree_add.assert_called_once()
+        assert Worktree.objects.filter(ticket=ticket).count() == 1, "the re-provision must reuse the existing row"
 
     def test_returns_failure_when_worktree_add_fails(self) -> None:
         repo_dir = self.workspace / "repo-a"
@@ -829,13 +831,28 @@ class TestWorktreeProvisionerIsIdempotent(TestCase):
         git.run_strict(repo=str(worktree), args=["add", "-A"])
         git.run_strict(repo=str(worktree), args=["commit", "-q", "-m", f"add {name}"])
 
-    def _provision(self, branch: str, *, repo: str = "repo-a", public_remote: bool = False) -> tuple[Any, Ticket]:
+    def _provision(
+        self,
+        branch: str,
+        *,
+        repo: str = "repo-a",
+        public_remote: bool = False,
+        recorded_path: str = "",
+    ) -> tuple[Any, Ticket]:
         ticket = Ticket.objects.create(
             overlay="test",
             issue_url="https://example.com/issues/3234",
             repos=[repo],
             extra={"branch": branch, "description": "x"},
         )
+        if recorded_path:
+            Worktree.objects.create(
+                ticket=ticket,
+                overlay="test",
+                repo_path=repo,
+                branch=branch,
+                extra={"worktree_path": recorded_path},
+            )
         with (
             patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
             patch("teatree.core.runners.provision.clone_root", return_value=self.workspace),
@@ -932,6 +949,81 @@ class TestWorktreeProvisionerIsIdempotent(TestCase):
         assert stale.is_dir(), "a leftover with unpushed commits was DESTROYED"
         assert (stale / "work.txt").read_text(encoding="utf-8") == "precious\n"
         assert self._recorded_path(ticket) == str(stale), "the surviving worktree must be the one recorded"
+
+    def test_row_recording_a_checkout_that_is_gone_is_reprovisioned(self) -> None:
+        # souliane/teatree#3943: the row records a path whose checkout no longer
+        # exists. Handing that path back makes provisioning a permanent no-op — the
+        # checkout can never be re-materialised and every later step walks into a
+        # directory that is not there.
+        self._clone()
+        branch = "3943-vanished"
+        vanished = self.tmp / "a-root-that-is-gone" / "repo-a"
+
+        result, ticket = self._provision(branch, recorded_path=str(vanished))
+
+        assert result.ok is True, result.detail
+        wt_path = self.workspace / branch / "repo-a"
+        assert self._recorded_path(ticket) == str(wt_path), "the dead path was handed back instead of re-provisioned"
+        assert git.current_branch(str(wt_path)) == branch
+
+    def test_row_recording_a_directory_that_is_not_a_checkout_is_reprovisioned(self) -> None:
+        # The dir survives but holds no checkout, so every git-driven step over it
+        # no-ops. A recorded path is not evidence; a live checkout is.
+        self._clone()
+        branch = "3943-hollow"
+        hollow = self.tmp / "hollow" / "repo-a"
+        hollow.mkdir(parents=True)
+
+        result, ticket = self._provision(branch, recorded_path=str(hollow))
+
+        assert result.ok is True, result.detail
+        recorded = Path(self._recorded_path(ticket))
+        assert (recorded / ".git").exists(), "a hollow directory was accepted as a checkout"
+        assert git.current_branch(str(recorded)) == branch
+
+    def test_live_recorded_checkout_short_circuits_provisioning(self) -> None:
+        # The other half of the contract: a checkout that IS there earns the no-op,
+        # so provisioning never enters the create path at all and the work standing
+        # in that checkout is never at risk.
+        clone = self._clone()
+        branch = "3943-live"
+        recorded = self._add_worktree(clone, self.tmp / "elsewhere" / "repo-a", branch)
+        self._commit(recorded, "work.txt", "in progress\n")
+
+        with patch.object(WorktreeProvisioner, "_create") as create:
+            result, ticket = self._provision(branch, recorded_path=str(recorded))
+
+        create.assert_not_called()
+        assert result.ok is True, result.detail
+        assert self._recorded_path(ticket) == str(recorded)
+        assert (recorded / "work.txt").read_text(encoding="utf-8") == "in progress\n"
+
+    def test_checkout_whose_admin_dir_is_scoped_to_another_context_counts_as_live(self) -> None:
+        # The vantage-point trap: a checkout records its admin dir as an absolute
+        # path written by whatever context created it, so from HERE git answers
+        # "not a git repository" for a checkout that is perfectly alive. The clone's
+        # own admin entry is what proves it live, so the short-circuit must consult
+        # the clone rather than trusting git's refusal in the checkout.
+        clone = self._clone()
+        branch = "3943-other-context"
+        recorded = self._add_worktree(clone, self.workspace / branch / "repo-a", branch)
+        (recorded / ".git").write_text(
+            f"gitdir: /a-root-this-context-cannot-reach/repo-a/.git/worktrees/{recorded.name}\n", encoding="utf-8"
+        )
+
+        assert git.run(repo=str(recorded), args=["rev-parse", "--git-dir"]) == "", "fixture: git must refuse here"
+        assert _recorded_checkout_is_live(str(recorded), clone=clone) is True
+
+    def test_checkout_no_clone_vouches_for_is_not_taken_as_live(self) -> None:
+        # The same unreadable pointer with no clone to resolve it against is exactly
+        # what a dead checkout looks like. Unproven is not dead — it just does not
+        # earn the short-circuit, and re-provisioning removes nothing.
+        clone = self._clone()
+        branch = "3943-unvouched"
+        recorded = self._add_worktree(clone, self.workspace / branch / "repo-a", branch)
+        (recorded / ".git").write_text("gitdir: /a-root-this-context-cannot-reach/wt\n", encoding="utf-8")
+
+        assert _recorded_checkout_is_live(str(recorded), clone=None) is False
 
     def test_failed_step_after_creation_leaves_no_stranded_worktree(self) -> None:
         # A provision STEP that fails after `git worktree add` succeeded must tear the

--- a/tests/teatree_core/worktree/test_dead_row_release.py
+++ b/tests/teatree_core/worktree/test_dead_row_release.py
@@ -224,6 +224,45 @@ class DispositionReportingTest(_DeadRowCase):
         assert plan_dead_row_release(self.workspace) == []
 
 
+class AbsentDirectoryTest(_DeadRowCase):
+    """A row whose recorded directory is not there is REPORTED, and never released.
+
+    Nothing else owns this shape — the done reaper reads it as an ordinary live row
+    — so a pass that dropped it from the plan answered "nothing to do" about the very
+    rows an operator reaches for this command to understand. It is also not proof of
+    death: a checkout created in another execution context is absent from here in
+    exactly the same way, so the row is kept and the reason says why.
+    """
+
+    def _row_with_no_directory(self, branch: str = "vanished-dir") -> Worktree:
+        return self._register(self.workspace / f"wt-{branch}", branch=branch)
+
+    def test_a_row_whose_directory_is_absent_is_reported(self) -> None:
+        row = self._row_with_no_directory()
+
+        verdicts = plan_dead_row_release(self.workspace)
+
+        assert [v.worktree_pk for v in verdicts] == [row.pk]
+        assert verdicts[0].disposition is DeadRowDisposition.UNVERIFIABLE
+
+    def test_an_absent_directory_never_authorises_a_release(self) -> None:
+        row = self._row_with_no_directory()
+
+        outcome = release_dead_rows(self.workspace, dry_run=False)
+
+        assert Worktree.objects.filter(pk=row.pk).exists()
+        assert outcome.released_pks == frozenset()
+        assert outcome.render() == [f"KEPT 'vanished-dir' (worktree {row.pk}): {outcome.verdicts[0].reason}"]
+
+    def test_the_reason_names_the_path_and_the_vantage_point(self) -> None:
+        self._row_with_no_directory()
+
+        [verdict] = plan_dead_row_release(self.workspace)
+
+        assert str(self.workspace / "wt-vanished-dir") in verdict.reason
+        assert "execution context" in verdict.reason
+
+
 class ProtectionGatesMatchTheSweepTest(_DeadRowCase):
     """The narrow release must protect exactly what ``clean-all`` protects.
 


### PR DESCRIPTION
fix(worktree): require proof, not a record, before a self-healing pass skips (#3943)

## Why

Closes #3943. Three checks that could not answer were treated as answers. Each one turns a recoverable state into a stuck one.

## What

### 1. Provisioning trusted a recorded path

`WorktreeProvisioner._provision_repo` returned `extra["worktree_path"]` whenever one was recorded. That tests whether a path was ever written down, not whether the checkout is still there — so a row whose checkout is gone made every later provision a no-op handing back an unusable path, and nothing could re-materialise the checkout.

The short-circuit now requires positive proof of LIFE and otherwise falls through to re-provision. The asymmetry with the reaper is deliberate: a reaper deletes, so it may act only on proof of DEATH; this skips the work that would create a checkout, so it may act only on proof of LIFE. Falling through adds a checkout and removes nothing.

The proof is the existing three-valued `probe_checkout`, handed the clone as this context reaches it — not a bare existence test. A checkout created in another execution context records an absolute admin dir that resolves to nothing here, and git's `not a git repository` there is about a pointer this context cannot follow, not about the directory. The clone's own admin entry, looked up by name, is what keeps such a checkout live.

### 2. `release-dead-rows` omitted the rows it is reached for

`plan_dead_row_release` classified a row whose directory is absent as `LIVE_CHECKOUT` and dropped it from the plan, so the command reported nothing and released nothing about exactly the rows an operator runs it for. No other pass owns that shape either — `reap_done_worktree` takes the same branch.

Such a row is now reported as `UNVERIFIABLE` and kept. It is not released: an absent directory is precisely the evidence one context cannot turn into proof of death, and the row is the registry's only handle on the branch. The reason names the path, the vantage-point limit, and the remedy — re-running provisioning, which now re-materialises the checkout.

### 3. An unanswerable dirt probe was worded as a data-loss refusal

`real_uncommitted_reasons` fails closed, and the dirty-worktree guard rendered every reason under one sentence — `refused cleanup — worktree has uncommitted changes (possibly in use): could not read working-tree status (…)`. A teardown blocked by an unreadable index therefore asserted uncommitted changes that may not exist.

`WorkingTreeDirt` now carries whether the probe answered. Keeping the worktree is unchanged in both cases; only the wording differs, so an inconclusive probe is no longer indistinguishable from proven dirt in messages and logs. `real_uncommitted_reasons` stays as the reasons-only accessor for callers that do not report to an operator.

The guard moved to `cleanup_dirt_guard.py` (mirroring `cleanup_busy_guards`) to keep the teardown orchestrator under the module-health LOC cap.

## Tests

Every new regression test was observed red before the fix:

- the two re-provision tests (recorded checkout gone; recorded directory holds no checkout) and the reused-row test fail against the old "a recorded path is trusted" contract;
- the vantage-point test fails against a probe that does not consult the clone — it is what stops the fix from calling a live checkout dead;
- the no-op test fails with the short-circuit removed (`_create` is entered);
- the three `release-dead-rows` tests fail on an empty plan;
- the guard test fails on a message that claims uncommitted changes.

Real git under `tmp_path` throughout.
