### PR TITLE
fix(gates): make three gates report the answer they actually measured (#3924, #3923, #3868)

### DIFF
--- a/dev/ci-parity-fast.sh
+++ b/dev/ci-parity-fast.sh
@@ -6,6 +6,24 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# A CALLER's pipeline (`bash dev/ci-parity-fast.sh 2>&1 | tail -25`) reports its
+# LAST stage's status, so this lane's exit code is erased before anyone reads it.
+# `pipefail` above governs only pipelines this script builds, never one a caller
+# wraps around it — no script can restore its own status once it has been piped
+# away. So the verdict lives in the OUTPUT too: this trap makes the final line of
+# a red run an unmistakable FAILED banner, matching the success banner at the end,
+# so a piped run cannot read as a clean one in either direction. It re-raises the
+# original code, so an unpiped caller still sees a true exit status.
+_announce_verdict() {
+    rc=$?
+    trap - EXIT
+    if [ "$rc" -ne 0 ]; then
+        echo "=== ci-parity-fast: FAILED (exit ${rc}) -- scoped pre-push checks did NOT pass ==="
+    fi
+    exit "$rc"
+}
+trap _announce_verdict EXIT
+
 # Skip the slow network hooks (their own dedicated CI jobs run them).
 export SKIP="${SKIP:-uv-audit,cyclonedx-sbom}"
 

--- a/dev/ci-parity.sh
+++ b/dev/ci-parity.sh
@@ -21,6 +21,23 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# A CALLER's pipeline (`bash dev/ci-parity.sh 2>&1 | tail -25`) reports its LAST
+# stage's status, so this lane's exit code is erased before anyone reads it.
+# `pipefail` above governs only pipelines this script builds, never one a caller
+# wraps around it. So the verdict lives in the OUTPUT too: this trap makes the
+# final line of a red run an unmistakable FAILED banner, matching the success
+# banner at the end. It re-raises the original code, so an unpiped caller still
+# sees a true exit status.
+_announce_verdict() {
+    rc=$?
+    trap - EXIT
+    if [ "$rc" -ne 0 ]; then
+        echo "=== ci-parity: FAILED (exit ${rc}) -- a blocking CI predicate did NOT pass ==="
+    fi
+    exit "$rc"
+}
+trap _announce_verdict EXIT
+
 # Skip the slow network hooks (their own dedicated CI jobs run them); everything
 # else runs exactly as CI's `lint` job does. Override with SKIP=... if needed.
 export SKIP="${SKIP:-uv-audit,cyclonedx-sbom}"

--- a/dev/lib/xdist-workers.sh
+++ b/dev/lib/xdist-workers.sh
@@ -24,6 +24,11 @@
 : "${T3_CGROUP_MEMORY_MAX_V2:=/sys/fs/cgroup/memory.max}"
 : "${T3_CGROUP_MEMORY_MAX_V1:=/sys/fs/cgroup/memory/memory.limit_in_bytes}"
 
+# Core count, injectable for the same reason. Empty means "detect with nproc"; a value
+# pins it, so a test can exercise the memory arithmetic without its result depending on
+# how many cores the runner happens to have.
+: "${T3_CPU_COUNT:=}"
+
 # cgroup v1 reports a near-2**63 page-aligned sentinel to mean "unlimited"; cgroup v2
 # uses the literal string "max". Both mean "no cap" and must not bound anything.
 _T3_CGROUP_UNLIMITED_SENTINEL=9223372036854771712
@@ -67,7 +72,11 @@ bound_xdist_workers_to_memory() {
     fi
 
     local cores
-    cores=$(nproc 2>/dev/null || echo 1)
+    if [ -n "$T3_CPU_COUNT" ]; then
+        cores=$T3_CPU_COUNT
+    else
+        cores=$(nproc 2>/dev/null || echo 1)
+    fi
     if [ "$allowed" -ge "$cores" ]; then
         # Memory is not the binding constraint here; leave `-n auto` to the cores.
         return 0

--- a/dev/lib/xdist-workers.sh
+++ b/dev/lib/xdist-workers.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Bound pytest-xdist's `-n auto` by the container's MEMORY cap, not just its cores.
+#
+# `-n auto` sizes the worker pool from the CPU count, and a cgroup memory limit does
+# not change `nproc` — so inside a memory-capped container `-n auto` still sees the
+# HOST's cores and spawns far more workers than the cap allows. The run then dies as
+# an opaque xdist "worker crashed", which reads as a flaky lane rather than as the
+# memory limit it actually is.
+#
+# Sourced (not executed) by every lane that runs pytest:
+#
+#   . "$(dirname "$0")/lib/xdist-workers.sh"
+#   bound_xdist_workers_to_memory
+#
+# An explicit `PYTEST_XDIST_AUTO_NUM_WORKERS=4 bash dev/<lane>.sh` always wins — the
+# bound only supplies a DEFAULT, and only when the cgroup reports a real cap that is
+# tighter than the core count. An uncapped box is left entirely alone.
+
+# Approximate resident memory one pytest-xdist worker needs for this suite. Override
+# to re-tune the bound without touching the lanes.
+: "${T3_MB_PER_TEST_WORKER:=512}"
+
+# Injectable for tests; the defaults are the real cgroup v2 / v1 paths.
+: "${T3_CGROUP_MEMORY_MAX_V2:=/sys/fs/cgroup/memory.max}"
+: "${T3_CGROUP_MEMORY_MAX_V1:=/sys/fs/cgroup/memory/memory.limit_in_bytes}"
+
+# cgroup v1 reports a near-2**63 page-aligned sentinel to mean "unlimited"; cgroup v2
+# uses the literal string "max". Both mean "no cap" and must not bound anything.
+_T3_CGROUP_UNLIMITED_SENTINEL=9223372036854771712
+
+# Echo the cgroup memory cap in bytes, or return non-zero when uncapped/unreadable.
+_t3_cgroup_memory_cap_bytes() {
+    local raw=""
+    if [ -r "$T3_CGROUP_MEMORY_MAX_V2" ]; then
+        raw=$(cat "$T3_CGROUP_MEMORY_MAX_V2" 2>/dev/null || true)
+    fi
+    if [ -z "$raw" ] || [ "$raw" = "max" ]; then
+        raw=""
+        if [ -r "$T3_CGROUP_MEMORY_MAX_V1" ]; then
+            raw=$(cat "$T3_CGROUP_MEMORY_MAX_V1" 2>/dev/null || true)
+        fi
+    fi
+    case "$raw" in
+        '' | max | *[!0-9]*) return 1 ;;
+    esac
+    if [ "$raw" -ge "$_T3_CGROUP_UNLIMITED_SENTINEL" ]; then
+        return 1
+    fi
+    echo "$raw"
+}
+
+# Default PYTEST_XDIST_AUTO_NUM_WORKERS from the cgroup cap. Always returns 0 — a box
+# with no cgroup, an unreadable cap, or an uncapped limit is simply left as it is.
+bound_xdist_workers_to_memory() {
+    if [ -n "${PYTEST_XDIST_AUTO_NUM_WORKERS:-}" ]; then
+        return 0
+    fi
+
+    local cap
+    cap=$(_t3_cgroup_memory_cap_bytes) || return 0
+
+    local allowed=$((cap / 1024 / 1024 / T3_MB_PER_TEST_WORKER))
+    if [ "$allowed" -lt 1 ]; then
+        # A cap below one worker's footprint still needs ONE worker: 0 would leave the
+        # lane with no runner at all, turning a tight box into a wedged one.
+        allowed=1
+    fi
+
+    local cores
+    cores=$(nproc 2>/dev/null || echo 1)
+    if [ "$allowed" -ge "$cores" ]; then
+        # Memory is not the binding constraint here; leave `-n auto` to the cores.
+        return 0
+    fi
+
+    export PYTEST_XDIST_AUTO_NUM_WORKERS="$allowed"
+    echo "=== bounding pytest to ${allowed} worker(s): cgroup memory cap $((cap / 1024 / 1024)) MiB at ${T3_MB_PER_TEST_WORKER} MiB/worker (${cores} cores) ==="
+    return 0
+}

--- a/dev/push-gate.sh
+++ b/dev/push-gate.sh
@@ -26,6 +26,13 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# `-n auto` sizes the worker pool from CPU count, which a cgroup memory cap does not
+# change — so a memory-capped container spawns host-many workers and dies as an opaque
+# xdist crash. Default the pool from the cap instead (an explicit
+# PYTEST_XDIST_AUTO_NUM_WORKERS still wins; an uncapped box is left alone).
+. dev/lib/xdist-workers.sh
+bound_xdist_workers_to_memory
+
 echo "=== [1/3] never-lockout safety contract ==="
 uv run pytest tests/test_gate_never_lockout_contract.py -q
 

--- a/dev/test-affected.sh
+++ b/dev/test-affected.sh
@@ -38,6 +38,13 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# `-n auto` sizes the worker pool from CPU count, which a cgroup memory cap does not
+# change — so a memory-capped container spawns host-many workers and dies as an opaque
+# xdist crash. Default the pool from the cap instead (an explicit
+# PYTEST_XDIST_AUTO_NUM_WORKERS still wins; an uncapped box is left alone).
+. dev/lib/xdist-workers.sh
+bound_xdist_workers_to_memory
+
 BASE="origin/main"
 FULL=0
 PYTEST_EXTRA=()

--- a/dev/test-cov.sh
+++ b/dev/test-cov.sh
@@ -12,6 +12,13 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# `-n auto` sizes the worker pool from CPU count, which a cgroup memory cap does not
+# change — so a memory-capped container spawns host-many workers and dies as an opaque
+# xdist crash. Default the pool from the cap instead (an explicit
+# PYTEST_XDIST_AUTO_NUM_WORKERS still wins; an uncapped box is left alone).
+. dev/lib/xdist-workers.sh
+bound_xdist_workers_to_memory
+
 PY_VERSION="${TEATREE_TEST_PYTHON:-3.13}"
 
 echo "=== Coverage gate: Python ${PY_VERSION} (host, parallel, 93% floor) ==="

--- a/dev/test-shuffle.sh
+++ b/dev/test-shuffle.sh
@@ -11,12 +11,15 @@
 # exit 0, because a shell pipeline's status is its LAST stage's. Measured on this repo:
 # the bare pytest exits 1, the identical run piped into `tail` exits 0. Anything gating
 # on that exit code reads a green shuffle lane that never collected a single test.
-# Three guards close it, cheapest first:
+# Four guards close it, cheapest first:
 #   1. `set -euo pipefail` and NO pipes — no exit code can be swallowed in here.
 #   2. an explicit `--group shuffle` install plus an import PREFLIGHT that fails loud
 #      with the fix command, BEFORE pytest is ever asked to load the plugin.
 #   3. `-o required_plugins=pytest-randomly` — pytest's own in-session assertion, so a
 #      degraded environment cannot silently produce an UNSHUFFLED green either.
+#   4. an EXIT trap announcing FAILED, because guard 1 cannot reach a pipe the CALLER
+#      wraps around this script — `… | tail -5` reports tail's status, so the verdict
+#      has to be in the output as well as in the exit code.
 # The curated directory set is pinned byte-for-byte against CI's lane by
 # tests/test_ci_shuffle_lane_scope.py, so the local twin cannot drift from the gate.
 #
@@ -30,9 +33,22 @@ SEEDS=("${@:-7}")
 
 # pytest-randomly auto-activates on import, so leaving it installed would shuffle every
 # later `uv run pytest` in this checkout — the exact destabilisation that keeps it out
-# of the `dev` group. Restore the default environment on the way out; an EXIT trap that
-# does not itself call `exit` leaves the script's own status untouched.
-trap 'uv sync --quiet || true' EXIT
+# of the `dev` group. Restore the default environment on the way out, then announce the
+# verdict: guard 1 stops a pipe INSIDE this script erasing an exit code, but a pipe the
+# CALLER wraps around the whole run (`bash dev/test-shuffle.sh | tail -5`) is beyond any
+# `pipefail` here — that pipeline reports tail's status. Announcing only success left a
+# red run's tail carrying no verdict at all, so it read as a clean one. The trap
+# re-raises the original code, leaving an unpiped caller's exit status true.
+_finish() {
+    rc=$?
+    trap - EXIT
+    uv sync --quiet || true
+    if [ "$rc" -ne 0 ]; then
+        echo "=== test-shuffle: FAILED (exit ${rc}) -- the order-dependence lane did NOT pass ==="
+    fi
+    exit "$rc"
+}
+trap _finish EXIT
 
 echo "=== [1/3] install the shuffle group (pytest-randomly is NOT in the default dev group) ==="
 uv sync --group shuffle

--- a/hooks/scripts/coverage_gate.py
+++ b/hooks/scripts/coverage_gate.py
@@ -33,7 +33,7 @@ import re
 import shutil
 from pathlib import Path
 
-from hooks.scripts.forge_api_detect import _is_api_create_endpoint_write
+from hooks.scripts.forge_api_detect import _is_api_create_endpoint_write, _is_existing_pr_metadata_only_edit
 from hooks.scripts.managed_repo import teatree_src_on_path
 from hooks.scripts.mr_cli_fields import extract_mr_target_repo, strip_quoted_and_heredoc
 
@@ -63,6 +63,13 @@ def is_merge_class_command(command: str) -> bool:
     if _GH_PR_READY_RE.search(skeleton) or _PR_MR_CREATE_RE.search(skeleton):
         return not _DRAFT_FLAG_RE.search(skeleton)
     if _FORGE_API_RE.search(skeleton) and _is_api_create_endpoint_write(command):
+        # Editing an existing PR's title/description creates nothing and merges
+        # nothing, so it is not a merge-class write. Sibling gates REQUIRE such a
+        # correction (conventional-commit first line, `## What` / `## Why`), and
+        # this gate blocks a push — so firing on it makes satisfying one gate trip
+        # another.
+        if _is_existing_pr_metadata_only_edit(command):
+            return False
         return not _DRAFT_FLAG_RE.search(skeleton)
     return False
 

--- a/hooks/scripts/forge_api_detect.py
+++ b/hooks/scripts/forge_api_detect.py
@@ -53,18 +53,25 @@ _REVIEW_POST_BODY_FLAG_RE = re.compile(
 _GLAB_GH_API_RE = re.compile(r"\b(?:glab|gh)\s+api\b")
 
 
-def _effective_method_is_write(command: str) -> bool:
-    """Whether a gh/glab REST command's EFFECTIVE HTTP method is a write (not GET).
+def _effective_method(command: str) -> str:
+    """The EFFECTIVE HTTP method of a gh/glab REST command, upper-cased.
 
     The LAST ``-X``/``--method`` value wins; with no method flag the forge
-    defaults to POST when a body/field flag is present, else GET. A GET is the
-    only read. Shared by the create-endpoint and merge-endpoint gates so the
-    classifier cannot drift between them.
+    defaults to POST when a body/field flag is present, else GET.
     """
     methods = [m.upper() for pair in _REVIEW_POST_METHOD_RE.findall(command) for m in pair if m]
     if methods:
-        return methods[-1] != "GET"
-    return bool(_REVIEW_POST_BODY_FLAG_RE.search(command))
+        return methods[-1]
+    return "POST" if _REVIEW_POST_BODY_FLAG_RE.search(command) else "GET"
+
+
+def _effective_method_is_write(command: str) -> bool:
+    """Whether a gh/glab REST command's EFFECTIVE HTTP method is a write (not GET).
+
+    A GET is the only read. Shared by the create-endpoint and merge-endpoint
+    gates so the classifier cannot drift between them.
+    """
+    return _effective_method(command) != "GET"
 
 
 def _is_api_create_endpoint_write(command: str) -> bool:
@@ -84,3 +91,48 @@ def _is_api_create_endpoint_write(command: str) -> bool:
     if _MERGE_ENDPOINT_RE.search(command):
         return False
     return _effective_method_is_write(command)
+
+
+# An EXISTING PR/MR's own endpoint, carrying its number: ``/pulls/3887``,
+# ``/merge_requests/77``. The lookahead rejects a nested sub-resource
+# (``/pulls/3887/commits``) so only the PR object itself matches.
+_API_NUMBERED_PR_ENDPOINT_RE = re.compile(r"/(?:pulls|merge_requests)/\d+(?![/\d])")
+
+# The ``key`` of a ``-f key=value`` / ``--field`` / ``-F`` / ``--raw-field`` /
+# ``-d`` / ``--data`` argument.
+_API_FIELD_KEY_RE = re.compile(
+    r"(?:^|\s)(?:-f|--field|-F|--raw-field|-d|--data)[\s=]+['\"]?([A-Za-z_][A-Za-z0-9_]*)=",
+)
+
+# Fields carrying only a PR/MR's DESCRIPTIVE metadata. Editing these changes no
+# repository state: the PR still exists, still targets the same base branch, and
+# keeps its open/closed and draft status. Anything outside this set (``state``,
+# ``base``, ``target_branch``, ``draft``, …) is a state change and stays gated.
+_PR_METADATA_FIELDS = frozenset({"title", "body", "description"})
+
+# The update methods a metadata edit uses. A POST to a numbered endpoint is not an
+# edit (the forges treat it as a create/sub-resource action), so it stays gated.
+_PR_UPDATE_METHODS = frozenset({"PATCH", "PUT"})
+
+
+def _is_existing_pr_metadata_only_edit(command: str) -> bool:
+    """Whether *command* only edits an EXISTING PR/MR's descriptive metadata.
+
+    True for an update (``PATCH``/``PUT``) against a PR's own numbered endpoint
+    that sets ONLY fields in :data:`_PR_METADATA_FIELDS`. Retitling a PR or
+    rewriting its description creates nothing, merges nothing, and closes
+    nothing, so it must not be classified alongside the create/merge/close
+    writes that move a PR toward merge.
+
+    Deliberately narrow and fail-safe: no recognised field, an unrecognised
+    field, the collection endpoint, or any other method all return ``False``,
+    leaving the caller's existing classification in force.
+    """
+    if not _API_NUMBERED_PR_ENDPOINT_RE.search(command):
+        return False
+    if _MERGE_ENDPOINT_RE.search(command):
+        return False
+    if _effective_method(command) not in _PR_UPDATE_METHODS:
+        return False
+    keys = {m.group(1) for m in _API_FIELD_KEY_RE.finditer(command)}
+    return bool(keys) and keys <= _PR_METADATA_FIELDS

--- a/scripts/hooks/generate_management_commands_doc.py
+++ b/scripts/hooks/generate_management_commands_doc.py
@@ -3,6 +3,16 @@
 Walks the Django management command tree in-process (no subprocess spawning)
 and writes ``docs/generated/management-commands.md``.  Auto-stages the file on
 change.
+
+``argv[0]`` selects the output path and is ALWAYS the file written, mirroring
+``generate_cli_reference.py``. That is the merge-driver contract: when
+``git_merge_generated`` runs this hook it passes git's ``%A`` output slot — a
+``.merge_file_XXXXXX`` temp path in the repo root — and takes whatever is left
+there as the merge result. Deriving a destination from ``argv[0].parent``
+instead would leave the slot untouched (resolving the merge to "ours" while
+reporting success) and drop the real output in the repo root. The ``.json``
+sibling is written only alongside the committed default output, where the
+docs-drift gate reads it.
 """
 
 import os
@@ -24,12 +34,24 @@ def main(argv: list[str] | None = None) -> int:
 
     django.setup()
 
-    from teatree.core.management_commands_doc import write_management_commands_doc
+    from teatree.core.management_commands_doc import (
+        build_management_commands_doc_payload,
+        render_management_commands_markdown,
+        write_management_commands_doc,
+    )
 
     output.parent.mkdir(parents=True, exist_ok=True)
-    write_management_commands_doc(output.parent)
 
-    markdown = output.read_text(encoding="utf-8")
+    if output == _DEFAULT_OUTPUT:
+        # The committed pair: the .md the docs-drift gate diffs plus its .json sibling.
+        write_management_commands_doc(output.parent)
+        markdown = output.read_text(encoding="utf-8")
+    else:
+        # An explicit output path (the merge driver's %A slot): write exactly that
+        # file and nothing else, so the slot carries the regenerated result and no
+        # stray sibling lands in whatever directory the slot happens to live in.
+        markdown = render_management_commands_markdown(build_management_commands_doc_payload())
+        output.write_text(markdown, encoding="utf-8")
 
     if markdown != old and output == _DEFAULT_OUTPUT:
         subprocess.run(["git", "add", str(output)], check=False)

--- a/src/teatree/utils/diff_coverage.py
+++ b/src/teatree/utils/diff_coverage.py
@@ -279,23 +279,62 @@ def _changed_production_symbols(diff: str, repo_root: Path, scope: CoverageScope
     return out
 
 
-def _test_imported_and_shadowed(tree: ast.Module) -> tuple[set[str], set[str]]:
-    """Return ``(imported_names, locally_defined_names)`` for a test module.
+def _attribute_chain_root(node: ast.Attribute) -> str | None:
+    """The root ``Name`` of an attribute chain (``a.b.c`` → ``a``), if it has one.
 
-    ``imported_names`` is every name a top-level ``import``/``from … import``
-    binds (the alias if present). ``locally_defined_names`` is every name
-    the test module itself ``def``/``class``-defines at any level — a local
-    redefinition that shadows the production symbol.
+    A chain rooted in a call or subscript (``factory().attr``) has no static
+    root name and returns ``None``.
+    """
+    current: ast.expr = node.value
+    while isinstance(current, ast.Attribute):
+        current = current.value
+    return current.id if isinstance(current, ast.Name) else None
+
+
+def _test_imported_and_shadowed(tree: ast.Module) -> tuple[set[str], set[str]]:
+    """Return ``(referenced_names, locally_defined_names)`` for a test module.
+
+    ``referenced_names`` is every production name the test module reaches, by
+    any of the three idioms that resolve to production at call time — so a
+    revert of production turns the test red:
+
+    - ``from mod import symbol`` — the bound name;
+    - ``from mod import symbol as alias`` — BOTH the alias and the underlying
+    ``symbol``, since the alias is only a local spelling of the same object.
+    Reading the bound name alone hid the symbol and reported a thoroughly
+    exercised function as unreferenced;
+    - ``import mod`` (aliased or not) plus ``mod.symbol`` attribute access —
+    the idiom this codebase's tests actually use. The attribute name counts
+    only when its chain is rooted in an imported MODULE binding, so a local
+    stub's ``stub.symbol(...)`` is not mistaken for a production reference.
+
+    ``locally_defined_names`` is every name the test module itself
+    ``def``/``class``-defines at any level — a local redefinition that shadows
+    the production symbol. That is the "test-a-local-copy" vacuity this check
+    exists to catch, and shadowing still wins over every idiom above.
     """
     imported: set[str] = set()
+    module_bindings: set[str] = set()
+    attribute_uses: list[ast.Attribute] = []
     local: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
-            imported.update(alias.asname or alias.name for alias in node.names)
+            for alias in node.names:
+                imported.add(alias.asname or alias.name)
+                imported.add(alias.name)
         elif isinstance(node, ast.Import):
-            imported.update((alias.asname or alias.name).split(".")[0] for alias in node.names)
+            for alias in node.names:
+                bound = (alias.asname or alias.name).split(".")[0]
+                imported.add(bound)
+                module_bindings.add(bound)
+        elif isinstance(node, ast.Attribute):
+            attribute_uses.append(node)
         elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
             local.add(node.name)
+
+    imported.update(
+        attribute.attr for attribute in attribute_uses if _attribute_chain_root(attribute) in module_bindings
+    )
     return imported, local
 
 

--- a/tests/cli_doctor/test_doctor_check_command.py
+++ b/tests/cli_doctor/test_doctor_check_command.py
@@ -163,7 +163,11 @@ class TestDoctorCheckCommand:
         # The editable/contribute mismatch is an advisory WARN — it must NOT
         # redden the run now that the exit code is real (#3313).
         assert result.exit_code == 0, result.output
-        assert "WARN" in result.output
+        # Assert THIS gate's own line, not a bare "WARN": the doctor emits many
+        # advisory WARNs unrelated to the editable state (host-reading advisories,
+        # reconciliation reads), so a substring check for "WARN" alone passes with
+        # the editable/contribute warning removed entirely — it would guard nothing.
+        assert "teatree is editable but contribute=false in the DB config" in result.output
 
     def test_fails_when_required_tool_missing(self, tmp_path, monkeypatch):
         _stage_home(tmp_path, monkeypatch)

--- a/tests/teatree_core/test_git_merge_driver.py
+++ b/tests/teatree_core/test_git_merge_driver.py
@@ -161,3 +161,102 @@ class TestEndToEndConflictResolution:
         for path in ("docs/generated/cli-reference.md", "evals/README.md"):
             attr = run_git(repo_root, "check-attr", "merge", "--", path)
             assert attr.endswith("merge: generated"), f"{path} not marked merge=generated: {attr!r}"
+
+
+class TestManagementCommandsRegeneratesThroughTheRealGenerator:
+    """A genuine 3-way merge of ``management-commands.md`` regenerates, not "ours".
+
+    ``TestEndToEndConflictResolution`` above drives the merge through a STUB
+    generator, so it proves the driver's plumbing but says nothing about whether a
+    registered generator actually fills the ``%A`` slot. That gap is what let a
+    generator which derived its destination from ``argv[0].parent`` pass every
+    existing test while silently resolving each merge to "ours". This drives the
+    real ``generate_management_commands_doc.py`` end to end.
+    """
+
+    def test_real_generator_fills_the_output_slot_on_a_real_merge(self, tmp_path):
+        repo = make_git_repo(tmp_path / "repo")
+        real_root = Path(__file__).resolve().parents[2]
+        # The driver spawns its generator by REPO-RELATIVE path, resolved against the
+        # merge's cwd, so the temp repo needs the same scripts/hooks layout.
+        (repo / "scripts").symlink_to(real_root / "scripts")
+        (repo / ".git" / "info" / "exclude").write_text("/scripts\n", encoding="utf-8")
+
+        gen = repo / "docs" / "generated" / "management-commands.md"
+        gen.parent.mkdir(parents=True)
+        (repo / ".gitattributes").write_text("docs/generated/management-commands.md merge=generated\n")
+        run_git(
+            repo,
+            "config",
+            "merge.generated.driver",
+            f"{sys.executable} {real_root / 'scripts' / 'hooks' / 'git_merge_generated.py'} %O %A %B %P",
+        )
+
+        gen.write_text("# Management commands\n\n- base\n", encoding="utf-8")
+        run_git(repo, "add", ".gitattributes", "docs")
+        run_git(repo, "commit", "-q", "-m", "base")
+
+        run_git(repo, "checkout", "-q", "-b", "feat-a")
+        gen.write_text("# Management commands\n\n- base\n- OURS-ONLY\n", encoding="utf-8")
+        run_git(repo, "commit", "-q", "-am", "ours")
+
+        run_git(repo, "checkout", "-q", "main")
+        run_git(repo, "checkout", "-q", "-b", "feat-b")
+        gen.write_text("# Management commands\n\n- base\n- THEIRS-ONLY\n", encoding="utf-8")
+        run_git(repo, "commit", "-q", "-am", "theirs")
+
+        run_git(repo, "merge", "feat-a", check=False)
+
+        merged = gen.read_text(encoding="utf-8")
+        assert "<<<<<<<" not in merged, f"merge left conflict markers: {merged!r}"
+        assert ">>>>>>>" not in merged, f"merge left conflict markers: {merged!r}"
+        assert "OURS-ONLY" not in merged, (
+            "the merge resolved to the un-regenerated 'ours' side — the driver reported success "
+            "without the generator ever writing its output slot."
+        )
+        assert "THEIRS-ONLY" not in merged
+        assert "lifecycle" in merged, (
+            "the merged file must hold the REGENERATED reference built from the live command tree."
+        )
+
+    def test_a_real_merge_leaves_no_generated_litter_in_the_repo_root(self, tmp_path):
+        repo = make_git_repo(tmp_path / "repo")
+        real_root = Path(__file__).resolve().parents[2]
+        (repo / "scripts").symlink_to(real_root / "scripts")
+        (repo / ".git" / "info" / "exclude").write_text("/scripts\n", encoding="utf-8")
+
+        gen = repo / "docs" / "generated" / "management-commands.md"
+        gen.parent.mkdir(parents=True)
+        (repo / ".gitattributes").write_text("docs/generated/management-commands.md merge=generated\n")
+        run_git(
+            repo,
+            "config",
+            "merge.generated.driver",
+            f"{sys.executable} {real_root / 'scripts' / 'hooks' / 'git_merge_generated.py'} %O %A %B %P",
+        )
+
+        gen.write_text("# Management commands\n\n- base\n", encoding="utf-8")
+        run_git(repo, "add", ".gitattributes", "docs")
+        run_git(repo, "commit", "-q", "-m", "base")
+
+        run_git(repo, "checkout", "-q", "-b", "feat-a")
+        gen.write_text("# Management commands\n\n- base\n- a\n", encoding="utf-8")
+        run_git(repo, "commit", "-q", "-am", "ours")
+
+        run_git(repo, "checkout", "-q", "main")
+        run_git(repo, "checkout", "-q", "-b", "feat-b")
+        gen.write_text("# Management commands\n\n- base\n- b\n", encoding="utf-8")
+        run_git(repo, "commit", "-q", "-am", "theirs")
+
+        run_git(repo, "merge", "feat-a", check=False)
+
+        # git's %A slot lives in the repo ROOT; a generator that writes beside it
+        # rather than into it drops these there, where nothing reads them.
+        for stray in ("management-commands.md", "management-commands.json"):
+            assert not (repo / stray).exists(), (
+                f"the merge dropped {stray} in the repo root — that is the un-tracked writer that "
+                "re-dirties a working tree mid-rebase."
+            )
+
+    def test_registered_paths_cover_the_management_commands_doc(self):
+        assert "docs/generated/management-commands.md" in driver.registered_paths()

--- a/tests/teatree_core/test_management_commands_doc.py
+++ b/tests/teatree_core/test_management_commands_doc.py
@@ -4,6 +4,7 @@ import json
 import logging
 from pathlib import Path
 
+import generate_management_commands_doc as generator
 import pytest
 from django.core.management import call_command
 
@@ -235,3 +236,45 @@ class TestGenerateAllDocsIncludesManagementCommands:
         output_dir = tmp_path / "generated"
         call_command("generate_all_docs", output_dir=str(output_dir))
         assert (output_dir / "management-commands.md").is_file()
+
+
+class TestGeneratorWritesTheOutputPathItIsGiven:
+    """The hook must write ``argv[0]`` itself — the merge-driver output contract.
+
+    ``git_merge_generated`` hands this generator git's ``%A`` output slot (a
+    ``.merge_file_XXXXXX`` temp path in the repo root) and takes whatever is left
+    there as the merge result. A generator that derives its own destination from
+    ``argv[0].parent`` instead of writing ``argv[0]`` therefore resolves every
+    merge to "ours" while reporting success, and drops its real output next to the
+    slot — in the repo root. Its sibling ``generate_cli_reference.py`` writes the
+    given path directly; this pins the same contract here.
+    """
+
+    def test_writes_the_given_path(self, tmp_path: Path) -> None:
+        slot_dir = tmp_path / "repo-root"
+        slot_dir.mkdir()
+        slot = slot_dir / ".merge_file_ABC123"
+        slot.write_text("OURS — the un-regenerated side\n", encoding="utf-8")
+
+        assert generator.main([str(slot)]) == 0
+
+        written = slot.read_text(encoding="utf-8")
+        assert written != "OURS — the un-regenerated side\n", (
+            "the generator left its output slot untouched — a merge driver using it "
+            "silently resolves to 'ours' instead of regenerating."
+        )
+        assert "lifecycle" in written, "the slot must hold the REGENERATED reference, not the ours-side content."
+
+    def test_writes_nothing_beside_the_given_path(self, tmp_path: Path) -> None:
+        slot_dir = tmp_path / "repo-root"
+        slot_dir.mkdir()
+        slot = slot_dir / ".merge_file_ABC123"
+        slot.write_text("OURS\n", encoding="utf-8")
+
+        generator.main([str(slot)])
+
+        strays = sorted(p.name for p in slot_dir.iterdir() if p != slot)
+        assert not strays, (
+            "the generator wrote files beside its output slot; during a real merge that slot's "
+            f"parent is the REPO ROOT, so these land there as untracked litter: {strays}"
+        )

--- a/tests/teatree_utils/test_diff_coverage.py
+++ b/tests/teatree_utils/test_diff_coverage.py
@@ -627,3 +627,83 @@ class TestCoverageScope:
         scope = CoverageScope(source_roots=("src",), omit=())
         report = measure_diff_coverage(diff, coverage_data_file=data_file, repo_root=git_repo, scope=scope)
         assert report.passes()
+
+
+class TestReferenceResolutionSeesRealProductionUses:
+    """The anti-vacuity check must resolve the SYMBOL, not just the bound name.
+
+    The check defeats the "test-a-local-copy" vacuity: a test that redefines a
+    local copy never imports the production symbol, so a revert of production
+    would not turn it red. Two idioms are genuine production references that the
+    bound-name-only reading missed, so a thoroughly exercised symbol was reported
+    unreferenced — and the only way to satisfy the gate was to add an import
+    written for the gate rather than for the reader.
+    """
+
+    def test_aliased_import_references_the_underlying_symbol(self, git_repo: Path) -> None:
+        (git_repo / "shipped.py").write_text("def register(x):\n    return x * 2\n", encoding="utf-8")
+        (git_repo / "tests").mkdir()
+        (git_repo / "tests" / "test_shipped.py").write_text(
+            "from shipped import register as register_slack\n\n\ndef test_it():\n    assert register_slack(2) == 4\n",
+            encoding="utf-8",
+        )
+        diff = _worktree_diff(git_repo)
+
+        assert unreferenced_changed_symbols(diff, repo_root=git_repo) == set(), (
+            "an aliased import binds a different NAME but references the same production "
+            "symbol — reverting production still turns this test red, so it is not vacuous."
+        )
+
+    def test_module_import_plus_attribute_access_is_a_reference(self, git_repo: Path) -> None:
+        (git_repo / "shipped.py").write_text("def register(x):\n    return x * 2\n", encoding="utf-8")
+        (git_repo / "tests").mkdir()
+        (git_repo / "tests" / "test_shipped.py").write_text(
+            "import shipped\n\n\ndef test_it():\n    assert shipped.register(2) == 4\n",
+            encoding="utf-8",
+        )
+        diff = _worktree_diff(git_repo)
+
+        assert unreferenced_changed_symbols(diff, repo_root=git_repo) == set(), (
+            "module-import plus attribute access is the idiom this codebase uses; it "
+            "resolves to production at call time, so it is a genuine reference."
+        )
+
+    def test_aliased_module_import_plus_attribute_access_is_a_reference(self, git_repo: Path) -> None:
+        (git_repo / "shipped.py").write_text("def register(x):\n    return x * 2\n", encoding="utf-8")
+        (git_repo / "tests").mkdir()
+        (git_repo / "tests" / "test_shipped.py").write_text(
+            "import shipped as mod\n\n\ndef test_it():\n    assert mod.register(2) == 4\n",
+            encoding="utf-8",
+        )
+        diff = _worktree_diff(git_repo)
+
+        assert unreferenced_changed_symbols(diff, repo_root=git_repo) == set()
+
+    def test_local_copy_vacuity_is_still_caught(self, git_repo: Path) -> None:
+        # The mechanism the check exists for must survive the widening: a test that
+        # defines its own copy references nothing in production, so a revert of
+        # production leaves it green — it must stay in the failing set.
+        (git_repo / "shipped.py").write_text("def register(x):\n    return x * 2\n", encoding="utf-8")
+        (git_repo / "tests").mkdir()
+        (git_repo / "tests" / "test_shipped.py").write_text(
+            "def register(x):\n    return x * 2\n\n\ndef test_it():\n    assert register(2) == 4\n",
+            encoding="utf-8",
+        )
+        diff = _worktree_diff(git_repo)
+
+        assert "register" in unreferenced_changed_symbols(diff, repo_root=git_repo)
+
+    def test_attribute_access_on_an_unimported_name_is_not_a_reference(self, git_repo: Path) -> None:
+        # A local stub's attribute access must not be mistaken for a production one:
+        # `stub.register(...)` where `stub` is a locally built object touches no
+        # production code, so the symbol stays unreferenced.
+        (git_repo / "shipped.py").write_text("def register(x):\n    return x * 2\n", encoding="utf-8")
+        (git_repo / "tests").mkdir()
+        (git_repo / "tests" / "test_shipped.py").write_text(
+            "class Stub:\n    def register(self, x):\n        return x * 2\n\n\n"
+            "def test_it():\n    stub = Stub()\n    assert stub.register(2) == 4\n",
+            encoding="utf-8",
+        )
+        diff = _worktree_diff(git_repo)
+
+        assert "register" in unreferenced_changed_symbols(diff, repo_root=git_repo)

--- a/tests/test_block_uncovered_diff_hook.py
+++ b/tests/test_block_uncovered_diff_hook.py
@@ -74,6 +74,45 @@ class TestMergeClassMutationDetection:
         assert _is_merge_class_mutation({"tool_name": "Bash", "tool_input": {"command": cmd}}) is False
 
 
+class TestMetadataOnlyPrEditIsNotMergeClass:
+    """Retitling an open PR creates nothing and merges nothing — the gate must not fire.
+
+    The per-diff coverage gate blocks a PUSH, so every spurious fire is paid by the
+    author. Several sibling gates *require* a PR's own description to be corrected
+    (conventional-commit first line, ``## What`` / ``## Why``); classifying that
+    correction as a merge-class write made satisfying one gate trip another. Only a
+    write that changes repository state — creating a PR, merging it, closing it —
+    is merge-class.
+    """
+
+    def _mutation(self, command: str) -> bool:
+        return _is_merge_class_mutation({"tool_name": "Bash", "tool_input": {"command": command}})
+
+    def test_patching_only_title_and_body_is_not_merge_class(self):
+        cmd = "gh api -X PATCH repos/souliane/teatree/pulls/3887 -f title=t -f body=b"
+        assert self._mutation(cmd) is False
+
+    def test_patching_only_the_description_is_not_merge_class(self):
+        cmd = "glab api -X PUT projects/12/merge_requests/77 -f description=d"
+        assert self._mutation(cmd) is False
+
+    def test_api_create_on_the_collection_endpoint_stays_merge_class(self):
+        cmd = "gh api -X POST repos/souliane/teatree/pulls -f title=t -f body=b"
+        assert self._mutation(cmd) is True
+
+    def test_closing_a_pr_stays_merge_class(self):
+        cmd = "gh api -X PATCH repos/souliane/teatree/pulls/3887 -f state=closed"
+        assert self._mutation(cmd) is True
+
+    def test_retargeting_the_base_branch_stays_merge_class(self):
+        cmd = "gh api -X PATCH repos/souliane/teatree/pulls/3887 -f base=main"
+        assert self._mutation(cmd) is True
+
+    def test_undrafting_via_the_api_stays_merge_class(self):
+        cmd = "gh api -X PATCH repos/souliane/teatree/pulls/3887 -f draft=false"
+        assert self._mutation(cmd) is True
+
+
 def _finding_json(*, uncovered: list[dict] | None = None, symbols: list[str] | None = None) -> str:
     return json.dumps(
         {

--- a/tests/test_dev_settings.py
+++ b/tests/test_dev_settings.py
@@ -1,6 +1,9 @@
 """Tests for teatree.settings, teatree.urls, teatree.wsgi and teatree.__main__."""
 
 import importlib
+import os
+import subprocess
+import sys
 from unittest.mock import patch
 
 from django.contrib.staticfiles.views import serve as serve_static
@@ -14,7 +17,11 @@ def test_settings_importable():
     """Importing the module should execute it without errors."""
     mod = importlib.import_module("teatree.settings")
     assert mod.SECRET_KEY == "teatree-dev-insecure"
-    assert mod.DEBUG is True
+    # DEBUG is COMPUTED from T3_DEBUG, so asserting a constant here would pin the
+    # RUNNER'S environment rather than the code, and turn red wherever a deployment
+    # sets T3_DEBUG=0. Assert the wiring; the value contract itself is pinned
+    # environment-independently by `test_debug_follows_the_environment`.
+    assert mod.DEBUG is _debug_enabled()
     assert mod.USE_TZ is True
     assert mod.ROOT_URLCONF == "teatree.urls"
     assert "default" in mod.DATABASES
@@ -104,3 +111,27 @@ def test_wsgi_application_is_a_callable():
     """teatree.wsgi exposes a WSGI `application` callable for gunicorn."""
     mod = importlib.import_module("teatree.wsgi")
     assert callable(mod.application)
+
+
+def test_debug_follows_the_environment():
+    """``settings.DEBUG`` is derived from ``T3_DEBUG``, in BOTH directions.
+
+    ``DEBUG`` is evaluated once, at module import, so the wiring cannot be
+    observed by re-reading the attribute inside an already-configured Django
+    process. Each direction runs in a fresh interpreter instead, which makes the
+    assertion independent of the T3_DEBUG value the runner itself happens to
+    carry — a constant asserted in-process pins the runner's environment, not
+    the code, and turns red on any deployment that sets ``T3_DEBUG=0``.
+    """
+    script = "import teatree.settings as s; print(s.DEBUG)"
+    for value, expected in (("0", "False"), ("1", "True")):
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            env={**os.environ, "T3_DEBUG": value},
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert completed.stdout.strip() == expected, (
+            f"T3_DEBUG={value} must yield DEBUG={expected}; settings.DEBUG is not wired to the env reader."
+        )

--- a/tests/test_lane_verdict_visibility.py
+++ b/tests/test_lane_verdict_visibility.py
@@ -1,0 +1,99 @@
+"""A verification lane must announce its FAILURE, not only its success.
+
+A shell pipeline reports its LAST stage's status, so ``bash dev/<lane>.sh 2>&1 |
+tail -25`` exits with ``tail``'s 0 no matter how the lane ended. ``set -o
+pipefail`` inside the lane cannot reach that pipe — it governs only pipelines the
+script itself builds, and the pipe here belongs to the CALLER. Nothing a script
+does can restore its own exit code once a caller has piped it away.
+
+So the verdict has to live in the OUTPUT rather than only in ``$?``. These lanes
+announced only their success: a green run ended with an unmistakable banner, and
+a red run ended with whatever its failing step happened to print last. Piped into
+``tail``, the red run therefore showed no verdict at all while the pipeline
+reported 0 — a lane that reads clean while failing, which is worse than no lane
+because it is trusted.
+
+The guard is an EXIT trap emitting a FAILED banner, so the final line of a piped
+run is always a verdict, in both directions. ``tests/test_ci_shuffle_lane_scope.py``
+pins the neighbouring half of the same hazard: that a lane never pipes pytest
+*internally*, where ``pipefail`` does apply.
+"""
+
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_BASH = shutil.which("bash") or "/bin/bash"
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# The lanes that announce a verdict banner on success. Each is a gate whose green
+# result is trusted, and each dies mid-step on failure — so each needs the
+# failure banner for its piped output to be readable.
+_VERDICT_LANES = (
+    "dev/ci-parity-fast.sh",
+    "dev/ci-parity.sh",
+    "dev/test-shuffle.sh",
+)
+
+
+@pytest.fixture
+def failing_uv_path(tmp_path: Path) -> str:
+    """A ``PATH`` whose ``uv`` fails immediately, so a lane dies in its FIRST step.
+
+    Every lane below reaches ``uv`` within its first step, so this drives a real
+    red run of the real script in well under a second — no stubbed copy of the
+    lane, which would pin a duplicate rather than the script that actually runs.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "uv"
+    stub.write_text("#!/bin/sh\necho 'simulated lane failure' >&2\nexit 1\n", encoding="utf-8")
+    stub.chmod(0o755)
+    return f"{bin_dir}{os.pathsep}{os.environ['PATH']}"
+
+
+def _run(command: str, path: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [_BASH, "-c", command],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": path},
+        cwd=_REPO_ROOT,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("lane", _VERDICT_LANES)
+class TestPipedLaneCannotReadAsClean:
+    def test_failure_banner_survives_a_pipe_into_tail(self, lane: str, failing_uv_path: str) -> None:
+        """The reported shape: the lane is red, but the pipeline's status is ``tail``'s."""
+        script = shlex.quote(str(_REPO_ROOT / lane))
+        result = _run(f"bash {script} 2>&1 | tail -5", failing_uv_path)
+
+        # The premise, asserted rather than assumed: the caller's pipe really does
+        # erase the failure from the exit status. If this ever stops holding, the
+        # banner below is belt-and-braces rather than the only signal.
+        assert result.returncode == 0, (
+            "expected the caller's pipeline to mask the lane's non-zero exit "
+            f"(that is the whole hazard), got {result.returncode}"
+        )
+        assert "FAILED" in result.stdout, (
+            f"{lane} produced no failure verdict in the last lines of a red run, so piped into "
+            "`tail` it is indistinguishable from a clean one — while the pipeline reports success."
+        )
+
+    def test_unpiped_run_still_exits_non_zero(self, lane: str, failing_uv_path: str) -> None:
+        """The banner must REPORT the failure, never absorb it.
+
+        A trap that ends in a bare ``exit`` (or forgets to re-raise the code) would
+        turn every red lane green for callers that do not pipe — trading one masked
+        exit status for a worse one.
+        """
+        script = shlex.quote(str(_REPO_ROOT / lane))
+        result = _run(f"bash {script} >/dev/null 2>&1", failing_uv_path)
+
+        assert result.returncode != 0, f"{lane} swallowed its own failing exit code"

--- a/tests/test_xdist_memory_bound.py
+++ b/tests/test_xdist_memory_bound.py
@@ -1,0 +1,118 @@
+"""``-n auto`` must be bounded by the container's MEMORY cap, not just its cores.
+
+pytest-xdist sizes ``-n auto`` from the CPU count. Inside a memory-capped
+container that count is the HOST's, because a cgroup memory limit does not change
+``nproc`` — so a container capped well below ``cores x per-worker RAM`` spawns far
+more workers than its memory allows. The run then dies as an opaque xdist "worker
+crashed" rather than as the memory limit it actually is, which reads as a flaky
+lane instead of a misconfigured one.
+
+``dev/lib/xdist-workers.sh`` closes that: it defaults
+``PYTEST_XDIST_AUTO_NUM_WORKERS`` from the cgroup cap when the caller has not
+pinned one, so the lane runs bounded instead of crashing, and says so.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_BASH = shutil.which("bash") or "/bin/bash"
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_HELPER = _REPO_ROOT / "dev" / "lib" / "xdist-workers.sh"
+
+_GIB = 1024 * 1024 * 1024
+
+# The lanes that run pytest and therefore must bound their own worker pool.
+_PYTEST_LANES = ("dev/push-gate.sh", "dev/test-affected.sh", "dev/test-cov.sh")
+
+
+def _invoke(*, v2_contents: str | None, env: dict[str, str] | None = None, tmp_path: Path) -> tuple[str, str]:
+    """Source the helper against a FAKE cgroup file and report the resulting cap."""
+    v2 = tmp_path / "memory.max"
+    if v2_contents is not None:
+        v2.write_text(v2_contents, encoding="utf-8")
+    script = (
+        f"set -euo pipefail\n"
+        f'export T3_CGROUP_MEMORY_MAX_V2="{v2}"\n'
+        f'export T3_CGROUP_MEMORY_MAX_V1="{tmp_path / "absent-v1"}"\n'
+        f'. "{_HELPER}"\n'
+        f"bound_xdist_workers_to_memory\n"
+        f'echo "WORKERS=${{PYTEST_XDIST_AUTO_NUM_WORKERS:-unset}}"\n'
+    )
+    # Drop any ambient PYTEST_XDIST_AUTO_NUM_WORKERS before applying the case's own
+    # env: the runner itself is often invoked with that variable set (bounding the
+    # suite on a memory-tight host), and inheriting it would take the helper's
+    # "an explicit pin wins" branch in EVERY case — so each cap assertion would read
+    # the runner's environment instead of the code, exactly the coupling these
+    # changes exist to remove.
+    base = {key: value for key, value in os.environ.items() if key != "PYTEST_XDIST_AUTO_NUM_WORKERS"}
+    completed = subprocess.run(
+        [_BASH, "-c", script],
+        capture_output=True,
+        text=True,
+        env={**base, **(env or {}), "T3_MB_PER_TEST_WORKER": "512"},
+        check=True,
+    )
+    workers = next(
+        line.removeprefix("WORKERS=") for line in completed.stdout.splitlines() if line.startswith("WORKERS=")
+    )
+    return workers, completed.stdout
+
+
+class TestMemoryDerivedWorkerBound:
+    def test_helper_exists(self) -> None:
+        assert _HELPER.is_file(), (
+            "dev/lib/xdist-workers.sh must exist — without it every pytest lane sizes `-n auto` "
+            "from host cores and OOM-crashes inside a memory-capped container."
+        )
+
+    def test_low_cap_bounds_the_worker_pool(self, tmp_path: Path) -> None:
+        # A 2 GiB cap at 512 MiB/worker allows 4 workers, however many cores the HOST has.
+        workers, output = _invoke(v2_contents=str(2 * _GIB), tmp_path=tmp_path)
+
+        assert workers == "4", f"expected a memory-derived bound of 4 workers, got {workers!r}"
+        assert "cgroup memory cap" in output, "the bound must SAY why it applied — an unexplained cap is a mystery"
+
+    def test_uncapped_cgroup_leaves_auto_detection_alone(self, tmp_path: Path) -> None:
+        # "max" is cgroup v2 for no limit: a full-size box must keep the whole machine.
+        workers, _ = _invoke(v2_contents="max", tmp_path=tmp_path)
+
+        assert workers == "unset"
+
+    def test_missing_cgroup_file_leaves_auto_detection_alone(self, tmp_path: Path) -> None:
+        workers, _ = _invoke(v2_contents=None, tmp_path=tmp_path)
+
+        assert workers == "unset"
+
+    def test_an_explicitly_pinned_worker_count_wins(self, tmp_path: Path) -> None:
+        # The documented override (`PYTEST_XDIST_AUTO_NUM_WORKERS=2 bash dev/...`) must
+        # never be silently overridden by the automatic bound.
+        workers, _ = _invoke(
+            v2_contents=str(2 * _GIB),
+            env={"PYTEST_XDIST_AUTO_NUM_WORKERS": "2"},
+            tmp_path=tmp_path,
+        )
+
+        assert workers == "2"
+
+    def test_a_tiny_cap_still_yields_at_least_one_worker(self, tmp_path: Path) -> None:
+        # A cap below one worker's footprint must degrade to a serial-ish run, not to 0
+        # (which xdist reads as "no workers" and which would wedge the lane entirely).
+        workers, _ = _invoke(v2_contents=str(100 * 1024 * 1024), tmp_path=tmp_path)
+
+        assert workers == "1"
+
+
+@pytest.mark.parametrize("lane", _PYTEST_LANES)
+def test_pytest_lane_bounds_its_worker_pool(lane: str) -> None:
+    body = (_REPO_ROOT / lane).read_text(encoding="utf-8")
+
+    reason = (
+        f"{lane} runs pytest but never bounds its worker pool by the container's memory cap, "
+        "so on a memory-tight box it dies as an opaque xdist crash instead of running bounded."
+    )
+    assert "xdist-workers.sh" in body, reason
+    assert "bound_xdist_workers_to_memory" in body, reason

--- a/tests/test_xdist_memory_bound.py
+++ b/tests/test_xdist_memory_bound.py
@@ -29,8 +29,20 @@ _GIB = 1024 * 1024 * 1024
 _PYTEST_LANES = ("dev/push-gate.sh", "dev/test-affected.sh", "dev/test-cov.sh")
 
 
-def _invoke(*, v2_contents: str | None, env: dict[str, str] | None = None, tmp_path: Path) -> tuple[str, str]:
-    """Source the helper against a FAKE cgroup file and report the resulting cap."""
+def _invoke(
+    *,
+    v2_contents: str | None,
+    env: dict[str, str] | None = None,
+    tmp_path: Path,
+    cores: int = 16,
+) -> tuple[str, str]:
+    """Source the helper against a FAKE cgroup file and report the resulting cap.
+
+    *cores* is pinned rather than detected: the bound only applies when memory is the
+    BINDING constraint, so a test that let the runner's real core count decide would
+    assert something different on a 2-core runner than on a 16-core one — the same
+    environment coupling these changes exist to remove.
+    """
     v2 = tmp_path / "memory.max"
     if v2_contents is not None:
         v2.write_text(v2_contents, encoding="utf-8")
@@ -38,6 +50,7 @@ def _invoke(*, v2_contents: str | None, env: dict[str, str] | None = None, tmp_p
         f"set -euo pipefail\n"
         f'export T3_CGROUP_MEMORY_MAX_V2="{v2}"\n'
         f'export T3_CGROUP_MEMORY_MAX_V1="{tmp_path / "absent-v1"}"\n'
+        f'export T3_CPU_COUNT="{cores}"\n'
         f'. "{_HELPER}"\n'
         f"bound_xdist_workers_to_memory\n"
         f'echo "WORKERS=${{PYTEST_XDIST_AUTO_NUM_WORKERS:-unset}}"\n'
@@ -116,3 +129,15 @@ def test_pytest_lane_bounds_its_worker_pool(lane: str) -> None:
     )
     assert "xdist-workers.sh" in body, reason
     assert "bound_xdist_workers_to_memory" in body, reason
+
+
+def test_cap_above_the_core_count_leaves_auto_detection_alone(tmp_path: Path) -> None:
+    """A cap that allows MORE workers than there are cores is not the binding constraint.
+
+    Bounding there would cut the pool below what `-n auto` would rightly pick, so the
+    helper must stand down. This branch is why the bound cannot be asserted against a
+    fixed number without pinning the core count too.
+    """
+    workers, _ = _invoke(v2_contents=str(64 * _GIB), tmp_path=tmp_path, cores=2)
+
+    assert workers == "unset"


### PR DESCRIPTION
Closes #3924
Closes #3923
Closes #3868

## What

Three gates that reported a verdict other than the one they actually measured. They bundle because the defect class is one: a gate whose answer is not the answer it measured.

### #3924 — a lane's verdict erased by a caller's pipe (fixed)

`dev/ci-parity-fast.sh`, `dev/ci-parity.sh` and `dev/test-shuffle.sh` announced only their SUCCESS. A shell pipeline reports its last stage's status, so `bash dev/<lane>.sh 2>&1 | tail -25` exits 0 however the lane ended — and because only the green path printed a banner, a red run's tail carried no verdict at all.

**The fix proposed on the issue — `set -o pipefail` — would not have worked: all nine `dev/*.sh` lanes already set it.** This is the same bug *class* as the shuffle-lane defect this repo fixed before, but a different **locus**:

- the shuffle-lane defect was a pipe **inside** the script, which `pipefail` does fix, and which that lane also closes by never piping pytest at all;
- this defect is a pipe the **caller** wraps around the script. `pipefail` governs only pipelines the script itself builds. No in-script setting can reach it, and no script can restore its own exit status once a caller has piped it away.

That distinction matters because the obvious remedy here is to re-add a setting that is already present, conclude the lane is protected, and leave the hole open.

So the verdict now also lives in the OUTPUT: an EXIT trap emits a FAILED banner and re-raises the original code. A piped run gets a readable verdict in both directions; an unpiped caller still gets a true exit status.

### #3924 — an environment asserted as a constant (fixed)

`test_settings_importable` asserted `DEBUG is True`, a value computed from `T3_DEBUG`. It pinned the runner's environment rather than the code, and turned red wherever `T3_DEBUG=0` is set. It now asserts the wiring, and a new test pins the value contract in a fresh interpreter per direction, independent of the environment the runner carries.

### #3924 — `-n auto` blind to the memory cap (fixed)

pytest-xdist sizes `-n auto` from the CPU count, which a cgroup memory limit does not change. A memory-capped container therefore spawned host-many workers and died as an opaque xdist crash rather than as the limit it was. `dev/lib/xdist-workers.sh` defaults the pool from the cgroup cap; an explicit `PYTEST_XDIST_AUTO_NUM_WORKERS` still wins, and an uncapped box is left alone.

### #3924 — the doctor-command tests (DID NOT REPRODUCE — not fixed)

The issue reports `tests/cli_doctor/test_doctor_check_command.py` failing on `pyright-lsp plugin is not enabled` and `contribute=false in the DB config`. That did not reproduce against current `main`, and this PR does not claim a fix for it. Evidence:

- every `doctor check` test in that module already sandboxes the host through `_stage_home` (which redirects `Path.home()`) and patches `shutil.which`, so both named gates are deterministic there;
- the pyright gate returns an advisory pass when the plugin is not enabled, so it cannot redden the exit code;
- all 14 tests pass unchanged, including under a staged home that enables the plugin.

The two tests in that module which do *not* sandbox the host do not run the check chain.

One genuine adjacent defect was found in that same file and **is** fixed: `test_reports_warning_when_editable_state_mismatches` asserted only `"WARN" in result.output`. The doctor emits many unrelated advisory warnings, so that assertion held with no editable mismatch present at all — it would have stayed green with the warning it names removed entirely. It now asserts that gate's own line.

### #3923 — the coverage gate fired on a metadata-only edit (fixed)

Editing an open PR's title or description was classified as a merge-class write, so correcting a PR description — which sibling gates *require* — tripped a gate that blocks pushes. A `PATCH`/`PUT` setting only `title`/`body`/`description` on an existing PR's own numbered endpoint is no longer merge-class. Creates, merges, closes, base re-targets and draft toggles still are. The classifier stays shared with the MR-metadata gate, which must keep validating an edited title, so the exemption is applied at the coverage gate rather than in the shared predicate.

### #3923 — the anti-vacuity check blind to aliased imports (fixed)

It read the bound name, so `from mod import register as register_slack` hid `register` and reported a thoroughly exercised symbol as unreferenced. It now resolves the underlying symbol, and recognises the module-import-plus-attribute idiom these tests actually use. The test-a-local-copy vacuity the check exists to catch is unchanged, and is pinned by two tests that were green before and after the widening.

### #3868 — the merge driver never wrote its output slot (fixed)

`generate_management_commands_doc.py` derived its destination from `argv[0].parent` instead of writing `argv[0]`. Handed git's `%A` temp slot it left that slot untouched — so every merge of the generated doc resolved to ours without regeneration while reporting success — and dropped its real output beside the slot, an untracked writer that re-dirties a working tree mid-rebase. It now writes the path it is given, mirroring `generate_cli_reference.py`. The other two registered generators were audited and are already correct.

## Why

A gate is trusted precisely because it is a gate, so one that reports a verdict it did not measure converts an unknown into a false assurance. Each of these did that differently: success it had not earned, a failure belonging to the environment rather than to the change, or a merge resolution it never performed.

## Testing

Every fix is pinned by a regression test observed RED before the fix.

- The lane-verdict tests drive the REAL scripts to a real failure and assert the verdict survives a pipe into `tail`, while separately asserting that the pipeline's status really is masked — so the test exercises the reported shape rather than a proxy, and would fail if the banner were the only thing present.
- The merge-driver test drives a genuine three-way merge through the REAL generator. The pre-existing end-to-end test used a stub driver, which is why it could not have caught this; that stub is exactly the gap the new test closes.
- The `DEBUG` test was mutation-checked: hardcoding `DEBUG = True` turns it red.

### Modifying the lane used for verification

This PR changes `dev/ci-parity-fast.sh`, which is also the lane used to verify it. Stated plainly: the change **cannot** mask its own failure.

- It only ADDS an EXIT trap. The trap's final act is `exit "$rc"` with the code it captured, so it can turn a green run red but never a red run green.
- `test_unpiped_run_still_exits_non_zero` pins exactly that, and it was green both before and after the change — so it is a genuine guard against the trap absorbing a failure, not a test the change invented to pass.
- Verification runs were invoked UNPIPED with the exit status read directly, never inferred from the banner the change introduces.

A note on scope of the local run: the affected-tests selector correctly escalates to the whole tree here (`diff_coverage.py` is widely imported), which exceeds the local run budget. What was run locally: the scoped prek hooks, `makemigrations --check --dry-run`, and 3705 tests spanning every changed surface plus `tests/cli_doctor/`, `tests/teatree_hooks/`, `tests/conformance/` and `tests/quality/`. CI's sharded lane remains the whole-tree authority.

That local run earned its keep: it caught an environment-coupling defect in one of this PR's own new tests, which inherited an ambient `PYTEST_XDIST_AUTO_NUM_WORKERS` and so read the runner's environment instead of the code — the same defect class as the `T3_DEBUG` one above. It is fixed and now passes with that variable both set and unset.
