### PR TITLE
fix(merge): resolve a merged PR's owning ticket through every store that records it

### DIFF
--- a/src/teatree/core/gates/merge_evidence_gate.py
+++ b/src/teatree/core/gates/merge_evidence_gate.py
@@ -47,6 +47,7 @@ from teatree.core.merge.ci_rollup import CodeHostQuery
 from teatree.core.modelkit.gate_registry import register_gate
 from teatree.core.models import MergeAudit, PullRequest
 from teatree.core.models.errors import InvalidTransitionError
+from teatree.url_classify import pr_ref
 from teatree.utils.forge import forge_from_remote
 from teatree.utils.pr_ref import PrRef
 
@@ -82,6 +83,31 @@ def _pr_host_kind(pr: PullRequest) -> str:
     return forge_from_remote(pr.url) or "github"
 
 
+def _probeable_refs(ticket: "Ticket") -> list[PrRef]:
+    """Every PR of *ticket* the gate can ask the forge about, rows first.
+
+    A ticket with no ``PullRequest`` row is not a ticket with no PR: the board
+    reconcile's rule B targets exactly the ticket whose OWN ``issue_url`` names the
+    PR, and that is the shape with no row by definition (#3859). Deriving refs only
+    from rows left that queryset empty, so the gate found no evidence and refused the
+    very transition the reconcile was holding a definite forge MERGED verdict for.
+    The rows stay authoritative; the ``issue_url`` fills the gap only when there are
+    none, and only when it names a pull request — an ``/issues/N`` url parses to no
+    ref and is never probed.
+    """
+    refs: list[PrRef] = []
+    for pr in PullRequest.objects.filter(ticket=ticket):
+        slug = (pr.repo or "").strip()
+        raw_id = str(pr.iid or "").strip()
+        if not slug or not raw_id.isdigit():
+            continue
+        refs.append(PrRef(slug=slug, pr_id=int(raw_id), host_kind=_pr_host_kind(pr)))
+    if refs:
+        return refs
+    own = pr_ref(ticket.issue_url or "")
+    return [own] if own is not None else []
+
+
 def forge_confirms_merged(ticket: "Ticket") -> bool:
     """True iff a live forge probe confirms a PR of *ticket* is MERGED — FAIL-CLOSED.
 
@@ -90,19 +116,14 @@ def forge_confirms_merged(ticket: "Ticket") -> bool:
     malformed response) is inconclusive and yields no evidence, so a transport
     error is never mistaken for "merged".
     """
-    for pr in PullRequest.objects.filter(ticket=ticket):
-        slug = (pr.repo or "").strip()
-        raw_id = str(pr.iid or "").strip()
-        if not slug or not raw_id.isdigit():
-            continue
+    for ref in _probeable_refs(ticket):
         try:
-            query = CodeHostQuery.for_ref(PrRef(slug=slug, pr_id=int(raw_id), host_kind=_pr_host_kind(pr)))
-            state = query.pr_merge_state()
+            state = CodeHostQuery.for_ref(ref).pr_merge_state()
         except Exception:  # noqa: BLE001 — any probe failure is inconclusive; fail CLOSED (no evidence).
             logger.warning(
                 "merge_evidence gate: forge merge-state probe failed for %s#%s; treating as NOT merged (fail-closed).",
-                slug,
-                raw_id,
+                ref.slug,
+                ref.pr_id,
             )
             continue
         if state.is_merged:

--- a/src/teatree/core/merge/__init__.py
+++ b/src/teatree/core/merge/__init__.py
@@ -3,21 +3,16 @@
 Package facade re-exporting the cross-package public surface so callers import
 from ``teatree.core.merge`` while each symbol keeps an explicit defining module
 (``errors`` / ``ci_rollup`` / ``pr_slug_resolution`` / ``authorization`` /
-``execution``). This is the package's public API, not a backward-compat alias —
+``execution`` / ``post_hook``). This is the package's public API, not a backward-compat alias —
 ``mock.patch`` targets name the defining submodule, never this facade.
 """
 
 from teatree.core.merge.authorization import MergePrecheck, PresentedApprovals, _assert_clear_authorized
 from teatree.core.merge.ci_rollup import CodeHostQuery, classify_required_rollup, failing_required_names
 from teatree.core.merge.errors import MergeHeadMovedError, MergePreconditionError, MergeReplayError, MergeTransientError
-from teatree.core.merge.execution import (
-    MergeOutcome,
-    assert_merge_preconditions,
-    execute_bound_merge,
-    merge_ticket_pr,
-    record_merge_and_advance,
-)
+from teatree.core.merge.execution import MergeOutcome, assert_merge_preconditions, execute_bound_merge, merge_ticket_pr
 from teatree.core.merge.head_guard import restore_caller_branch
+from teatree.core.merge.post_hook import MergeAuditAuthorizers, record_merge_and_advance
 from teatree.core.merge.pr_slug_resolution import (
     _GIT_BRANCH_PREFIXES,
     _looks_like_owner_repo,
@@ -29,6 +24,7 @@ from teatree.core.merge.pr_slug_resolution import (
 __all__ = [
     "_GIT_BRANCH_PREFIXES",
     "CodeHostQuery",
+    "MergeAuditAuthorizers",
     "MergeHeadMovedError",
     "MergeOutcome",
     "MergePrecheck",

--- a/src/teatree/core/merge/execution.py
+++ b/src/teatree/core/merge/execution.py
@@ -11,7 +11,7 @@ transient / head-moved / policy-refusal classification and the exact error
 f-strings — the residual host-kind switch selects the classifier, never the
 transport. The #928 lost-post-hook reconciliation and the #1813 transient retry
 are documented on :func:`assert_merge_preconditions` / :func:`execute_bound_merge`
-/ :func:`record_merge_and_advance`.
+/ :func:`teatree.core.merge.post_hook.record_merge_and_advance`.
 """
 
 import dataclasses
@@ -19,11 +19,6 @@ import logging
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
-
-from django.apps import apps
-from django.db import transaction
-from django.utils import timezone
-from django_fsm import TransitionNotAllowed
 
 from teatree.core.merge.authorization import (
     MergePrecheck,
@@ -37,9 +32,10 @@ from teatree.core.merge.authorization import (
     assert_review_verdict_gate,
 )
 from teatree.core.merge.ci_rollup import CodeHostQuery, attach_touched_paths
-from teatree.core.merge.errors import MergePreconditionError, MergeReplayError, MergeTransientError
+from teatree.core.merge.errors import MergePreconditionError, MergeTransientError
 from teatree.core.merge.head_guard import restore_caller_branch
 from teatree.core.merge.merge_response import _raise_bound_merge_failure
+from teatree.core.merge.post_hook import MergeAuditAuthorizers, record_merge_and_advance
 from teatree.core.merge.pr_slug_resolution import (
     _reconcile_slug_against_reviewed_sha,
     _resolve_host_kind,
@@ -57,21 +53,6 @@ logger = logging.getLogger(__name__)
 
 MERGE_TRANSIENT_ATTEMPTS = 3
 MERGE_TRANSIENT_BASE_DELAY = 0.5
-
-
-@dataclass(frozen=True, slots=True)
-class MergeAuditAuthorizers:
-    """The authorizer ids the post hook stamps on the ``MergeAudit`` for a non-default merge.
-
-    Both empty for an ordinary merge. ``expedited_by`` is the PENDING-checks
-    expedite waiver authoriser (§17.4.3 / PR-07); ``standing_delegation_by`` is the
-    config-sourced standing substrate authorizer (#3413). Grouped so
-    :func:`record_merge_and_advance` takes one audit-authorizer argument instead of
-    a widening list.
-    """
-
-    expedited_by: str = ""
-    standing_delegation_by: str = ""
 
 
 @dataclass(frozen=True, slots=True)
@@ -408,137 +389,6 @@ def _attempt_bound_merge(*, query: CodeHostQuery, expected_head_oid: str) -> str
             host_kind=query.ref.host_kind,
         )
     return result.merged_sha or expected_head_oid
-
-
-def record_merge_and_advance(
-    *,
-    clear: object,
-    merged_sha: str,
-    required_checks_status: str,
-    repo_slug: str = "",
-    authorizers: MergeAuditAuthorizers | None = None,
-) -> str:
-    """Post hook: consume CLEAR, write audit, supersede siblings, ``mark_merged()``.
-
-    All in ONE ``transaction.atomic()`` so the FSM advance and the durable
-    merge record land atomically (the §4 worker-enqueue / sync-atomicity
-    invariant): a crash *within* this post hook rolls back the whole
-    transaction, leaving the CLEAR unconsumed and the FSM unmoved — a
-    re-runnable state. A crash *between* the irreversible GitHub merge and
-    this hook also leaves the CLEAR unconsumed, but the PR is now merged on
-    GitHub; that case is recovered by the #928 reconciliation in
-    :func:`assert_merge_preconditions` (the retry detects "already merged
-    at ``reviewed_sha``" and runs this hook idempotently instead of
-    re-issuing the merge). Returns the resulting ticket state.
-
-    ``repo_slug`` is the #1335-reconciled ``owner/repo`` the caller merged
-    against; it is stamped on the ``MergeAudit`` (#19) so the S1/S3 signal joins
-    read the merge-time truth first instead of re-resolving the CLEAR's offline
-    workstream slug. Empty only for a legacy/direct caller — the signal resolver
-    falls back to ``resolve_pr_repo_slug`` for a blank audit.
-
-    §15: a head-move re-review issues a fresh CLEAR at the new SHA, leaving the
-    older sibling unconsumed. Consuming ONE via a merge supersedes every sibling
-    unconsumed CLEAR for the same ``(slug, pr_id)`` in the same atomic block under
-    the row lock, so a stale orphan can no longer ratchet S4 hard-red forever. No
-    ``ReviewVerdict`` is moved: each sibling's verdict persists at its own
-    reviewed_sha and S3 counts it regardless of SHA, so there is no verdict-copy
-    path to hand-roll (GM-4's ``carry_forward`` is the primitive if one is ever
-    needed).
-
-    The atomic block is wrapped in :func:`retry_on_locked` (#1520): a transient
-    ``database is locked`` from a concurrent canonical-DB writer must not abort
-    the merge keystone mid-flight. A retry re-opens the transaction, re-reads
-    the CLEAR ``select_for_update``-locked, and re-asserts the single-use
-    guard, so it consumes the CLEAR exactly once and never double-merges (the
-    irreversible GitHub merge already ran before this hook; only this
-    idempotent DB write retries).
-    """
-    from teatree.core.modelkit.db_retry import retry_on_locked  # noqa: PLC0415 — deferred: call-time import, kept lazy
-    from teatree.core.models import MergeClear  # noqa: PLC0415 — deferred: ORM import needs the app registry
-
-    stamps = authorizers or MergeAuditAuthorizers()
-    if not isinstance(clear, MergeClear):  # pragma: no cover - guarded by caller
-        msg = "record_merge_and_advance requires a MergeClear instance"
-        raise MergePreconditionError(msg)
-
-    merge_audit_model = apps.get_model("core", "MergeAudit")
-
-    def _consume_and_advance() -> str:
-        with transaction.atomic():
-            locked = MergeClear.objects.select_for_update().get(pk=clear.pk)
-            # Re-assert single-use UNDER the row lock. ``assert_merge_preconditions``
-            # checked ``is_actionable()`` unlocked; two concurrent executors that
-            # both passed it must not both consume — exactly one wins this
-            # serialized re-check, the loser raises ``MergeReplayError`` and
-            # writes no audit / does not advance the FSM.
-            if locked.consumed_at is not None:
-                msg = (
-                    f"MergeClear {locked.pk} ({locked.slug}#{locked.pr_id}) was already "
-                    f"consumed at {locked.consumed_at.isoformat()} — concurrent double-merge "
-                    f"refused under the row lock (§17.4.3 single-use replay defence)"
-                )
-                raise MergeReplayError(msg)
-            locked.consumed_at = timezone.now()
-            locked.save(update_fields=["consumed_at"])
-            merge_audit_model.objects.create(
-                clear=locked,
-                merged_sha=merged_sha,
-                required_checks_status=required_checks_status,
-                expedited_by=stamps.expedited_by,
-                repo_slug=repo_slug,
-                standing_delegation_by=stamps.standing_delegation_by,
-            )
-            # §15: supersede every sibling unconsumed CLEAR for the same PR —
-            # re-review at a moved head issues a fresh CLEAR at the new SHA,
-            # leaving the older one unconsumed. Once THIS merge consumes one, its
-            # siblings are no longer a stalled merge, so consume them in the same
-            # atomic block (single serialized UPDATE) under the row lock. The slug
-            # is matched case-INSENSITIVELY (``slug__iexact``): a forge slug is
-            # case-insensitive, so a sibling CLEAR recorded with a differently-cased
-            # ``owner/Repo`` must NOT survive to keep ratcheting the S4 hard-red gate
-            # forever (the rest of the pipeline resolves slugs with ``__iexact``).
-            MergeClear.objects.filter(
-                slug__iexact=locked.slug,
-                pr_id=locked.pr_id,
-                consumed_at__isnull=True,
-            ).exclude(pk=locked.pk).update(consumed_at=locked.consumed_at)
-            # The forge merge already landed, so the PR row is MERGED and a ticketless
-            # CLEAR (``--ticket-id`` is optional, and the loop never passed one) can
-            # recover from the PR the FSM it otherwise has nothing to advance.
-            ticket = locked.record_merged_pull_request()
-            if ticket is None:
-                return ""
-            # Bind the phase attestation to the merged HEAD/workstream it was
-            # earned against (the §17.6 enforcement candidate (7), absorbed
-            # here): the canonical phase session records the SHA that actually
-            # landed, so a later stale-workstream attestation cannot be reused
-            # against a different HEAD.
-            session = ticket.resolve_phase_session(agent_id="merge-loop")
-            session.visit_phase("merged", agent_id=f"merge-loop@{merged_sha[:12]}")
-            # #1343: state-complete reconcile. An authorised, audited PR-merge
-            # is the authority — every pre-merged state (NOT_STARTED through
-            # IN_REVIEW, plus SHIPPED) must advance to MERGED. RETROSPECTED/
-            # DELIVERED are past MERGED and stay where they are; IGNORED is
-            # abandoned. The original ``state in {in_review, merged}`` guard
-            # left STARTED tickets visibly stuck on the statusline after their
-            # PR merged (#1324 follow-up). The FSM source-set on
-            # ``reconcile_merged`` is the single source of truth — catching
-            # ``TransitionNotAllowed`` lets the source list evolve in one
-            # place (the model) without a parallel guard here.
-            try:
-                ticket.reconcile_merged()
-            except TransitionNotAllowed:
-                logger.info(
-                    "merge keystone: ticket %s state=%s is past MERGED; FSM unchanged",
-                    ticket.pk,
-                    ticket.state,
-                )
-            else:
-                ticket.save()
-            return ticket.state
-
-    return retry_on_locked(_consume_and_advance)
 
 
 def merge_ticket_pr(

--- a/src/teatree/core/merge/post_hook.py
+++ b/src/teatree/core/merge/post_hook.py
@@ -1,0 +1,170 @@
+"""The §17.4 keystone post hook: consume the CLEAR, write the audit, advance the FSM.
+
+Split from :mod:`teatree.core.merge.execution` — the precondition/bound-merge concern
+ends the moment the forge merge is irreversible, and everything after it is one
+atomic DB write. :func:`record_merge_and_advance` is what
+:func:`teatree.core.merge.execution.merge_ticket_pr` calls once the merge has landed.
+"""
+
+import logging
+from dataclasses import dataclass
+
+from django.apps import apps
+from django.db import transaction
+from django.utils import timezone
+from django_fsm import TransitionNotAllowed
+
+from teatree.core.merge.errors import MergePreconditionError, MergeReplayError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class MergeAuditAuthorizers:
+    """The authorizer ids the post hook stamps on the ``MergeAudit`` for a non-default merge.
+
+    Both empty for an ordinary merge. ``expedited_by`` is the PENDING-checks
+    expedite waiver authoriser (§17.4.3 / PR-07); ``standing_delegation_by`` is the
+    config-sourced standing substrate authorizer (#3413). Grouped so
+    :func:`record_merge_and_advance` takes one audit-authorizer argument instead of
+    a widening list.
+    """
+
+    expedited_by: str = ""
+    standing_delegation_by: str = ""
+
+
+def record_merge_and_advance(
+    *,
+    clear: object,
+    merged_sha: str,
+    required_checks_status: str,
+    repo_slug: str = "",
+    authorizers: MergeAuditAuthorizers | None = None,
+) -> str:
+    """Post hook: consume CLEAR, write audit, supersede siblings, ``mark_merged()``.
+
+    All in ONE ``transaction.atomic()`` so the FSM advance and the durable
+    merge record land atomically (the §4 worker-enqueue / sync-atomicity
+    invariant): a crash *within* this post hook rolls back the whole
+    transaction, leaving the CLEAR unconsumed and the FSM unmoved — a
+    re-runnable state. A crash *between* the irreversible GitHub merge and
+    this hook also leaves the CLEAR unconsumed, but the PR is now merged on
+    GitHub; that case is recovered by the #928 reconciliation in
+    :func:`assert_merge_preconditions` (the retry detects "already merged
+    at ``reviewed_sha``" and runs this hook idempotently instead of
+    re-issuing the merge). Returns the resulting ticket state.
+
+    ``repo_slug`` is the #1335-reconciled ``owner/repo`` the caller merged
+    against; it is stamped on the ``MergeAudit`` (#19) so the S1/S3 signal joins
+    read the merge-time truth first instead of re-resolving the CLEAR's offline
+    workstream slug. Empty only for a legacy/direct caller — the signal resolver
+    falls back to ``resolve_pr_repo_slug`` for a blank audit.
+
+    §15: a head-move re-review issues a fresh CLEAR at the new SHA, leaving the
+    older sibling unconsumed. Consuming ONE via a merge supersedes every sibling
+    unconsumed CLEAR for the same ``(slug, pr_id)`` in the same atomic block under
+    the row lock, so a stale orphan can no longer ratchet S4 hard-red forever. No
+    ``ReviewVerdict`` is moved: each sibling's verdict persists at its own
+    reviewed_sha and S3 counts it regardless of SHA, so there is no verdict-copy
+    path to hand-roll (GM-4's ``carry_forward`` is the primitive if one is ever
+    needed).
+
+    The atomic block is wrapped in :func:`retry_on_locked` (#1520): a transient
+    ``database is locked`` from a concurrent canonical-DB writer must not abort
+    the merge keystone mid-flight. A retry re-opens the transaction, re-reads
+    the CLEAR ``select_for_update``-locked, and re-asserts the single-use
+    guard, so it consumes the CLEAR exactly once and never double-merges (the
+    irreversible GitHub merge already ran before this hook; only this
+    idempotent DB write retries).
+    """
+    from teatree.core.modelkit.db_retry import retry_on_locked  # noqa: PLC0415 — deferred: call-time import, kept lazy
+    from teatree.core.models import MergeClear  # noqa: PLC0415 — deferred: ORM import needs the app registry
+
+    stamps = authorizers or MergeAuditAuthorizers()
+    if not isinstance(clear, MergeClear):  # pragma: no cover - guarded by caller
+        msg = "record_merge_and_advance requires a MergeClear instance"
+        raise MergePreconditionError(msg)
+
+    merge_audit_model = apps.get_model("core", "MergeAudit")
+
+    def _consume_and_advance() -> str:
+        with transaction.atomic():
+            locked = MergeClear.objects.select_for_update().get(pk=clear.pk)
+            # Re-assert single-use UNDER the row lock. ``assert_merge_preconditions``
+            # checked ``is_actionable()`` unlocked; two concurrent executors that
+            # both passed it must not both consume — exactly one wins this
+            # serialized re-check, the loser raises ``MergeReplayError`` and
+            # writes no audit / does not advance the FSM.
+            if locked.consumed_at is not None:
+                msg = (
+                    f"MergeClear {locked.pk} ({locked.slug}#{locked.pr_id}) was already "
+                    f"consumed at {locked.consumed_at.isoformat()} — concurrent double-merge "
+                    f"refused under the row lock (§17.4.3 single-use replay defence)"
+                )
+                raise MergeReplayError(msg)
+            locked.consumed_at = timezone.now()
+            locked.save(update_fields=["consumed_at"])
+            merge_audit_model.objects.create(
+                clear=locked,
+                merged_sha=merged_sha,
+                required_checks_status=required_checks_status,
+                expedited_by=stamps.expedited_by,
+                repo_slug=repo_slug,
+                standing_delegation_by=stamps.standing_delegation_by,
+            )
+            # §15: supersede every sibling unconsumed CLEAR for the same PR —
+            # re-review at a moved head issues a fresh CLEAR at the new SHA,
+            # leaving the older one unconsumed. Once THIS merge consumes one, its
+            # siblings are no longer a stalled merge, so consume them in the same
+            # atomic block (single serialized UPDATE) under the row lock. The slug
+            # is matched case-INSENSITIVELY (``slug__iexact``): a forge slug is
+            # case-insensitive, so a sibling CLEAR recorded with a differently-cased
+            # ``owner/Repo`` must NOT survive to keep ratcheting the S4 hard-red gate
+            # forever (the rest of the pipeline resolves slugs with ``__iexact``).
+            MergeClear.objects.filter(
+                slug__iexact=locked.slug,
+                pr_id=locked.pr_id,
+                consumed_at__isnull=True,
+            ).exclude(pk=locked.pk).update(consumed_at=locked.consumed_at)
+            # The forge merge already landed, so the PR row is MERGED and a ticketless
+            # CLEAR (``--ticket-id`` is optional, and the loop never passed one) can
+            # recover from the PR the FSM it otherwise has nothing to advance.
+            ticket = locked.record_merged_pull_request()
+            if ticket is None:
+                # #3840: the merge landed, the CLEAR is consumed and the audit is written,
+                # but no FSM advanced. Returning "" quietly made that indistinguishable from
+                # a merge with nothing to advance, so a board that never moved looked healthy.
+                # `t3 <overlay> ticket backfill-clears` links the row once the PR is attributable.
+                logger.warning("merge keystone: %s#%s merged but resolved no owning ticket", locked.slug, locked.pr_id)
+                return ""
+            # Bind the phase attestation to the merged HEAD/workstream it was
+            # earned against (the §17.6 enforcement candidate (7), absorbed
+            # here): the canonical phase session records the SHA that actually
+            # landed, so a later stale-workstream attestation cannot be reused
+            # against a different HEAD.
+            session = ticket.resolve_phase_session(agent_id="merge-loop")
+            session.visit_phase("merged", agent_id=f"merge-loop@{merged_sha[:12]}")
+            # #1343: state-complete reconcile. An authorised, audited PR-merge
+            # is the authority — every pre-merged state (NOT_STARTED through
+            # IN_REVIEW, plus SHIPPED) must advance to MERGED. RETROSPECTED/
+            # DELIVERED are past MERGED and stay where they are; IGNORED is
+            # abandoned. The original ``state in {in_review, merged}`` guard
+            # left STARTED tickets visibly stuck on the statusline after their
+            # PR merged (#1324 follow-up). The FSM source-set on
+            # ``reconcile_merged`` is the single source of truth — catching
+            # ``TransitionNotAllowed`` lets the source list evolve in one
+            # place (the model) without a parallel guard here.
+            try:
+                ticket.reconcile_merged()
+            except TransitionNotAllowed:
+                logger.info(
+                    "merge keystone: ticket %s state=%s is past MERGED; FSM unchanged",
+                    ticket.pk,
+                    ticket.state,
+                )
+            else:
+                ticket.save()
+            return ticket.state
+
+    return retry_on_locked(_consume_and_advance)

--- a/src/teatree/core/models/pull_request.py
+++ b/src/teatree/core/models/pull_request.py
@@ -8,6 +8,7 @@ from teatree.url_classify import repo_and_iid
 
 if TYPE_CHECKING:
     from teatree.core.models.ticket import Ticket
+    from teatree.core.models.types import JSONObject
 
 
 class PullRequestQuerySet(models.QuerySet):
@@ -25,10 +26,14 @@ class PullRequestQuerySet(models.QuerySet):
     def owning_ticket(self, *, slug: str, pr_id: int, pr_url: str = "") -> "Ticket | None":
         """The delivery ticket that owns *(slug, pr_id)*, or ``None``.
 
-        The FK is authoritative (the ship pipeline persists it). ``Ticket.extra["prs"]``
-        is the fallback for a PR opened outside the pipeline, which has no row at all.
-        A ticket whose ``issue_url`` merely equals the PR url is never the owner — that
-        shape is the reviewer-role ticket, which carries no delivery lease.
+        The FK is authoritative. The JSON fallback covers a PR with no row —
+        one opened outside the pipeline, or opened before the row write existed —
+        and reads EVERY store a ticket records its own PRs in, because a resolver
+        that reads one store while the writer fills another resolves nothing: the
+        keystone then has no FSM to advance and a merge lands with the board
+        unmoved (#3840). A ticket whose ``issue_url`` merely equals the PR url is
+        never the owner — that shape is the reviewer-role ticket, which carries no
+        delivery lease.
         """
         row = self.for_pr(slug=slug, pr_id=pr_id).select_related("ticket").order_by("-id").first()
         if row is not None:
@@ -37,7 +42,7 @@ class PullRequestQuerySet(models.QuerySet):
 
     @staticmethod
     def _names_pr(key: str, *, slug: str, pr_id: int, pr_url: str) -> bool:
-        """True iff the ``extra["prs"]`` *key* is this PR.
+        """True iff the recorded url *key* is this PR.
 
         Keyed on the PARSED ``(slug, pr_id)`` as well as the literal url, because
         the callers that most need this arm — the merge keystone and the CLEAR
@@ -48,17 +53,68 @@ class PullRequestQuerySet(models.QuerySet):
         ref = repo_and_iid(key)
         return ref is not None and ref[0].casefold() == slug.casefold() and ref[1] == pr_id
 
+    @staticmethod
+    def _recorded_pr_urls(extra: "JSONObject | None") -> list[str]:
+        """Every PR url a ticket's own ``extra`` names, across all three stores.
+
+        ``prs`` is the forge-sync map (url → payload); ``pr_urls`` is the flat list
+        and ``pr_url_by_branch`` the per-branch index, both written by the ship
+        pipeline the moment it opens a PR. All three are read together so which
+        writer ran never decides whether the PR is attributable.
+        """
+        if not isinstance(extra, dict):
+            return []
+        urls: list[str] = []
+        synced = extra.get("prs")
+        if isinstance(synced, dict):
+            urls.extend(key for key in synced if isinstance(key, str))
+        by_branch = extra.get("pr_url_by_branch")
+        if isinstance(by_branch, dict):
+            urls.extend(value for value in by_branch.values() if isinstance(value, str))
+        recorded = extra.get("pr_urls")
+        if isinstance(recorded, list):
+            urls.extend(item for item in recorded if isinstance(item, str))
+        return urls
+
     @classmethod
     def _ticket_carrying_pr(cls, *, slug: str, pr_id: int, pr_url: str) -> "Ticket | None":
         from teatree.core.models.ticket import Ticket  # noqa: PLC0415 — deferred: sibling model, imported at call time
 
         for ticket in Ticket.objects.exclude(extra={}).only("issue_url", "extra", "id"):
-            prs = ticket.extra.get("prs") if isinstance(ticket.extra, dict) else None
-            if not isinstance(prs, dict):
-                continue
-            if any(cls._names_pr(key, slug=slug, pr_id=pr_id, pr_url=pr_url) for key in prs):
+            urls = cls._recorded_pr_urls(ticket.extra)
+            if any(cls._names_pr(url, slug=slug, pr_id=pr_id, pr_url=pr_url) for url in urls):
                 return ticket
         return None
+
+    def record_opened(self, *, ticket: "Ticket", url: str, overlay: str = "") -> "PullRequest | None":
+        """Persist the arbiter row for a PR *ticket* just opened; ``None`` if *url* names none.
+
+        ``PullRequest`` is the PR-facts arbiter every merge-time consumer resolves
+        through — the keystone's ticket adoption, the board reconcile's merged-row
+        rule, the merge-evidence gate. Writing it only from the tick-time open-PR
+        reconciler meant a PR that opened and merged between two ticks never got a
+        row at all, so those consumers had nothing to read. The row is written by
+        the path that opens the PR, where the ticket is already in hand.
+
+        Idempotent on the PR url (its unique key), so a ship retry reuses the row.
+        ``create_verification`` is stamped CONFIRMED because the ship path persists
+        only after its verify-by-re-read confirmed the PR is live.
+        """
+        ref = repo_and_iid(url)
+        if ref is None:
+            return None
+        row, _ = self.get_or_create(
+            url=url,
+            defaults={
+                "ticket": ticket,
+                "overlay": overlay or ticket.overlay,
+                "repo": ref[0],
+                "iid": str(ref[1]),
+                "create_verification": PullRequest.CreateVerification.CONFIRMED,
+                "create_verified_at": timezone.now(),
+            },
+        )
+        return row
 
     def record_forge_merge(self, *, slug: str, pr_id: int) -> int:
         """Transition every non-merged row for *(slug, pr_id)* to MERGED; return the count.

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -3,6 +3,8 @@ import re
 from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, NamedTuple, cast
 
+from django.apps import apps
+
 from teatree.config import get_effective_settings
 from teatree.core.backend_factory import code_host_for_repo_from_overlay
 from teatree.core.backend_protocols import BackendResolutionError, PullRequestSpec
@@ -551,6 +553,4 @@ class ShipExecutor(RunnerBase):
         # in hand and the PR has just been verify-by-re-read confirmed, so a PR that
         # merges before the next tick is still attributable to its ticket.
         if url:
-            from teatree.core.models import PullRequest  # noqa: PLC0415 — deferred: ORM import needs the app registry
-
-            PullRequest.objects.record_opened(ticket=ticket, url=url, overlay=ticket.overlay)
+            apps.get_model("core", "PullRequest").objects.record_opened(ticket=ticket, url=url, overlay=ticket.overlay)

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -545,3 +545,12 @@ class ShipExecutor(RunnerBase):
             merge_into_dicts=merge_dicts,
             pop_keys=["pr_title_override", "ship_invoking_branch"],
         )
+        # #3840: the JSON index above is the ticket's own cache; the arbiter row is
+        # what the merge keystone, the board reconcile and the merge-evidence gate
+        # resolve the PR's owning ticket through. Write it here, where the ticket is
+        # in hand and the PR has just been verify-by-re-read confirmed, so a PR that
+        # merges before the next tick is still attributable to its ticket.
+        if url:
+            from teatree.core.models import PullRequest  # noqa: PLC0415 — deferred: ORM import needs the app registry
+
+            PullRequest.objects.record_opened(ticket=ticket, url=url, overlay=ticket.overlay)

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -103,7 +103,12 @@
 # model registry in pre-app-registry (#3334).
 "src/teatree/core/messaging_tokens.py" = 1
 "src/teatree/core/merge/authorization.py" = 4
-"src/teatree/core/merge/execution.py" = 4
+"src/teatree/core/merge/execution.py" = 2
+# souliane/teatree#3840: the keystone post hook moved to its own module and took its two
+# call-time ORM imports with it — the retry helper and the `MergeClear` the atomic block
+# re-reads under the row lock. Same edges, new home; the pair below is execution.py's old
+# 4 split, not a new one.
+"src/teatree/core/merge/post_hook.py" = 2
 # substrate_standing defers `from teatree.core.overlay_loader import infer_overlay_for_url`
 # so resolving a repo's owning overlay stays a call-time read of the live overlay
 # registry — the edge moved here verbatim from merge/authorization.py (#3648).

--- a/tests/teatree_core/gates/test_merge_evidence_gate.py
+++ b/tests/teatree_core/gates/test_merge_evidence_gate.py
@@ -142,6 +142,58 @@ class TestForgeConfirmsMerged(TestCase):
         assert probe.call_args.args[0].ref.host_kind == "gitlab"
 
 
+class TestForgeConfirmsThroughTheTicketsOwnPr(TestCase):
+    """A ticket whose own ``issue_url`` names the PR is confirmable without a row (#3859).
+
+    The board reconcile's rule B exists precisely for the ticket that has NO
+    ``PullRequest`` row — it holds a definite forge MERGED verdict for the PR the
+    ticket's ``issue_url`` names. Resolving evidence only over ``PullRequest`` rows
+    made that queryset empty, so the gate found no evidence and refused the very
+    transition the reconcile was holding proof for.
+    """
+
+    URL = "https://github.com/souliane/teatree/pull/42"
+
+    def test_true_when_the_probe_reports_the_tickets_own_pr_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW, issue_url=self.URL)
+        with patch(
+            "teatree.core.merge.ci_rollup.CodeHostQuery.pr_merge_state", return_value=_pr_merge_state(merged=True)
+        ):
+            assert forge_confirms_merged(ticket) is True
+
+    def test_false_when_the_probe_reports_it_not_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW, issue_url=self.URL)
+        with patch(
+            "teatree.core.merge.ci_rollup.CodeHostQuery.pr_merge_state", return_value=_pr_merge_state(merged=False)
+        ):
+            assert forge_confirms_merged(ticket) is False
+
+    def test_an_issue_url_is_never_probed_as_a_pull_request(self) -> None:
+        """An ``/issues/N`` url names no PR — probing it would invent evidence."""
+        ticket = Ticket.objects.create(
+            overlay="t3-teatree",
+            state=Ticket.State.IN_REVIEW,
+            issue_url="https://github.com/souliane/teatree/issues/42",
+        )
+        with patch(
+            "teatree.core.merge.ci_rollup.CodeHostQuery.pr_merge_state", return_value=_pr_merge_state(merged=True)
+        ) as probe:
+            assert forge_confirms_merged(ticket) is False
+        probe.assert_not_called()
+
+    def test_a_ticket_with_its_own_rows_does_not_fall_back(self) -> None:
+        """The rows are the evidence when they exist; the ``issue_url`` is the gap-filler."""
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW, issue_url=self.URL)
+        _pr_for(ticket)
+        with patch(
+            "teatree.core.merge.ci_rollup.CodeHostQuery.pr_merge_state",
+            autospec=True,
+            return_value=_pr_merge_state(merged=False),
+        ) as probe:
+            assert forge_confirms_merged(ticket) is False
+        assert probe.call_count == 1
+
+
 class TestCheckMergeEvidence(TestCase):
     def test_gate_off_passes_without_any_evidence(self) -> None:
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)

--- a/tests/teatree_core/merge/test_execution.py
+++ b/tests/teatree_core/merge/test_execution.py
@@ -9,7 +9,7 @@ case-mismatched orphan must not survive to keep ratcheting the S4 hard-red gate.
 from django.test import TestCase
 
 from teatree.core.merge import execution
-from teatree.core.merge.execution import record_merge_and_advance
+from teatree.core.merge.post_hook import record_merge_and_advance
 from teatree.core.models import MergeClear, PullRequest, Ticket
 
 _SHA = "a" * 40
@@ -182,3 +182,39 @@ class TestSiblingSupersedeCaseInsensitive(TestCase):
 
         unrelated.refresh_from_db()
         assert unrelated.consumed_at is None
+
+
+class TestKeystoneReportsAnUnresolvableTicket(TestCase):
+    """A merge whose ticket cannot be resolved must not pass silently (#3840).
+
+    The post hook returned ``""`` and logged nothing when neither the CLEAR nor the
+    PR named a ticket, so a merge landed, consumed its CLEAR and wrote its audit
+    while the board stayed exactly where it was — with no record anywhere that an
+    FSM advance had been skipped.
+    """
+
+    def test_warns_when_no_ticket_resolves(self) -> None:
+        clear = MergeClear.objects.create(
+            pr_id=42,
+            slug="acme/widget",
+            reviewed_sha=_SHA,
+            reviewer_identity="cold-reviewer",
+            gh_verify_result=MergeClear.VerifyResult.GREEN,
+            blast_class=MergeClear.BlastClass.LOGIC,
+        )
+
+        with self.assertLogs("teatree.core.merge.post_hook", level="WARNING") as captured:
+            state = record_merge_and_advance(clear=clear, merged_sha="c" * 40, required_checks_status="green")
+
+        assert state == ""
+        assert any("acme/widget#42" in line for line in captured.output), captured.output
+
+    def test_a_resolvable_ticket_logs_no_warning(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        _pull_request(ticket, slug="acme/widget", pr_id=42)
+        clear = _clear(ticket, slug="acme/widget", pr_id=42)
+
+        with self.assertNoLogs("teatree.core.merge.post_hook", level="WARNING"):
+            state = record_merge_and_advance(clear=clear, merged_sha="c" * 40, required_checks_status="green")
+
+        assert state == Ticket.State.MERGED

--- a/tests/teatree_core/models/test_pull_request.py
+++ b/tests/teatree_core/models/test_pull_request.py
@@ -183,3 +183,76 @@ class TestRecordForgeMerge(TestCase):
 
     def test_no_row_for_the_pr_is_a_no_op(self) -> None:
         assert PullRequest.objects.record_forge_merge(slug="acme/widget", pr_id=99) == 0
+
+
+class TestOwningTicketReadsTheDeliveryPipelinesOwnIndex(TestCase):
+    """The pipeline's record of the PR it opened must resolve the owning ticket (#3840).
+
+    ``ShipExecutor`` records every PR it opens under ``extra["pr_urls"]`` and the
+    per-branch ``extra["pr_url_by_branch"]`` index. Resolving only ``extra["prs"]``
+    — the key the GitLab PR sync writes — left the keystone's post hook with no
+    ticket to advance for a PR the pipeline itself opened: the merge landed, the
+    CLEAR was consumed, the audit row was written, and the FSM never moved.
+    """
+
+    def test_resolves_through_the_per_branch_index(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", extra={"pr_url_by_branch": {"feat/x": _URL}})
+
+        assert PullRequest.objects.owning_ticket(slug="acme/widget", pr_id=42) == ticket
+
+    def test_resolves_through_the_recorded_url_list(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", extra={"pr_urls": [_URL]})
+
+        assert PullRequest.objects.owning_ticket(slug="acme/widget", pr_id=42) == ticket
+
+    def test_a_different_pr_in_the_index_is_not_the_owner(self) -> None:
+        Ticket.objects.create(overlay="t3-teatree", extra={"pr_url_by_branch": {"feat/x": _URL}})
+
+        assert PullRequest.objects.owning_ticket(slug="acme/widget", pr_id=43) is None
+
+    def test_the_index_matches_a_differently_cased_slug(self) -> None:
+        ticket = Ticket.objects.create(
+            overlay="t3-teatree",
+            extra={"pr_urls": ["https://github.com/Acme/Widget/pull/42"]},
+        )
+
+        assert PullRequest.objects.owning_ticket(slug="acme/widget", pr_id=42) == ticket
+
+
+class TestRecordOpened(TestCase):
+    """The arbiter row is written when the pipeline opens the PR, not a tick later.
+
+    ``PullRequest`` is the PR-facts arbiter every merge-time consumer reads, yet the
+    only writer was the tick-time open-PR reconciler — so a PR that opened and merged
+    between two ticks never got a row at all, and the keystone had nothing to resolve.
+    """
+
+    def test_persists_the_row_for_the_opened_pr(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree")
+
+        row = PullRequest.objects.record_opened(ticket=ticket, url=_URL)
+
+        assert row is not None
+        assert row.ticket == ticket
+        assert row.repo == "acme/widget"
+        assert row.iid == "42"
+        assert row.overlay == "t3-teatree"
+        assert row.create_verification == PullRequest.CreateVerification.CONFIRMED
+        assert row.create_verified_at is not None
+
+    def test_a_retry_reuses_the_existing_row(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree")
+
+        first = PullRequest.objects.record_opened(ticket=ticket, url=_URL)
+        second = PullRequest.objects.record_opened(ticket=ticket, url=_URL)
+
+        assert first is not None
+        assert second is not None
+        assert first.pk == second.pk
+        assert PullRequest.objects.filter(url=_URL).count() == 1
+
+    def test_a_url_that_names_no_pull_request_writes_nothing(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree")
+
+        assert PullRequest.objects.record_opened(ticket=ticket, url="https://example.com/pr/b-new") is None
+        assert PullRequest.objects.count() == 0

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -636,6 +636,36 @@ class TestShipMultiWorkstreamStaleUrlGuard(TestCase):
         ticket.refresh_from_db()
         assert ticket.extra["pr_url_by_branch"]["s-1263-pr-b-current"] == "https://example.com/pr/b-new"
 
+    def test_persists_the_pull_request_arbiter_row_for_the_pr_it_opened(self) -> None:
+        """#3840: the row every merge-time consumer reads is written when the PR opens.
+
+        ``PullRequest`` is the PR-facts arbiter the merge keystone, the board
+        reconcile and the merge-evidence gate all resolve through. Recording the
+        URL only in ``extra`` left the pipeline's own PRs with no row, so the
+        keystone had no ticket to advance when they merged.
+        """
+        ticket = self._multi_worktree_ticket()
+        ticket.extra = {"ship_invoking_branch": "s-1263-pr-b-current"}
+        ticket.save(update_fields=["extra"])
+        host = MagicMock()
+        host.create_pr.return_value = {"web_url": "https://github.com/acme/widget/pull/77"}
+        host.current_user.return_value = "souliane"
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.ship.code_host_for_repo_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.git.push"),
+            patch("teatree.core.runners.ship.git.last_commit_message", return_value=("feat: b", "body")),
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+        ):
+            ShipExecutor(ticket).run()
+
+        row = PullRequest.objects.get(url="https://github.com/acme/widget/pull/77")
+        assert row.ticket == ticket
+        assert row.repo == "acme/widget"
+        assert row.iid == "77"
+        assert PullRequest.objects.owning_ticket(slug="acme/widget", pr_id=77) == ticket
+
 
 class TestShipReconcilesWorktreeBranch(TestCase):
     """#1519: ship pushes the worktree's ACTUAL git branch and reconciles the DB.


### PR DESCRIPTION
## Correcting the premise first

The issue reads the pile-up in `review_posted` as the defect. It is not: `review_posted` is the terminal state of a **reviewer-role** ticket, and every row sitting there carries `role = reviewer`. Those cards are correctly at rest, and the board reconcile deliberately excludes that state from its candidate sets for the same reason. The real defect is upstream of the board, in the keystone.

## The defect

The merge keystone's post hook advances the FSM of the ticket it resolves. It resolves that ticket from `MergeClear.ticket` — or, since `--ticket-id` is optional and the sanctioned merge recipe omits it, from `PullRequest.objects.owning_ticket()`.

`owning_ticket` consulted exactly two stores, and the path that opens the PR writes neither:

- **a `PullRequest` row.** `PullRequest` is documented as the PR-facts arbiter, but its only writer was the tick-time open-PR reconciler, which projects rows from open-PR scan signals. A PR that opens and merges between two ticks never gets a row at all, and `ShipExecutor` — the pipeline that opens the PR, with the ticket already in hand — wrote none.
- **`Ticket.extra["prs"]`.** That is the forge PR-sync map. The ship pipeline records what it opened under `extra["pr_urls"]` and the per-branch `extra["pr_url_by_branch"]` — a third store the resolver never read.

So both lookups missed, `adopt_owning_ticket()` returned `None`, and the post hook took its `return ""` branch: the merge landed, the CLEAR was consumed, the `MergeAudit` row was written, and **no FSM advanced and nothing was logged**. A board that never moved was indistinguishable from a board with nothing to move.

The same resolver is the single chokepoint for `t3 <overlay> ticket clear`'s adoption, the `ticket backfill-clears` recovery walk, and the statusline's PR→ticket index, so all of them failed together.

## The fix

- **`owning_ticket` reads every store a ticket records its own PRs in** (`prs`, `pr_urls`, `pr_url_by_branch`), so which writer ran no longer decides whether a PR is attributable to its ticket. The FK stays authoritative; the JSON walk stays the fallback.
- **`PullRequest.objects.record_opened()`** — the ship pipeline persists the arbiter row where the PR is opened, right after its verify-by-re-read confirms the PR is live. Idempotent on the PR url, so a ship retry reuses the row.
- **The post hook names an unresolved merge** instead of returning quietly, so a skipped advance is observable rather than inferred from a stale board.
- **The merge-evidence gate derives its probe targets from the ticket's own `issue_url` when the ticket has no `PullRequest` rows** (#3859). The board reconcile's rule B targets exactly the ticket with no row, so the gate's row-only queryset was empty and it refused the transition the reconcile was holding a definite forge MERGED verdict for. Rows stay authoritative; an `/issues/N` url parses to no PR ref and is never probed.

The post hook moves to `core/merge/post_hook.py`: the precondition/bound-merge concern ends where the forge merge becomes irreversible, and everything after it is one atomic DB write.

No backfill command is added — `t3 <overlay> ticket backfill-clears` already exists and bottomed out on this same resolver, so it starts resolving with this change.

## Tests

Every test below was observed failing before the change:

| Test | Failure without the fix |
|---|---|
| `TestOwningTicketReadsTheDeliveryPipelinesOwnIndex` (×3) | `assert None == <Ticket>` — the pipeline's own record resolved nothing |
| `TestRecordOpened` (×3) | `AttributeError: … has no attribute 'record_opened'` |
| `TestKeystoneReportsAnUnresolvableTicket::test_warns_when_no_ticket_resolves` | `no logs of level WARNING or higher triggered` |
| `TestForgeConfirmsThroughTheTicketsOwnPr::test_true_when_the_probe_reports_the_tickets_own_pr_merged` | `assert False is True` |
| `test_persists_the_pull_request_arbiter_row_for_the_pr_it_opened` | `PullRequest.DoesNotExist` |

Each is paired with a guard that pins what must **not** widen: a different PR number in the index is not the owner, an `/issues/N` url is never probed as a PR, a ticket with its own rows does not fall back, and a resolvable ticket logs no warning.

## Not in scope

#3906 (record the branch-head → squashed-commit mapping at merge time) shares this file but not this mechanism. It exists so `clean-all` stops reconstructing branch↔squash equivalence by subject matching; its key is the **branch name**, which no code-host backend currently reads — `CodeHostBackend` exposes head *SHA*, merge state, draft, author, cross-repo and changed paths, but no `headRefName` / `source_branch`. Adding that read, the columns, and the `clean-all` read path is a distinct change with its own retention question, and fixing this defect neither needs it nor delivers it.

Closes #3840
Closes #3859

## Open questions & assumptions

- **assumed** — `record_opened` stamps `create_verification = CONFIRMED` because `ShipExecutor` persists only after `verify_pr_exists` confirms the PR; a future caller that has not verified would need to pass its own value.
- **assumed** — the three `extra` stores are read as a union rather than in priority order; they name the same PRs for a given ticket, and `_names_pr` matches on the parsed `(slug, pr_id)`, so ordering cannot change which ticket is selected.
- **decided-by-code** — the post hook's move to its own module was forced by the module-health LOC cap on `execution.py`; the split follows the boundary the module docstring already named.
