### PR TITLE
fix(loop): dedupe the dispatch-zone phase-task mint at the write seam (#3969)

### DIFF
--- a/src/teatree/loop/persistence.py
+++ b/src/teatree/loop/persistence.py
@@ -25,6 +25,7 @@ from teatree.core.models.ticket_external_review import schedule_external_review
 from teatree.loop.dispatch import DispatchAction
 from teatree.loop.dispatch_gates import claim_red_mr_fix
 from teatree.loop.dispatch_tables import PERSISTED_AT_SOURCE_ZONES, ActionPayload
+from teatree.loop.persistence_phase_task import create_phase_task, has_open_task, open_task_in_phase
 
 if TYPE_CHECKING:
     from teatree.core.models.types import TicketExtra
@@ -174,7 +175,7 @@ def _handle_reviewer(action: DispatchAction) -> Task | None:
         # review of the genuinely new revision (the recorded APPROVED
         # belonged to the old SHA).
         ticket.merge_extra(set_keys={"reviewed_sha": head_sha}, pop_keys=["last_review_state"])
-    open_task = _open_task_in_phase(ticket, phase="reviewing")
+    open_task = open_task_in_phase(ticket, phase="reviewing")
     if open_task is not None:
         _link_broadcast_reviewer_task(payload, open_task)
         return None
@@ -279,7 +280,7 @@ def _handle_orchestrator(action: DispatchAction) -> Task | None:
             ticket.role,
         )
         return None
-    if _has_open_task(ticket, phase="coding") or ticket.state != Ticket.State.NOT_STARTED:
+    if has_open_task(ticket, phase="coding") or ticket.state != Ticket.State.NOT_STARTED:
         return None
     # Mark the plan-skipped direct-coding path BEFORE scheduling coding, so the
     # coding-completion transition (``Task._apply_phase_transition`` ->
@@ -300,18 +301,6 @@ def _link_claimed_marker(ticket: Ticket, issue_url: str) -> None:
     ImplementedIssueMarker.objects.filter(issue_url=issue_url).exclude(
         state__in=ImplementedIssueMarker.State.terminal()
     ).update(ticket=ticket, state=ImplementedIssueMarker.State.TICKET_CREATED)
-
-
-def _open_task_in_phase(ticket: Ticket, *, phase: str) -> Task | None:
-    # #769 audit: match any accepted phase spelling (short verb or
-    # gerund) via the shared SSOT helper, not a raw ``phase=phase``
-    # filter that would miss a short-verb ``code`` task and let the
-    # orchestrator create a duplicate.
-    return Task.objects.pending_in_phase(phase).filter(ticket=ticket).first()
-
-
-def _has_open_task(ticket: Ticket, *, phase: str) -> bool:
-    return _open_task_in_phase(ticket, phase=phase) is not None
 
 
 def _get_or_create_ticket(
@@ -342,22 +331,6 @@ def _get_or_create_ticket(
     )
     _reconcile_existing_overlay(ticket, created=created)
     return ticket, created
-
-
-def _create_phase_task(ticket: Ticket, *, phase: str, agent_id: str, reason: str) -> Task:
-    """Create a fresh ``Session`` + initial ``Task`` for ``(ticket.role, phase)``.
-
-    Mirrors ``ticket.schedule_coding`` / ``schedule_external_review`` for the
-    phases those methods do not cover (``debugging``/``e2e``/``answering``/
-    ``codex_reviewing``). ``Task.save`` routes a loop-dispatched ``(role, phase)``
-    to INTERACTIVE under an ``interactive`` ``agent_runtime`` (the /loop slot is its
-    dispatcher) and leaves it HEADLESS under the shipped headless one, so no explicit
-    ``execution_target`` is set here.
-    """
-    from teatree.core.models.session import Session  # noqa: PLC0415 — lazy: avoids the models import cycle
-
-    session = Session.objects.create(ticket=ticket, agent_id=agent_id)
-    return Task.objects.create(ticket=ticket, session=session, phase=phase, execution_reason=reason)
 
 
 def _handle_orchestrator_zone(action: DispatchAction) -> Task | None:
@@ -402,11 +375,11 @@ def _handle_red_card(action: DispatchAction) -> Task | None:
         },
         kind=classify_ticket_kind(origin=TicketOrigin.CORRECTION),
     )
-    if ticket.role != Ticket.Role.AUTHOR or _has_open_task(ticket, phase="coding"):
+    if ticket.role != Ticket.Role.AUTHOR or has_open_task(ticket, phase="coding"):
         return None
     # Intentionally NOT gated by plan_currency (SELFCATCH-3): a redcard:// synthetic
     # ticket carries no PlanArtifact, so the adequacy/currency gate would false-positive.
-    return _create_phase_task(
+    return create_phase_task(
         ticket,
         phase="coding",
         agent_id="red-card",
@@ -438,11 +411,11 @@ def _handle_debug(action: DispatchAction) -> Task | None:
             overlay=_owning_overlay(pr_url, str(payload.get("overlay") or "")),
             kind=classify_ticket_kind(origin=TicketOrigin.CORRECTION),
         )
-        if ticket.role != Ticket.Role.AUTHOR or _has_open_task(ticket, phase="debugging"):
+        if ticket.role != Ticket.Role.AUTHOR or has_open_task(ticket, phase="debugging"):
             return None
         if not claim_red_mr_fix(payload):
             return None
-        return _create_phase_task(
+        return create_phase_task(
             ticket,
             phase="debugging",
             agent_id="debug",
@@ -479,7 +452,7 @@ def _handle_codex_review(action: DispatchAction) -> Task | None:
             overlay=_owning_overlay(pr_url, str(payload.get("overlay") or "")),
             extra={"reviewed_sha": head_sha, "codex_variant": variant},
         )
-        if ticket.role != Ticket.Role.REVIEWER or _has_open_task(ticket, phase=phase):
+        if ticket.role != Ticket.Role.REVIEWER or has_open_task(ticket, phase=phase):
             return None
         marker = CodexReviewMarker.claim(
             slug=slug,
@@ -490,7 +463,7 @@ def _handle_codex_review(action: DispatchAction) -> Task | None:
         )
         if marker is None:
             return None
-        return _create_phase_task(
+        return create_phase_task(
             ticket,
             phase=phase,
             agent_id="codex-review",
@@ -519,9 +492,9 @@ def _handle_e2e_fix(action: DispatchAction) -> Task | None:
         extra={"e2e_spec": spec, "e2e_test_title": str(payload.get("test_title") or "")},
         kind=classify_ticket_kind(origin=TicketOrigin.CORRECTION),
     )
-    if ticket.role != Ticket.Role.AUTHOR or _has_open_task(ticket, phase="e2e"):
+    if ticket.role != Ticket.Role.AUTHOR or has_open_task(ticket, phase="e2e"):
         return None
-    return _create_phase_task(
+    return create_phase_task(
         ticket,
         phase="e2e",
         agent_id="e2e-fix",
@@ -553,11 +526,11 @@ def _handle_skill_drift(action: DispatchAction) -> Task | None:
         },
         kind=classify_ticket_kind(origin=TicketOrigin.CORRECTION),
     )
-    if ticket.role != Ticket.Role.AUTHOR or _has_open_task(ticket, phase="coding"):
+    if ticket.role != Ticket.Role.AUTHOR or has_open_task(ticket, phase="coding"):
         return None
     # Intentionally NOT gated by plan_currency (SELFCATCH-3): a t3:coder skill-drift
     # synthetic ticket carries no PlanArtifact, so the currency gate would false-positive.
-    return _create_phase_task(
+    return create_phase_task(
         ticket,
         phase="coding",
         agent_id="skill-drift",
@@ -582,9 +555,9 @@ def _handle_answerer(action: DispatchAction) -> Task | None:
         overlay=str(payload.get("overlay") or ""),
         extra={"answer_event_id": event_id, "answer_detail": str(payload.get("detail") or "")},
     )
-    if ticket.role != Ticket.Role.AUTHOR or _has_open_task(ticket, phase="answering"):
+    if ticket.role != Ticket.Role.AUTHOR or has_open_task(ticket, phase="answering"):
         return None
-    return _create_phase_task(
+    return create_phase_task(
         ticket,
         phase="answering",
         agent_id="answerer",

--- a/src/teatree/loop/persistence_phase_task.py
+++ b/src/teatree/loop/persistence_phase_task.py
@@ -1,0 +1,74 @@
+"""The loop-side phase-task mint: one ``Session`` + initial ``Task`` per ticket+phase.
+
+``persistence.py`` owns routing a dispatch signal to a ``Ticket``; this module owns
+the decision to mint a ``Task`` for one, and the guard that stops two dispatchers
+minting two. It is the sibling of ``Ticket._schedule_headless`` for the phases the
+FSM scheduler does not cover, and holds the same idempotency contract keyed on the
+same lock.
+"""
+
+import logging
+
+from django.db import transaction
+
+from teatree.core.models import Task, Ticket
+
+logger = logging.getLogger(__name__)
+
+
+def open_task_in_phase(ticket: Ticket, *, phase: str) -> Task | None:
+    # #769 audit: match any accepted phase spelling (short verb or
+    # gerund) via the shared SSOT helper, not a raw ``phase=phase``
+    # filter that would miss a short-verb ``code`` task and let the
+    # orchestrator create a duplicate.
+    return Task.objects.pending_in_phase(phase).filter(ticket=ticket).first()
+
+
+def has_open_task(ticket: Ticket, *, phase: str) -> bool:
+    return open_task_in_phase(ticket, phase=phase) is not None
+
+
+def create_phase_task(ticket: Ticket, *, phase: str, agent_id: str, reason: str) -> Task:
+    """Create a fresh ``Session`` + initial ``Task`` for ``(ticket.role, phase)``.
+
+    Mirrors ``ticket.schedule_coding`` / ``schedule_external_review`` for the
+    phases those methods do not cover (``debugging``/``e2e``/``answering``/
+    ``codex_reviewing``). ``Task.save`` routes a loop-dispatched ``(role, phase)``
+    to INTERACTIVE under an ``interactive`` ``agent_runtime`` (the /loop slot is its
+    dispatcher) and leaves it HEADLESS under the shipped headless one, so no explicit
+    ``execution_target`` is set here.
+
+    **Idempotent in its side effects, not merely in the state it converges to**
+    (#3969) — the contract :meth:`Ticket._schedule_headless` holds at the FSM mint,
+    keyed on the same lock. An in-flight sibling (a PENDING or CLAIMED Task on this
+    ``(ticket, phase)``, in any accepted spelling) is RETURNED rather than raced.
+    The zone handlers keep their :func:`has_open_task` pre-checks — those
+    short-circuit before useless marker/claim work — but a pre-check is a
+    read-then-write, so two dispatchers can both observe "no open task" before
+    either writes; this guard is what makes them non-load-bearing for correctness.
+
+    The check and the mint share one ``atomic`` block, so the guard is a real CAS:
+    SQLite is opened in ``transaction_mode="IMMEDIATE"``, so the first writer holds
+    the reserved lock for the whole block and a concurrent tick cannot pass the same
+    check. Checking BEFORE the ``Session`` is created is what keeps a deduped call
+    from leaving an orphan session row behind.
+
+    A TERMINAL sibling is not a duplicate: a COMPLETED or FAILED task is a finished
+    attempt, so the next call mints a fresh Session + Task. Deduping on "a task ever
+    existed" would let one crashed attempt suppress the phase permanently.
+    """
+    from teatree.core.models.session import Session  # noqa: PLC0415 — lazy: avoids the models import cycle
+
+    with transaction.atomic():
+        in_flight = Task.objects.in_flight_for_phase(ticket.overlay, phase).filter(ticket=ticket).order_by("pk").first()
+        if in_flight is not None:
+            logger.info(
+                "Reused in-flight %s task %s for ticket %s (status=%s) instead of minting a rival",
+                phase,
+                in_flight.pk,
+                ticket.pk,
+                in_flight.status,
+            )
+            return in_flight
+        session = Session.objects.create(ticket=ticket, agent_id=agent_id)
+        return Task.objects.create(ticket=ticket, session=session, phase=phase, execution_reason=reason)

--- a/src/teatree/loop/persistence_self_pr_review.py
+++ b/src/teatree/loop/persistence_self_pr_review.py
@@ -21,7 +21,8 @@ from django.db import transaction
 from teatree.core.models import Task, Ticket
 from teatree.core.models.codex_review_marker import CodexReviewMarker
 from teatree.loop.dispatch import DispatchAction
-from teatree.loop.persistence import _create_phase_task, _get_or_create_ticket, _has_open_task, _owning_overlay
+from teatree.loop.persistence import _get_or_create_ticket, _owning_overlay
+from teatree.loop.persistence_phase_task import create_phase_task, has_open_task
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ def handle_self_pr_review(action: DispatchAction) -> Task | None:
             overlay=_owning_overlay(pr_url, overlay),
             extra={"reviewed_sha": head_sha, "self_pr_review_variant": variant},
         )
-        if ticket.role != Ticket.Role.REVIEWER or _has_open_task(ticket, phase="reviewing"):
+        if ticket.role != Ticket.Role.REVIEWER or has_open_task(ticket, phase="reviewing"):
             return None
         marker = CodexReviewMarker.claim(
             slug=slug,
@@ -56,7 +57,7 @@ def handle_self_pr_review(action: DispatchAction) -> Task | None:
         )
         if marker is None:
             return None
-        return _create_phase_task(
+        return create_phase_task(
             ticket,
             phase="reviewing",
             agent_id="reviewer",

--- a/tests/teatree_loop/test_persistence_phase_task_mint.py
+++ b/tests/teatree_loop/test_persistence_phase_task_mint.py
@@ -24,7 +24,33 @@ from django.test import TestCase
 from teatree.core.models import Session, Task, Ticket
 from teatree.loop.dispatch import DispatchAction
 from teatree.loop.persistence import _handle_answerer
-from teatree.loop.persistence_phase_task import create_phase_task
+from teatree.loop.persistence_phase_task import create_phase_task, has_open_task, open_task_in_phase
+
+
+class TestOpenTaskLookup(TestCase):
+    """The pre-check the zone handlers short-circuit on: active-only, spelling-tolerant."""
+
+    @staticmethod
+    def _ticket() -> Ticket:
+        return Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/1")
+
+    def _store(self, ticket: Ticket, *, phase: str, status: str) -> Task:
+        session = Session.objects.create(ticket=ticket, agent_id="coder")
+        return Task.objects.create(ticket=ticket, session=session, phase=phase, status=status)
+
+    def test_an_active_task_reads_as_open_in_any_spelling(self) -> None:
+        ticket = self._ticket()
+        stored = self._store(ticket, phase="code", status=Task.Status.CLAIMED)
+
+        assert open_task_in_phase(ticket, phase="coding") == stored
+        assert has_open_task(ticket, phase="coding")
+
+    def test_a_terminal_task_does_not_read_as_open(self) -> None:
+        ticket = self._ticket()
+        self._store(ticket, phase="coding", status=Task.Status.COMPLETED)
+
+        assert open_task_in_phase(ticket, phase="coding") is None
+        assert has_open_task(ticket, phase="coding") is False
 
 
 class TestPhaseTaskMintCollapsesDuplicates(TestCase):

--- a/tests/teatree_loop/test_persistence_phase_task_mint.py
+++ b/tests/teatree_loop/test_persistence_phase_task_mint.py
@@ -1,0 +1,174 @@
+"""The dispatch-zone phase-task mint is idempotent in its side effects (#3969).
+
+``create_phase_task`` is the mint for the phases ``Ticket._schedule_headless``
+does not cover — ``debugging`` / ``e2e`` / ``answering`` / ``codex_reviewing`` and
+the corrective ``coding`` re-entries. It used to mint unconditionally, so two
+dispatchers that both passed a caller's ``has_open_task`` pre-check before either
+wrote produced TWO Sessions and TWO Tasks for one ``(ticket, phase)`` — the same
+defect #3903 fixed at the other mint.
+
+The two directions are pinned separately, as at the sibling seam: an in-flight
+sibling is a DUPLICATE and collapses; a terminal sibling is a finished attempt and
+the next call is legitimate re-work that must still mint. A guard that also
+swallowed the terminal case would let one crashed attempt wedge the phase forever.
+
+Anti-vacuity: every collapse assertion below was observed RED against the pre-fix
+mint (two rows where one is asserted), and every re-work assertion was observed RED
+against a guard widened to dedupe on "a task ever existed".
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from teatree.core.models import Session, Task, Ticket
+from teatree.loop.dispatch import DispatchAction
+from teatree.loop.persistence import _handle_answerer
+from teatree.loop.persistence_phase_task import create_phase_task
+
+
+class TestPhaseTaskMintCollapsesDuplicates(TestCase):
+    """A second mint for a ticket+phase that is already in flight returns the live task."""
+
+    @staticmethod
+    def _ticket(url: str = "answer://event/1") -> Ticket:
+        return Ticket.objects.create(overlay="test", issue_url=url)
+
+    def _mint(self, ticket: Ticket, *, phase: str = "debugging") -> Task:
+        return create_phase_task(ticket, phase=phase, agent_id="debug", reason="Auto-scheduled red-MR fix")
+
+    def test_two_mints_for_one_ticket_phase_yield_one_task(self) -> None:
+        # The load-bearing case: two dispatchers that both read "no open task"
+        # before either wrote. Pre-fix this minted a rival task.
+        ticket = self._ticket()
+
+        first = self._mint(ticket)
+        second = self._mint(ticket)
+
+        assert second.pk == first.pk, "the second mint created a rival task for the same ticket+phase"
+        assert Task.objects.filter(ticket=ticket, phase="debugging").count() == 1
+
+    def test_a_deduped_mint_leaves_no_orphan_session(self) -> None:
+        # The Session is minted first, so a guard placed AFTER it would collapse the
+        # Task and still leak a session row per raced dispatcher.
+        ticket = self._ticket()
+
+        self._mint(ticket)
+        self._mint(ticket)
+
+        assert Session.objects.filter(ticket=ticket).count() == 1
+
+    def test_a_claimed_sibling_is_a_duplicate_not_a_retry(self) -> None:
+        # A live lease is the strongest possible "already being worked".
+        ticket = self._ticket()
+        first = self._mint(ticket)
+        first.status = Task.Status.CLAIMED
+        first.save(update_fields=["status"])
+
+        second = self._mint(ticket)
+
+        assert second.pk == first.pk
+        assert Task.objects.filter(ticket=ticket, phase="debugging").count() == 1
+
+    def test_a_short_verb_row_dedupes_against_the_gerund_phase(self) -> None:
+        # ``tasks create <id> code`` stores the short verb; the corrective coding
+        # re-entries mint the gerund. One phase, so one lock — or each spelling
+        # mints a rival for the other.
+        ticket = self._ticket("skill-drift://o/r/f.md")
+        session = Session.objects.create(ticket=ticket, agent_id="skill-drift")
+        stored = Task.objects.create(ticket=ticket, session=session, phase="code")
+
+        minted = create_phase_task(ticket, phase="coding", agent_id="skill-drift", reason="Auto-scheduled fix")
+
+        assert minted.pk == stored.pk
+        assert Task.objects.filter(ticket=ticket).count() == 1
+
+    def test_every_zone_phase_collapses(self) -> None:
+        ticket = self._ticket()
+
+        for phase in ("debugging", "e2e", "answering", "codex_reviewing"):
+            assert self._mint(ticket, phase=phase).pk == self._mint(ticket, phase=phase).pk
+
+        assert Task.objects.filter(ticket=ticket).count() == 4
+
+    def test_raced_dispatchers_past_the_caller_precheck_mint_once(self) -> None:
+        # End to end through a real zone handler, with the caller's read-then-write
+        # pre-check forced to the value BOTH dispatchers read in the race: no open
+        # task. The pre-check is no longer load-bearing for correctness.
+        action = DispatchAction(
+            kind="agent",
+            zone="t3:answerer",
+            detail="inbound question",
+            payload={"event_id": 77, "overlay": "test"},
+        )
+        with patch("teatree.loop.persistence.has_open_task", return_value=False):
+            first = _handle_answerer(action)
+            second = _handle_answerer(action)
+
+        assert first is not None
+        assert second is not None
+        assert second.pk == first.pk
+        assert Task.objects.filter(phase="answering").count() == 1
+        assert Session.objects.count() == 1
+
+
+class TestPhaseTaskMintStillMintsLegitimateRework(TestCase):
+    """The guard is not over-eager: a finished attempt never blocks the next one."""
+
+    @staticmethod
+    def _ticket(url: str = "e2e-failure://test/spec.ts") -> Ticket:
+        return Ticket.objects.create(overlay="test", issue_url=url)
+
+    def _mint(self, ticket: Ticket, *, phase: str = "e2e") -> Task:
+        return create_phase_task(ticket, phase=phase, agent_id="e2e-fix", reason="Auto-scheduled E2E fix")
+
+    def test_a_failed_attempt_is_followed_by_a_fresh_task(self) -> None:
+        # The wedge-forever direction: a crashed worker's FAILED task must not
+        # suppress every later attempt at the same phase.
+        ticket = self._ticket()
+        first = self._mint(ticket)
+        first.status = Task.Status.FAILED
+        first.save(update_fields=["status"])
+
+        second = self._mint(ticket)
+
+        assert second.pk != first.pk, "a failed attempt blocked its own retry"
+        assert second.session_id != first.session_id, "re-work must run in a fresh session"
+
+    def test_a_completed_attempt_is_followed_by_a_fresh_task(self) -> None:
+        ticket = self._ticket()
+        first = self._mint(ticket)
+        first.status = Task.Status.COMPLETED
+        first.save(update_fields=["status"])
+
+        assert self._mint(ticket).pk != first.pk
+
+    def test_every_terminal_status_is_followed_by_a_fresh_task(self) -> None:
+        # ``Status.terminal()`` is the SSOT for "finished"; every member of it is
+        # re-work, so the guard is keyed on the active half of that partition.
+        for index, status in enumerate(sorted(Task.Status.terminal())):
+            ticket = self._ticket(f"e2e-failure://test/terminal-{index}.ts")
+            first = self._mint(ticket)
+            first.status = status
+            first.save(update_fields=["status"])
+
+            assert self._mint(ticket).pk != first.pk, f"a {status} attempt blocked its own retry"
+
+    def test_distinct_phases_never_dedupe_against_each_other(self) -> None:
+        ticket = self._ticket()
+
+        debugging = self._mint(ticket, phase="debugging")
+        e2e = self._mint(ticket, phase="e2e")
+
+        assert debugging.pk != e2e.pk
+        assert Task.objects.filter(ticket=ticket).count() == 2
+
+    def test_a_sibling_ticket_in_the_same_phase_is_not_a_duplicate(self) -> None:
+        # Overlay scoping is NOT asserted here: this seam narrows by ``ticket``,
+        # which already implies the overlay. That axis is pinned at the manager
+        # (``test_in_flight_for_phase_scopes_to_overlay_and_phase``).
+        mine = self._ticket()
+        theirs = self._ticket("e2e-failure://test/other.ts")
+
+        assert self._mint(mine).pk != self._mint(theirs).pk
+        assert Task.objects.filter(phase="e2e").count() == 2

--- a/tests/teatree_loop/test_persistence_zone_handlers.py
+++ b/tests/teatree_loop/test_persistence_zone_handlers.py
@@ -84,7 +84,7 @@ class TestDebugZoneRevived(TestCase):
         # Force the Task write to fail AFTER the marker claim: the shared atomic
         # block must roll the RedMrFixAttempt row back so the dropped action does
         # not burn its idempotency marker (#1 blocker — markers survive for retry).
-        with patch("teatree.loop.persistence._create_phase_task", side_effect=RuntimeError("boom")):
+        with patch("teatree.loop.persistence.create_phase_task", side_effect=RuntimeError("boom")):
             errors: dict[str, str] = {}
             created = persist_agent_actions(
                 _agent_actions(self._signal(pr_url="https://x/pr/12", head_sha="sha-12")),
@@ -162,7 +162,7 @@ class TestCodexReviewZoneRevived(TestCase):
         assert not CodexReviewMarker.objects.filter(slug="o/r", pr_id=13).exists()
 
     def test_task_creation_failure_rolls_back_marker(self) -> None:
-        with patch("teatree.loop.persistence._create_phase_task", side_effect=RuntimeError("boom")):
+        with patch("teatree.loop.persistence.create_phase_task", side_effect=RuntimeError("boom")):
             errors: dict[str, str] = {}
             created = persist_agent_actions(
                 _agent_actions(self._signal(pr_url="https://github.com/o/r/pull/14", pr_id=14, head_sha="csha-14")),
@@ -256,7 +256,7 @@ class TestSelfPrReviewZoneRevived(TestCase):
 
     def test_task_creation_failure_rolls_back_marker(self) -> None:
         with patch(
-            "teatree.loop.persistence_self_pr_review._create_phase_task",
+            "teatree.loop.persistence_self_pr_review.create_phase_task",
             side_effect=RuntimeError("boom"),
         ):
             errors: dict[str, str] = {}


### PR DESCRIPTION
fix(loop): dedupe the dispatch-zone phase-task mint at the write seam (#3969)

## What

`create_phase_task` (formerly `persistence._create_phase_task`) deduplicates **at the write**. It is the mint for the phases `Ticket._schedule_headless` does not cover — `debugging`, `e2e`, `answering`, `codex_reviewing` / `codex_adversarial_reviewing`, and the corrective `coding` re-entries (red card, skill drift) — and it minted a `Session` + `Task` unconditionally.

The only dedupe on this path was the per-handler `has_open_task(ticket, phase=...)` pre-check, which is a read-then-write: two dispatchers that both read "no open task" before either writes both mint, so one unit of work gets two Sessions and two Tasks and two agents claim it.

The lock is the existing `Task.objects.in_flight_for_phase` SSOT — the same one `_schedule_headless` consults at the FSM mint since #3903/#3934, and the same one the periodic cadence scanners read. No third mechanism: this seam now reads like the other one.

What counts as a **duplicate** vs a **legitimate retry**, both directions pinned in tests:

| | Duplicate (collapses) | Legitimate re-work (still mints) |
| --- | --- | --- |
| phase-task mint | a `PENDING` or `CLAIMED` Task on the same `(ticket, phase)`, in any accepted spelling | a terminal sibling (`COMPLETED` / `FAILED`) — a finished attempt, so the next call gets a fresh Session + Task |

Two failure modes the shape is chosen to avoid:

- **Wedging the phase forever.** Deduping on "a task ever existed" would let one crashed attempt suppress every later one. The lock is `Status.active()`, the SSOT active half of the task-state partition, so every member of `Status.terminal()` is re-work. `test_every_terminal_status_is_followed_by_a_fresh_task` iterates that set rather than naming statuses, so a new terminal status cannot quietly become a wedge.
- **Leaking an orphan Session.** The `Session` is minted first, so a guard placed after it would collapse the Task and still leave one session row per raced dispatcher. The check runs before the `Session` is created, and `test_a_deduped_mint_leaves_no_orphan_session` pins it.

The check and the mint share one `atomic` block, and the DB is opened in `transaction_mode="IMMEDIATE"`, so the guard is a real CAS rather than a second read-then-write.

Callers keep their `has_open_task` pre-checks — they short-circuit before doing useless marker/claim work, which is worth having. What changes is that they are no longer load-bearing for correctness.

`persistence.py` was at its module-health LOC budget, so the mint moves to its own concern module rather than growing the router — the same split #3934 made for the teardown enqueue. `persistence.py` owns routing a dispatch signal to a `Ticket`; `persistence_phase_task.py` owns the decision to mint a `Task` for one, and the guard.

## Why

`_schedule_headless` was hardened at the write in #3903 and #3934; those changes touched `core/managers.py`, `core/managers_phase_cadence.py` and `core/models/ticket_scheduling.py` and did not reach this second mint. A scheduler with N callers has N chances to forget a pre-check, and a pre-check that races is not a guard at all — so the mint that both of them precede is where the check belongs.

## Testing

`tests/teatree_loop/test_persistence_phase_task_mint.py`, both directions, each observed failing before it passed:

- **RED against the pre-fix mint** — every collapse assertion (including the end-to-end one through a real zone handler with the caller pre-check forced to the value both racing dispatchers read): two rows where one is asserted.
- **RED against a deliberately over-eager guard** (dedupe on "a task ever existed"): every re-work assertion fails, so the negative direction is not vacuous either.

`bash dev/ci-parity-fast.sh` green: scoped prek, `makemigrations --check`, the affected-tests lane (10163 passed), and the incremental push gate.

Closes #3969