### PR TITLE
fix(deploy): heartbeat the worker drain and detect a stranded quiescing gate (#3983)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,7 +117,13 @@ jobs:
           # provisioned pass store.
           TEATREE_BOX_USE_PASS: ${{ vars.TEATREE_BOX_USE_PASS || 'false' }}
         run: |
-          SSH="ssh -p ${SSH_PORT} -i ${HOME}/.ssh/id_deploy -o UserKnownHostsFile=${HOME}/.ssh/known_hosts -o StrictHostKeyChecking=yes -o ConnectTimeout=20"
+          # ServerAlive* is load-bearing, not hygiene: three deploys died 276.8s /
+          # 280.0s / ~280s into the worker drain, which prints nothing while it waits
+          # for in-flight agents. A 3s spread across runs is a fixed idle timeout, and
+          # it fires far short of the 1800s the drain is allowed — so without
+          # keepalives the drain budget is unreachable and the deploy dies before the
+          # swap that clears `worker_quiescing`. 30s x 20 tolerates a 10-min stall.
+          SSH="ssh -p ${SSH_PORT} -i ${HOME}/.ssh/id_deploy -o UserKnownHostsFile=${HOME}/.ssh/known_hosts -o StrictHostKeyChecking=yes -o ConnectTimeout=20 -o ServerAliveInterval=30 -o ServerAliveCountMax=20"
           TARGET="${SSH_USER}@${SERVER_HOST}"
 
           # 1. Ensure the build-context checkout exists on the box.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -582,8 +582,12 @@ service is down — exactly the outage it exists to repair.
    non-zero / a worker stuck `Created`, a free worker flock over overdue loop
    work, an `execute_headless_task` stranded RUNNING with no live worker, a READY
    loop timer stale past 2× its cadence, a PENDING `interactive` task under
-   `agent_runtime=headless`, a FAILED task on a still-live ticket, and a runtime
-   clone drifted off its default branch.
+   `agent_runtime=headless`, a FAILED task on a still-live ticket, a runtime
+   clone drifted off its default branch, and a `worker_quiescing` gate older than
+   any deploy could explain
+   ([#3983](https://github.com/souliane/teatree/issues/3983) — a deploy killed
+   between its drain and the swap that clears the gate leaves the claim path
+   admitting ZERO work while every other surface stays green).
 4. On any **red** finding it DMs the owner via `t3 teatree notify send`, keyed on
    the finding set so an ongoing outage does not re-spam every pass. (The default
    deploy wires no Slack credential; until you add one the DM step no-ops and the

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -5166,7 +5166,10 @@ Usage: t3 worker drain [OPTIONS]
  when the worker is drained; exits ``_GRACE_EXCEEDED_EXIT`` (naming the still-
  CLAIMED task pks) when the grace lapses, so a deploy can proceed knowing a
  stuck
- task re-queues via its lease lapse.
+ task re-queues via its lease lapse. The wait heartbeats to stderr while it
+ runs, so
+ the deploy's SSH session never idles out mid-drain and takes the deploy with
+ it.
 
  THE WORKER IS LEFT QUIESCED: this command stops nothing, and the gate it sets
  is

--- a/src/teatree/cli/doctor/self_heal.py
+++ b/src/teatree/cli/doctor/self_heal.py
@@ -13,6 +13,7 @@ of the stack it watches) can restart the stack and DM the owner:
 - a PENDING ``interactive`` task under ``agent_runtime=headless`` (unrunnable),
 - a FAILED task on a still-live ticket (the silent-freeze signature),
 - a runtime clone that has drifted off its default branch,
+- a ``worker_quiescing`` gate outliving any deploy that could explain it,
 - a slack-drain sidecar failing every pass or gone silent (``self_heal_slack_drain``),
 - a ``loop:<name>``/``t3-master`` lease held by a dead session past TTL (this one AUTO-REPAIRS).
 
@@ -32,6 +33,7 @@ from pathlib import Path
 
 import typer
 
+from teatree.cli.doctor.self_heal_quiescing import check_stranded_quiescing_gate
 from teatree.cli.doctor.self_heal_slack_drain import check_slack_drain_alive
 
 #: The compose project the box runs the factory under (``deploy/docker-compose.yml``).
@@ -517,6 +519,7 @@ def run_self_heal_checks() -> bool:
         _check_interactive_task_under_headless,
         _check_failed_tasks_on_live_tickets,
         _check_runtime_clone_on_default_branch,
+        check_stranded_quiescing_gate,
         check_slack_drain_alive,
         _check_dead_owner_lease,
     )

--- a/src/teatree/cli/doctor/self_heal_quiescing.py
+++ b/src/teatree/cli/doctor/self_heal_quiescing.py
@@ -1,0 +1,80 @@
+"""Self-heal detector for a ``worker_quiescing`` gate no deploy can still explain (#3983).
+
+Quiescing is a STEP in a sequence that ends in a restart, never a decision on its own:
+``deploy/deploy.sh``'s drain sets the gate and the fresh worker's init clears it. A
+deploy killed in between — an SSH session torn down mid-drain, then SIGKILLed past any
+trap — leaves it ON, after which the claim path admits ZERO new work while already-
+claimed tasks run to completion, loops keep ticking green and ``t3 worker status``
+reports RUNNING. The outage is visible only by reading the flag, which is how one ran
+for roughly six hours across two failed deploys.
+
+The gate's own age bounds the deploy that could have set it, so aged past that budget
+there is nothing left to explain it and the finding is a hard FAIL.
+"""
+
+import datetime as dt
+import os
+
+import typer
+
+from teatree.loop.drain import QUIESCING_SETTING
+
+#: The drain grace ``deploy/deploy.sh`` allows (its ``TEATREE_DRAIN_TIMEOUT`` default).
+_DEFAULT_DRAIN_TIMEOUT_SECONDS = 1800
+#: What the deploy still has to do after the drain — build, `up -d`, and the 60x10s
+#: admin health wait — before the fresh worker's init clears the gate.
+_DEPLOY_SWAP_BUDGET_SECONDS = 1200
+
+
+def _now() -> dt.datetime:
+    from django.utils import timezone  # noqa: PLC0415 — deferred: Django import at call time
+
+    return timezone.now()
+
+
+def quiescing_deploy_budget_seconds() -> int:
+    """The widest window in which a set ``worker_quiescing`` is still a live deploy."""
+    raw = os.environ.get("TEATREE_DRAIN_TIMEOUT", "").strip()
+    drain = int(raw) if raw.isdigit() else _DEFAULT_DRAIN_TIMEOUT_SECONDS
+    return drain + _DEPLOY_SWAP_BUDGET_SECONDS
+
+
+def _gate_age_seconds() -> float | None:
+    """Seconds since the newest ON ``worker_quiescing`` row was written, or ``None``.
+
+    ``None`` means no DB row carries the gate — it resolves ON from env or file, which
+    no deploy could have written, so nothing can date it.
+    """
+    from teatree.core.models import ConfigSetting  # noqa: PLC0415 — deferred: ORM import needs the app registry
+
+    written = [
+        row.updated_at
+        for row in ConfigSetting.objects.filter(key=QUIESCING_SETTING)
+        if row.value is True  # a JSONField holds any shape; only a literal ON dates the gate
+    ]
+    return (_now() - max(written)).total_seconds() if written else None
+
+
+def check_stranded_quiescing_gate() -> bool:
+    """FAIL when ``worker_quiescing`` outlives any deploy that could explain it (#3983)."""
+    try:
+        from teatree.config.resolution import worker_is_quiescing  # noqa: PLC0415 — deferred: heavy config import
+
+        if not worker_is_quiescing():
+            return True
+        age = _gate_age_seconds()
+        if age is not None and age < quiescing_deploy_budget_seconds():
+            return True
+    except Exception as exc:  # noqa: BLE001 — a self-heal probe must never crash the doctor run
+        typer.echo(f"WARN  Stranded-quiescing check crashed: {exc.__class__.__name__}: {exc}")
+        return True
+    since = f"set {age / 60:.0f} min ago" if age is not None else "set outside the config store, so undateable"
+    typer.echo(
+        f"FAIL  worker_quiescing is ON and {since} — no deploy can still explain it, and the claim "
+        f"path is admitting ZERO new work. Resume admission with "
+        f"`t3 <overlay> config_setting set worker_quiescing false`."
+    )
+    return False
+
+
+__all__ = ["check_stranded_quiescing_gate", "quiescing_deploy_budget_seconds"]

--- a/src/teatree/cli/worker.py
+++ b/src/teatree/cli/worker.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, TypedDict
 import typer
 
 if TYPE_CHECKING:
-    from teatree.loop.drain import DrainReport
+    from teatree.loop.drain import DrainProgress, DrainReport
     from teatree.loop.worker_lifecycle import StopReport
 
 
@@ -271,6 +271,36 @@ def ensure_command(
 #: apart and proceed knowing a stuck task re-queues via its lease lapse.
 _GRACE_EXCEEDED_EXIT = 3
 
+#: Shortest measured drain-to-broken-pipe interval across the three deploys that died
+#: mid-drain (276.8s / 280.0s / ~280s). A 3s spread is a fixed idle timeout, not a flaky
+#: link — so a silent wait can never reach its own 1800s budget, and the deploy dies
+#: before the swap that clears `worker_quiescing` (#3983).
+OBSERVED_SSH_IDLE_TIMEOUT_SECONDS = 276.0
+#: Heartbeat cadence, chosen to leave room for several missed lines inside that window.
+_PROGRESS_ECHO_INTERVAL_SECONDS = 60.0
+
+
+class _DrainHeartbeat:
+    """Echo at most one drain progress line per :data:`_PROGRESS_ECHO_INTERVAL_SECONDS`.
+
+    Writes to STDERR so `--json` stdout stays a single parseable document, and relies
+    on ``click.echo``'s unconditional flush: the deploy reaches this through
+    `docker compose exec -T`, whose piped stdio Python would otherwise block-buffer —
+    an unflushed heartbeat never reaches the transport it exists to keep alive.
+    """
+
+    def __init__(self) -> None:
+        self._next_at = 0.0
+
+    def __call__(self, progress: "DrainProgress") -> None:
+        if progress.waited_seconds < self._next_at:
+            return
+        self._next_at = progress.waited_seconds + _PROGRESS_ECHO_INTERVAL_SECONDS
+        typer.echo(
+            f"draining: {len(progress.still_claimed)} task(s) still in flight after {progress.waited_seconds:.0f}s",
+            err=True,
+        )
+
 
 @worker_app.command("drain")
 def drain_command(
@@ -286,7 +316,8 @@ def drain_command(
     the supervisor is never stopped and no in-flight sub-agent is killed. Exits 0
     when the worker is drained; exits ``_GRACE_EXCEEDED_EXIT`` (naming the still-
     CLAIMED task pks) when the grace lapses, so a deploy can proceed knowing a stuck
-    task re-queues via its lease lapse.
+    task re-queues via its lease lapse. The wait heartbeats to stderr while it runs, so
+    the deploy's SSH session never idles out mid-drain and takes the deploy with it.
 
     THE WORKER IS LEFT QUIESCED: this command stops nothing, and the gate it sets is
     cleared only by a fresh container boot (``deploy/entrypoint.sh``). On a bare host
@@ -301,7 +332,7 @@ def drain_command(
     from teatree.config.resolution import worker_is_quiescing  # noqa: PLC0415 (deferred: no Django/DB at CLI import)
     from teatree.loop.drain import DrainOutcome, drain_worker  # noqa: PLC0415 (deferred: no Django/DB at CLI import)
 
-    report = drain_worker(timeout=timeout, poll_interval=poll_interval)
+    report = drain_worker(timeout=timeout, poll_interval=poll_interval, on_progress=_DrainHeartbeat())
     quiescing = worker_is_quiescing()
     if json_output:
         typer.echo(

--- a/src/teatree/loop/drain.py
+++ b/src/teatree/loop/drain.py
@@ -6,8 +6,8 @@ must never kill an in-flight sub-agent. ``drain_worker`` flips the
 (``TaskQuerySet.claim_next_pending`` / ``_claimable_for_target``) admits ZERO new
 work — then polls the SSOT in-flight set (``Task.objects.active_claims``, the live
 CLAIMED leases) until it reads empty or the grace ``timeout`` lapses. It NEVER stops
-the supervisor and never touches a
-CLAIMED lease; an in-flight task keeps renewing via ``renew_lease`` and finishes.
+the supervisor and never touches a CLAIMED lease; an in-flight task keeps renewing
+via ``renew_lease`` and finishes.
 
 ``deploy/deploy.sh`` runs ``t3 worker drain`` before swapping the worker image; the
 FRESH worker's init clears ``worker_quiescing`` so admission resumes. On a grace

--- a/src/teatree/loop/drain.py
+++ b/src/teatree/loop/drain.py
@@ -4,9 +4,9 @@ The first half of drain-then-deploy (rolling / zero-downtime deploy): a deploy
 must never kill an in-flight sub-agent. ``drain_worker`` flips the
 ``worker_quiescing`` config gate ON — after which the claim/admission chokepoint
 (``TaskQuerySet.claim_next_pending`` / ``_claimable_for_target``) admits ZERO new
-work — then polls the SSOT in-flight predicate
-(``Task.objects.active_claim_exists``, a live CLAIMED lease) until it reads clear
-or the grace ``timeout`` lapses. It NEVER stops the supervisor and never touches a
+work — then polls the SSOT in-flight set (``Task.objects.active_claims``, the live
+CLAIMED leases) until it reads empty or the grace ``timeout`` lapses. It NEVER stops
+the supervisor and never touches a
 CLAIMED lease; an in-flight task keeps renewing via ``renew_lease`` and finishes.
 
 ``deploy/deploy.sh`` runs ``t3 worker drain`` before swapping the worker image; the
@@ -14,6 +14,11 @@ FRESH worker's init clears ``worker_quiescing`` so admission resumes. On a grace
 overrun the deploy proceeds anyway — a still-CLAIMED task re-queues PENDING via its
 lease lapse (``reclaim_orphaned_claims``) and is picked up by the fresh worker, so
 no work is lost.
+
+The wait reports a :class:`DrainProgress` sample on every poll. Waiting on in-flight
+agents is inherently long, and the deploy reaches this command through an SSH session
+that tears down after ~280s of silence — so a wait that says nothing cannot reach its
+own 1800s budget, and the deploy dies before the swap that clears the gate (#3983).
 """
 
 import time
@@ -29,6 +34,15 @@ class DrainOutcome(Enum):
 
     DRAINED = "drained"
     GRACE_EXCEEDED = "grace_exceeded"
+
+
+@dataclass(frozen=True, slots=True)
+class DrainProgress:
+    """One heartbeat sample of an ongoing drain wait."""
+
+    waited_seconds: float
+    #: The pks still CLAIMED with a live lease at this sample.
+    still_claimed: list[int]
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,47 +75,49 @@ def _still_claimed_pks() -> list[int]:
     return list(Task.objects.active_claims().order_by("pk").values_list("pk", flat=True))
 
 
-def _in_flight() -> bool:
-    from teatree.core.models.task import Task  # noqa: PLC0415 — deferred: ORM needs the app registry
-
-    return Task.objects.active_claim_exists()
-
-
 def drain_worker(
     *,
     timeout: int,
     poll_interval: float = 5.0,
     sleep: Callable[[float], None] = time.sleep,
     monotonic: Callable[[], float] = time.monotonic,
+    on_progress: Callable[[DrainProgress], None] | None = None,
 ) -> DrainReport:
     """Quiesce admission and wait for in-flight CLAIMED leases to clear.
 
     Sets ``worker_quiescing`` ON (so no new task is admitted), then polls the
-    in-flight predicate every ``poll_interval`` seconds. Returns a
-    :class:`DrainReport` with :attr:`DrainOutcome.DRAINED` as soon as no live lease
-    remains, or :attr:`DrainOutcome.GRACE_EXCEEDED` (naming the still-CLAIMED pks)
-    once ``timeout`` seconds elapse. The in-flight set is checked BEFORE the first
-    sleep, so a quiet worker returns DRAINED immediately. ``sleep`` / ``monotonic``
-    are injectable so a test can drive the wait without wall-clock time.
+    in-flight set every ``poll_interval`` seconds. Returns a :class:`DrainReport`
+    with :attr:`DrainOutcome.DRAINED` as soon as no live lease remains, or
+    :attr:`DrainOutcome.GRACE_EXCEEDED` (naming the still-CLAIMED pks) once
+    ``timeout`` seconds elapse. The in-flight set is checked BEFORE the first
+    sleep, so a quiet worker returns DRAINED immediately. ``on_progress`` receives
+    one :class:`DrainProgress` per poll the wait continues past — the heartbeat the
+    deploy's transport needs to tell a working drain from a hung session.
+    ``sleep`` / ``monotonic`` are injectable so a test can drive the wait without
+    wall-clock time.
     """
     set_worker_quiescing(value=True)
     start = monotonic()
     while True:
-        if not _in_flight():
+        still_claimed = _still_claimed_pks()
+        if not still_claimed:
             return DrainReport(outcome=DrainOutcome.DRAINED, waited_seconds=monotonic() - start)
         waited = monotonic() - start
         if waited >= timeout:
             return DrainReport(
                 outcome=DrainOutcome.GRACE_EXCEEDED,
                 waited_seconds=waited,
-                still_claimed=_still_claimed_pks(),
+                still_claimed=still_claimed,
             )
+        if on_progress is not None:
+            on_progress(DrainProgress(waited_seconds=waited, still_claimed=still_claimed))
         sleep(poll_interval)
 
 
 __all__ = [
     "QUIESCING_SETTING",
     "DrainOutcome",
+    "DrainProgress",
     "DrainReport",
     "drain_worker",
     "set_worker_quiescing",

--- a/tests/teatree_cli/doctor/test_self_heal_quiescing.py
+++ b/tests/teatree_cli/doctor/test_self_heal_quiescing.py
@@ -1,0 +1,114 @@
+"""``check_stranded_quiescing_gate`` — a quiesced worker outside a live deploy (#3983).
+
+``worker_quiescing`` is set by the deploy's drain and cleared by the fresh worker's
+init. A deploy that dies in between leaves it ON, the claim path admits ZERO work, and
+every other health surface stays green — the outage is visible only by reading the flag.
+This detector dates the gate against the widest window a live deploy could explain and
+hard-FAILs past it, so the doctor exit code the watchdog keys on turns red.
+"""
+
+import datetime as dt
+import io
+from collections.abc import Callable
+from contextlib import redirect_stdout
+from unittest import mock
+
+import django.test
+from django.utils import timezone
+
+from teatree.cli.doctor import self_heal, self_heal_quiescing
+from teatree.core.models import ConfigSetting
+from teatree.loop.drain import QUIESCING_SETTING, set_worker_quiescing
+
+
+def _echoes(check: Callable[[], bool]) -> tuple[bool, str]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        ok = check()
+    return ok, buf.getvalue()
+
+
+def _age_the_gate(seconds: float) -> None:
+    """Backdate the gate row's ``updated_at``, bypassing its ``auto_now`` write."""
+    ConfigSetting.objects.filter(key=QUIESCING_SETTING).update(
+        updated_at=timezone.now() - dt.timedelta(seconds=seconds)
+    )
+
+
+class StrandedQuiescingCheckTest(django.test.TestCase):
+    def test_a_clear_gate_passes_silently(self) -> None:
+        set_worker_quiescing(value=False)
+
+        ok, out = _echoes(self_heal_quiescing.check_stranded_quiescing_gate)
+
+        assert ok is True
+        assert out == ""
+
+    def test_a_freshly_set_gate_is_a_live_deploy_and_passes(self) -> None:
+        set_worker_quiescing(value=True)
+
+        ok, out = _echoes(self_heal_quiescing.check_stranded_quiescing_gate)
+
+        assert ok is True, "a drain that just started is a deploy in flight, not a stranded gate"
+        assert out == ""
+
+    def test_a_gate_older_than_any_deploy_could_explain_hard_fails(self) -> None:
+        set_worker_quiescing(value=True)
+        _age_the_gate(self_heal_quiescing.quiescing_deploy_budget_seconds() + 60)
+
+        ok, out = _echoes(self_heal_quiescing.check_stranded_quiescing_gate)
+
+        assert ok is False, "an aged quiescing gate is a zero-admission outage and must redden the doctor"
+        assert "FAIL" in out
+        assert "worker_quiescing" in out
+        assert "config_setting set worker_quiescing false" in out, "the finding must name its own recovery"
+
+    def test_the_finding_is_not_swallowed_by_the_watchdogs_deploy_sensitive_gating(self) -> None:
+        # deploy/watchdog.sh drops a finding matching one of these while a convergence
+        # is in flight. This one means the convergence ALREADY died, so it must page.
+        set_worker_quiescing(value=True)
+        _age_the_gate(self_heal_quiescing.quiescing_deploy_budget_seconds() + 60)
+
+        _ok, out = _echoes(self_heal_quiescing.check_stranded_quiescing_gate)
+
+        for gated in ("no loop worker holds the flock", "slack-listener receiver is DOWN", "commit(s) behind origin/"):
+            assert gated not in out
+
+    def test_a_gate_no_db_row_can_date_hard_fails(self) -> None:
+        # Resolved ON from env/file: nothing can date it, so nothing can call it a live
+        # deploy — and a zero-admission factory must never be silent.
+        with mock.patch("teatree.config.resolution.worker_is_quiescing", return_value=True):
+            ok, out = _echoes(self_heal_quiescing.check_stranded_quiescing_gate)
+
+        assert ok is False
+        assert "FAIL" in out
+
+    def test_a_read_error_degrades_to_a_pass(self) -> None:
+        with mock.patch("teatree.config.resolution.worker_is_quiescing", side_effect=RuntimeError("boom")):
+            ok, out = _echoes(self_heal_quiescing.check_stranded_quiescing_gate)
+
+        assert ok is True, "a detector that aborted the run would recreate the outage it exists to catch"
+        assert "WARN" in out
+
+    def test_it_is_wired_into_the_self_heal_sequence(self) -> None:
+        set_worker_quiescing(value=True)
+        _age_the_gate(self_heal_quiescing.quiescing_deploy_budget_seconds() + 60)
+
+        ok, out = _echoes(self_heal.run_self_heal_checks)
+
+        assert ok is False
+        assert "worker_quiescing" in out
+
+    def test_the_budget_covers_the_drain_grace_plus_the_swap(self) -> None:
+        with mock.patch.dict("os.environ", {"TEATREE_DRAIN_TIMEOUT": "600"}):
+            assert (
+                self_heal_quiescing.quiescing_deploy_budget_seconds()
+                == 600 + self_heal_quiescing._DEPLOY_SWAP_BUDGET_SECONDS
+            )
+
+    def test_an_unreadable_drain_timeout_falls_back_to_the_deploy_default(self) -> None:
+        with mock.patch.dict("os.environ", {"TEATREE_DRAIN_TIMEOUT": "not-a-number"}):
+            expected = (
+                self_heal_quiescing._DEFAULT_DRAIN_TIMEOUT_SECONDS + self_heal_quiescing._DEPLOY_SWAP_BUDGET_SECONDS
+            )
+            assert self_heal_quiescing.quiescing_deploy_budget_seconds() == expected

--- a/tests/teatree_cli/test_cli_worker.py
+++ b/tests/teatree_cli/test_cli_worker.py
@@ -11,6 +11,7 @@ paths run under a real test DB; no test signals a real process.
 import datetime as dt
 import json
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from unittest import mock
 
@@ -23,7 +24,7 @@ import teatree.cli.worker as worker_cli
 from teatree.cli.doctor.checks_runtime import _check_singletons, _check_worker_running
 from teatree.cli.worker import DrainPayload, _drain_payload, worker_app
 from teatree.core.models import ConfigSetting, Loop, Prompt
-from teatree.loop.drain import QUIESCING_SETTING, DrainOutcome, DrainReport, set_worker_quiescing
+from teatree.loop.drain import QUIESCING_SETTING, DrainOutcome, DrainProgress, DrainReport, set_worker_quiescing
 from teatree.loop.worker_lifecycle import StartReport, StopOutcome, StopReport, WorkerStopper
 from teatree.loops.loop_staleness import Admission, LoopHealth
 from teatree.utils import singleton as singleton_mod
@@ -379,6 +380,49 @@ class TestWorkerDrain(django.test.TestCase):
         result = runner.invoke(worker_app, ["drain", "--help"])
         rendered = " ".join(result.stdout.split())
         assert "config_setting set worker_quiescing false" in rendered
+
+
+class TestWorkerDrainHeartbeat(django.test.TestCase):
+    """The drain speaks while it waits, so its transport never sees an idle session (#3983)."""
+
+    @staticmethod
+    def _drain_emitting(samples: list[DrainProgress]) -> Callable[..., DrainReport]:
+        """A ``drain_worker`` stand-in that replays *samples* through the caller's callback."""
+
+        def _drain(*, on_progress: Callable[[DrainProgress], None] | None = None, **_kwargs: object) -> DrainReport:
+            assert on_progress is not None, "drain_command must hand drain_worker a progress sink"
+            for sample in samples:
+                on_progress(sample)
+            return DrainReport(outcome=DrainOutcome.DRAINED, waited_seconds=samples[-1].waited_seconds)
+
+        return _drain
+
+    def test_the_wait_emits_a_heartbeat_naming_the_elapsed_time_and_in_flight_count(self) -> None:
+        samples = [DrainProgress(waited_seconds=5.0, still_claimed=[7, 9])]
+        with mock.patch("teatree.loop.drain.drain_worker", side_effect=self._drain_emitting(samples)):
+            result = runner.invoke(worker_app, ["drain"])
+
+        assert result.exit_code == 0
+        assert "2 task(s) still in flight after 5s" in result.stderr
+
+    def test_heartbeats_are_throttled_but_stay_well_inside_the_idle_window(self) -> None:
+        # Three failed deploys tore down at ~278s of silence; the throttle must keep the
+        # gap between heartbeats far below that, and must not emit one line per 5s poll.
+        samples = [DrainProgress(waited_seconds=float(t), still_claimed=[7]) for t in range(5, 305, 5)]
+        with mock.patch("teatree.loop.drain.drain_worker", side_effect=self._drain_emitting(samples)):
+            result = runner.invoke(worker_app, ["drain"])
+
+        beats = [line for line in result.stderr.splitlines() if "still in flight" in line]
+        assert 1 < len(beats) < len(samples), "every poll must not echo, but the wait must not go silent"
+        assert worker_cli._PROGRESS_ECHO_INTERVAL_SECONDS < worker_cli.OBSERVED_SSH_IDLE_TIMEOUT_SECONDS / 2
+
+    def test_json_output_stays_parseable_while_the_wait_heartbeats(self) -> None:
+        samples = [DrainProgress(waited_seconds=5.0, still_claimed=[7])]
+        with mock.patch("teatree.loop.drain.drain_worker", side_effect=self._drain_emitting(samples)):
+            result = runner.invoke(worker_app, ["drain", "--json"])
+
+        assert json.loads(result.stdout)["outcome"] == "drained"
+        assert "still in flight" in result.stderr
 
 
 class TestWorkerStop(django.test.TestCase):

--- a/tests/teatree_loop/test_drain.py
+++ b/tests/teatree_loop/test_drain.py
@@ -13,7 +13,7 @@ import pytest
 
 from teatree.core.models import ConfigSetting
 from teatree.core.models.task import Task
-from teatree.loop.drain import DrainOutcome, drain_worker, set_worker_quiescing
+from teatree.loop.drain import DrainOutcome, DrainProgress, drain_worker, set_worker_quiescing
 from tests.factories import TaskFactory
 
 
@@ -84,3 +84,33 @@ class TestDrainWorker(django.test.TestCase):
 
         assert report.outcome is DrainOutcome.DRAINED
         assert sleeps == [5]
+
+
+class TestDrainProgress(django.test.TestCase):
+    """The wait speaks on every poll, so nothing downstream can read it as idle (#3983)."""
+
+    def test_each_poll_reports_the_elapsed_wait_and_the_in_flight_pks(self) -> None:
+        task = TaskFactory(status=Task.Status.PENDING)
+        task.claim(claimed_by="loop", lease_seconds=300)
+
+        samples: list[DrainProgress] = []
+        # monotonic: start=0, two in-budget readings (one progress sample each), then
+        # one past the timeout that ends the wait without a third sample.
+        clock = _FakeClock([0.0, 10.0, 20.0, 90.0])
+        drain_worker(
+            timeout=60,
+            poll_interval=5,
+            sleep=lambda _seconds: None,
+            monotonic=clock,
+            on_progress=samples.append,
+        )
+
+        assert [round(sample.waited_seconds) for sample in samples] == [10, 20]
+        assert all(sample.still_claimed == [task.pk] for sample in samples)
+
+    def test_a_quiet_worker_emits_no_progress(self) -> None:
+        samples: list[DrainProgress] = []
+        report = drain_worker(timeout=1800, sleep=lambda _seconds: None, on_progress=samples.append)
+
+        assert report.outcome is DrainOutcome.DRAINED
+        assert samples == []

--- a/tests/test_deploy_rolling_drain.py
+++ b/tests/test_deploy_rolling_drain.py
@@ -13,8 +13,14 @@ Piece B (drain): ``deploy.sh`` drains the running worker before the image swap;
 resumes; the worker gets a stop grace window for a clean shutdown.
 """
 
+import os
+import re
+import signal
+import subprocess
+import time
 from pathlib import Path
 
+import pytest
 import yaml
 
 _ROOT = Path(__file__).resolve().parents[1]
@@ -23,6 +29,56 @@ _DEPLOY_SH = _ROOT / "deploy" / "deploy.sh"
 _FF_CHECKOUT_SH = _ROOT / "deploy" / "fast-forward-checkout.sh"
 _ENTRYPOINT_SH = _ROOT / "deploy" / "entrypoint.sh"
 _COMPOSE_YML = _ROOT / "deploy" / "docker-compose.yml"
+#: The shortest measured drain-to-broken-pipe interval across the three failed deploys
+#: (276.8s / 280.0s), i.e. the idle window the transport is known NOT to outlive.
+_OBSERVED_IDLE_TEARDOWN_SECONDS = 276
+
+#: Anchors bounding deploy.sh's stranded-gate fail-safe, so the signal probe below runs
+#: the SHIPPED code rather than a re-typed copy of it.
+_FAIL_SAFE_START = "_DRAINED=false"
+_FAIL_SAFE_END = "trap _clear_quiescing_if_stranded EXIT"
+
+
+def _fail_safe_block() -> str:
+    """deploy.sh's stranded-gate fail-safe, verbatim, anchors included."""
+    body = _DEPLOY_SH.read_text(encoding="utf-8")
+    start, end = body.find(_FAIL_SAFE_START), body.find(_FAIL_SAFE_END)
+    moved = "deploy.sh's stranded-gate fail-safe moved — re-anchor this probe"
+    assert start != -1, moved
+    assert end > start, moved
+    return body[start : end + len(_FAIL_SAFE_END)] + "\n"
+
+
+def _run_fail_safe_under_signal(tmp_path: Path, sig: int, *, fail_safe: str) -> list[str]:
+    """Signal a script carrying *fail_safe* mid-drain; return the `docker` calls it made."""
+    docker_log = tmp_path / "docker.log"
+    ready = tmp_path / "ready"
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir()
+    stub = stub_bin / "docker"
+    stub.write_text(f'#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> "{docker_log}"\n', encoding="utf-8")
+    stub.chmod(0o755)
+
+    script = tmp_path / "harness.sh"
+    script.write_text(
+        "#!/usr/bin/env bash\nset -euo pipefail\nCOMPOSE_FILE=/dev/null\n"
+        f"{fail_safe}"
+        f'_DRAINED=true\ntouch "{ready}"\nsleep 5\n',
+        encoding="utf-8",
+    )
+
+    env = {**os.environ, "PATH": f"{stub_bin}{os.pathsep}{os.environ['PATH']}"}
+    proc = subprocess.Popen(["bash", str(script)], env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)  # noqa: S607 — a fixture-authored script under tmp_path
+    try:
+        deadline = time.monotonic() + 10
+        while not ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert ready.exists(), "the harness never reached its drain"
+        proc.send_signal(sig)
+        proc.wait(timeout=10)
+    finally:
+        proc.kill()
+    return docker_log.read_text(encoding="utf-8").splitlines() if docker_log.exists() else []
 
 
 def _deploy_workflow() -> dict:
@@ -119,3 +175,40 @@ class TestDeployDrain:
             "teatree-worker needs a stop_grace_period so a recreate lets the SIGTERM "
             "handler exit cleanly instead of SIGKILL at the 10s default."
         )
+
+
+class TestDrainSurvivesItsTransport:
+    """The long drain outlives its SSH session, and a torn-down one still frees admission (#3983)."""
+
+    def test_the_ssh_transport_is_kept_alive_while_the_drain_waits(self) -> None:
+        # Three deploys died 276.8s / 280.0s / ~280s into the drain — a 3s spread is a
+        # fixed idle timeout, not a flaky link. Without keepalives the 1800s drain
+        # budget is unreachable: any wait on in-flight agents outlives the connection.
+        body = _DEPLOY_YML.read_text(encoding="utf-8")
+        match = re.search(r"ServerAliveInterval=(\d+)", body)
+        assert match is not None, "deploy.yml's ssh invocation must set ServerAliveInterval"
+        assert int(match.group(1)) * 2 < _OBSERVED_IDLE_TEARDOWN_SECONDS, (
+            "the keepalive cadence must leave room for a missed probe inside the observed idle window"
+        )
+        assert re.search(r"ServerAliveCountMax=(\d+)", body) is not None
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("sig", [signal.SIGHUP, signal.SIGPIPE, signal.SIGTERM, signal.SIGINT])
+    def test_a_torn_down_session_still_clears_the_stranded_gate(self, tmp_path: Path, sig: int) -> None:
+        # A dropped SSH session kills deploy.sh with one of these, mid-drain and long
+        # before the swap. Run deploy.sh's REAL fail-safe under each and prove it
+        # clears the gate — otherwise the still-live old worker admits nothing.
+        calls = _run_fail_safe_under_signal(tmp_path, sig, fail_safe=_fail_safe_block())
+
+        assert any("config_setting set worker_quiescing false" in call for call in calls), (
+            f"a deploy killed by {signal.Signals(sig).name} after its drain must free admission; docker calls={calls}"
+        )
+
+    @pytest.mark.integration
+    def test_the_signal_probe_detects_a_missing_fail_safe(self, tmp_path: Path) -> None:
+        # The control for the parametrised probe above: strip the trap and the same
+        # harness must record NO clear, so a green there is evidence and not an artifact.
+        without_trap = _fail_safe_block().replace(_FAIL_SAFE_END, "")
+        calls = _run_fail_safe_under_signal(tmp_path, signal.SIGHUP, fail_safe=without_trap)
+
+        assert calls == []


### PR DESCRIPTION
fix(deploy): heartbeat the worker drain and detect a stranded quiescing gate (#3983)

## What
The deploy dies mid-drain and leaves the factory admitting zero work, silently
and indefinitely.

- `t3 worker drain` now heartbeats to stderr (<=1 line/60s) while it waits. It
  previously printed nothing between its opening line and its verdict, so the
  deploy's SSH session looked idle for the whole wait. Three deploys died
  276.8s / 280.0s / ~280s in — a 3s spread is a fixed idle timeout, which makes
  the 1800s drain budget unreachable in practice.
- `deploy.yml`'s ssh gains ServerAliveInterval=30 / CountMax=20, so the
  transport is kept alive independently of what the remote prints.
- New self-heal detector `self_heal_quiescing.check_stranded_quiescing_gate`:
  hard-FAIL when `worker_quiescing` resolves ON past the widest window a live
  deploy could explain (drain grace + swap budget), or when no DB row can date
  it. Wired into `run_self_heal_checks`, so `t3 doctor check` reddens and the
  watchdog DMs the owner. It matches none of watchdog.sh's deploy-sensitive
  tokens, so it pages on sight — the convergence it reports has already died.
- `drain_worker` reads the in-flight set once per poll instead of twice
  (`active_claims` supersedes the `active_claim_exists` + re-query pair).

Proven RED: each regression test observed failing before its fix — the drain
progress samples empty, the CLI heartbeat absent, the aged-gate detector green.
The signal probe carries its own control (fail-safe stripped -> no clear
recorded), so its green is evidence rather than an artifact.

Open questions & assumptions
- (decided-by-evidence) The issue proposed also trapping the transport's fatal
  signals in deploy.sh, on the premise that bash runs no EXIT trap when killed
  by one. A probe with a control disproved that for bash: the EXIT trap runs on
  HUP, PIPE and TERM alike, and only SIGKILL escapes it. No signal traps were
  added — shipping them would have been a no-op dressed as a fix. The existing
  EXIT trap is now pinned by an integration test that runs deploy.sh's real
  fail-safe block under each of those signals.
- (assumed) The untrappable residue is SIGKILL — most plausibly systemd-logind
  reaping the SSH session's cgroup. Nothing in-process can cover it, so the
  doctor detector is the backstop for exactly that case.
- (assumed) A deploy's outside bound is TEATREE_DRAIN_TIMEOUT + 1200s of
  build/`up`/health-wait. The deploy job's own 50-minute ceiling matches the
  1800s default, so past that window no deploy can still be running.
- (assumed) `worker_quiescing` resolving ON with no DB row to date it (an env or
  file pin) FAILs rather than passing: it cannot be a live deploy, and a
  zero-admission factory must never be silent.
- (open) Detection is bounded by that budget, so a SIGKILLed deploy is surfaced
  within ~50 min rather than immediately. Making the gate a self-expiring lease
  at the admission chokepoint would close the residue entirely; out of scope
  here, since the issue asks for a doctor FAIL.
- (pre-existing, unrelated) test_intent_freshness_check.py's
  test_the_shipped_flag_makes_an_unmasked_loop_a_live_consumer fails on the base
  commit too (verified by stashing this diff), so it is not from here.

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.