### PR TITLE
fix(tests): pin the billing-cycle clock and mirror production's TIME_ZONE (#3996)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,8 +333,13 @@ skip = "src/teatree/core/static/teatree/js/*,src/teatree/dash/static/dash/js/*"
 # contribution) is enforced where it belongs, off the fast inner loop.
 
 [tool.pytest.ini_options]
+# ``--ds`` (not just the ``DJANGO_SETTINGS_MODULE`` ini key below) because pytest-django
+# ranks an ambient env var ABOVE the ini value: a shell exporting it — the dogfooding box
+# does — silently ran the whole suite against PRODUCTION settings, a different DB and a
+# different TIME_ZONE than CI (#3996). ``addopts`` is prepended, so the e2e lane's own
+# trailing ``--ds=e2e.dash.settings`` still wins.
 addopts = """
---color=yes --strict-config --strict-markers --reuse-db -n auto
+--color=yes --strict-config --strict-markers --reuse-db -n auto --ds=tests.django_settings
 """
 timeout = 60
 # Keep only a FAILING test's scratch — a passing one's tmp_path is nothing anyone

--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -16,6 +16,8 @@ The names re-exported below keep ``from teatree.loop.rendering import X``
 working for every existing consumer and test after the split.
 """
 
+import logging
+
 from django.utils import timezone
 
 from teatree.loop.dispatch import DispatchAction
@@ -40,6 +42,8 @@ __all__ = [
     "cost_chip_lines",
     "zones_for",
 ]
+
+logger = logging.getLogger(__name__)
 
 
 def zones_for(
@@ -171,5 +175,8 @@ def cost_chip_lines() -> list[str]:
             today=today,
         )
         return [report.chip()]
-    except Exception:  # noqa: BLE001 — rendering is best-effort; a failure degrades to no anchors
+    except Exception:
+        # Loud: a silent empty chip is indistinguishable from "no spend this cycle",
+        # so the swallowed cause has to be named or the next failure is a mystery.
+        logger.warning("cost chip read failed — statusline renders without it", exc_info=True)
         return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for teatree script tests."""
 
+import datetime as dt
 import importlib.util
 import json
 import os
@@ -8,7 +9,7 @@ import time
 import types
 from collections.abc import Iterator
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -87,6 +88,23 @@ def pg_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("POSTGRES_HOST", "localhost")
     monkeypatch.setenv("POSTGRES_USER", "testuser")
     monkeypatch.setenv("POSTGRES_PASSWORD", "testpass")
+
+
+#: A fixed instant, deliberately mid-cycle, for every billing-cycle-scoped assertion.
+#: A cycle-scoped reader filters ``started_at >= cycle_start(localdate())``, so a test
+#: that stamps its attempt from the wall clock and then lets the reader re-read the
+#: clock silently loses the attempt whenever the local date rolls onto a cycle start
+#: between the two reads — the #3996 shuffle-lane red, which hit whichever test was on
+#: the clock at that second. ``test_pinned_clock_sits_well_inside_its_cycle`` keeps this
+#: value away from either boundary.
+CYCLE_MIDPOINT = dt.datetime(2026, 6, 10, 12, 0, tzinfo=dt.UTC)
+
+
+@pytest.fixture
+def pinned_clock() -> Iterator[dt.datetime]:
+    """Pin ``timezone.now`` (and therefore ``localdate``) to :data:`CYCLE_MIDPOINT`."""
+    with patch("django.utils.timezone.now", return_value=CYCLE_MIDPOINT):
+        yield CYCLE_MIDPOINT
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,10 @@ import pytest
 from tests._db_template import build_or_reuse_template, restore_from_template
 from tests._thread_db_sentinel import ThreadDbHandleSentinel
 
-# Ensure unit tests use the settings declared in pyproject.toml, not a stale
-# DJANGO_SETTINGS_MODULE from the shell. pytest-django falls back to
-# pyproject.toml when the env var is absent.
+# Keep a stale shell DJANGO_SETTINGS_MODULE out of any SUBPROCESS a test spawns. The
+# suite's own settings are pinned by ``--ds`` in pyproject's addopts, because this pop
+# lands after pytest-django has already resolved the module and so never stopped an
+# ambient value winning here (#3996).
 os.environ.pop("DJANGO_SETTINGS_MODULE", None)
 # Pin T3_OVERLAY_NAME to the in-repo overlay so tests stay deterministic even
 # when extra overlays are editable-installed for dogfooding (see #120). Tests

--- a/tests/django_settings.py
+++ b/tests/django_settings.py
@@ -4,6 +4,10 @@ import teatree
 
 SECRET_KEY = "teatree-tests"
 USE_TZ = True
+# Django's own default is ``America/Chicago``, so omitting this ran every date-boundary
+# assertion against a local midnight at 05:00/06:00 UTC — inside the window this repo's
+# CI actually runs in — while production resolves the same dates in UTC (#3996).
+TIME_ZONE = "UTC"
 ROOT_URLCONF = "teatree.urls"
 STATIC_URL = "/static/"
 

--- a/tests/teatree_core/management_commands/test_cost.py
+++ b/tests/teatree_core/management_commands/test_cost.py
@@ -12,8 +12,10 @@ from teatree.core.management.commands.cost import CostPayload
 from teatree.core.models import Session, Task, TaskAttempt
 from tests.factories import TicketFactory
 
+# ``pinned_clock``: the report is cycle-scoped, so a ``when=timezone.now()`` attempt falls
+# outside the cycle the command re-derives once the local date rolls over mid-test (#3996).
 # ast-grep-ignore: ac-django-no-pytest-django-db
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("pinned_clock")]
 
 
 def _call(*args: str, **kwargs: object) -> str:

--- a/tests/teatree_loop/test_statusline_cost_chip.py
+++ b/tests/teatree_loop/test_statusline_cost_chip.py
@@ -13,13 +13,18 @@ from pathlib import Path
 import pytest
 from django.utils import timezone
 
+from teatree.core.cost import cycle_start
 from teatree.core.models import Session, Task, TaskAttempt
 from teatree.loop.rendering import cost_chip_lines
 from teatree.loop.tick_freshness import _write_tick_meta
+from tests.conftest import CYCLE_MIDPOINT
 from tests.factories import TicketFactory
 
+# ``pinned_clock`` is not decoration: the chip filters on the cycle the READER derives
+# from ``localdate()``, so an attempt stamped from the wall clock disappears when the
+# local date rolls onto a cycle start between the stamp and the read (#3996).
 # ast-grep-ignore: ac-django-no-pytest-django-db
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("pinned_clock")]
 
 
 def _headless_attempt(task: Task, *, cost: float) -> TaskAttempt:
@@ -87,3 +92,42 @@ class TestCostChipInTickMeta:
         _write_tick_meta(started, target=statusline)
         meta = json.loads((tmp_path / "tick-meta.json").read_text(encoding="utf-8"))
         assert meta["rendered_at"] == int(started.timestamp())
+
+
+class TestChipAssertionsAreClockIndependent:
+    """The #3996 shuffle-lane red: a wall-clock race, not an order leak.
+
+    ``cost_chip_lines`` keeps attempts whose ``started_at`` is at or after the cycle
+    the READER derives from ``localdate()`` at read time. Excluding an attempt stamped
+    a hair before a cycle start is correct — it belongs to the previous cycle — so the
+    defect was never in production, it was these tests stamping from the wall clock and
+    then letting the reader re-read it. Under a shuffled order the seed only decided
+    which test was on the clock when the local date rolled over.
+    """
+
+    def setup_method(self) -> None:
+        self.ticket = TicketFactory()
+        self.session = Session.objects.create(ticket=self.ticket)
+        self.task = Task.objects.create(ticket=self.ticket, session=self.session)
+
+    def test_attempts_are_stamped_from_the_pinned_clock(self) -> None:
+        assert _headless_attempt(self.task, cost=1.0).started_at == CYCLE_MIDPOINT
+
+    def test_pinned_clock_sits_well_inside_its_cycle(self) -> None:
+        # A pin parked ON a boundary would re-open the race the pin exists to close:
+        # a sub-second read drift either side must not change the cycle.
+        today = timezone.localdate()
+        start = cycle_start(today)
+        assert start < today, f"reading {today}, not a mid-cycle pin — the pin was dropped or moved onto a boundary"
+        assert timezone.localtime(timezone.now()).hour not in {0, 23}
+
+    def test_an_attempt_before_the_cycle_start_is_excluded(self) -> None:
+        # The exclusion the flake surfaced, pinned deliberately: it is the intended
+        # month-boundary reset, not the bug.
+        start = timezone.make_aware(
+            dt.datetime.combine(cycle_start(timezone.localdate()), dt.time.min),
+            timezone.get_current_timezone(),
+        )
+        attempt = _headless_attempt(self.task, cost=48.0)
+        TaskAttempt.objects.filter(pk=attempt.pk).update(started_at=start - dt.timedelta(microseconds=1))
+        assert cost_chip_lines() == []

--- a/tests/teatree_loop/test_statusline_segments.py
+++ b/tests/teatree_loop/test_statusline_segments.py
@@ -20,8 +20,10 @@ from teatree.core.statusline_segment import StatuslineSegment
 from teatree.loop.tick_freshness import _write_tick_meta
 from tests.factories import TicketFactory
 
+# ``pinned_clock``: the cost segment is cycle-scoped, so a wall-clock stamp goes missing
+# when the local date rolls onto a cycle start mid-test (#3996).
 # ast-grep-ignore: ac-django-no-pytest-django-db
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.usefixtures("pinned_clock")]
 
 
 def _meta(tmp_path: Path) -> dict:

--- a/tests/test_dev_settings.py
+++ b/tests/test_dev_settings.py
@@ -34,6 +34,31 @@ def test_settings_importable():
     assert mod.STATIC_URL == "static/"
 
 
+class TestSuiteSettingsMirrorProduction:
+    """The suite must resolve dates in production's zone, and actually run on its own settings.
+
+    Django's global ``TIME_ZONE`` default is ``America/Chicago``, so omitting it from
+    ``tests/django_settings.py`` put every ``localdate()`` boundary at 05:00/06:00 UTC —
+    inside the window this repo's CI runs in — while production resolves them at 00:00
+    UTC. That is what turned a once-a-cycle rollover into a shuffle-lane red on an
+    unrelated PR (souliane/teatree#3996).
+    """
+
+    def test_timezone_matches_production(self) -> None:
+        prod = importlib.import_module("teatree.settings")
+        suite = importlib.import_module("tests.django_settings")
+        assert getattr(suite, "TIME_ZONE", None) == prod.TIME_ZONE
+        assert getattr(suite, "USE_TZ", None) is prod.USE_TZ
+
+    def test_the_active_settings_are_the_suite_settings(self) -> None:
+        # pytest-django ranks an ambient DJANGO_SETTINGS_MODULE above the ini key, so
+        # without the ``--ds`` in addopts a shell that exports it runs the whole suite
+        # against production settings — a different DB and a different TIME_ZONE.
+        from django.conf import settings  # noqa: PLC0415 — deferred: read the ACTIVE module, not an import-time copy
+
+        assert settings.SETTINGS_MODULE == "tests.django_settings"
+
+
 def test_discover_overlay_apps_skips_broken_entry_points():
     """Entry points that raise on load are silently skipped."""
     broken_ep = type("FakeEP", (), {"load": lambda self: (_ for _ in ()).throw(ImportError("boom"))})()


### PR DESCRIPTION
fix(tests): pin the billing-cycle clock and mirror production's TIME_ZONE (#3996)

## What
`test_meta_carries_period_labelled_chip` red'd the shuffle lane on an unrelated
PR with `IndexError: list index out of range` — `tick-meta.json`'s `segments`
was empty because the cost chip was silent.

Root cause is a wall-clock race, not an order leak:

- `cost_chip_lines` keeps attempts whose `started_at` is at or after the cycle
  the READER derives from `localdate()` at read time. The test stamped its
  attempt from the wall clock and then let the reader re-read it, so when the
  local date rolled onto a cycle start between the two, the attempt fell
  outside the freshly-computed cycle and the chip went silent. Production is
  right to exclude it — it belongs to the previous cycle.
- `tests/django_settings.py` never set `TIME_ZONE`, so the suite ran on
  Django's `America/Chicago` default while production runs UTC. That put the
  suite's local midnight at 05:00 UTC, inside the window this repo's CI runs
  in, instead of 00:00 UTC.
- The shuffle seed only decided which test was on the clock at that second.
  Evidence: CI run 30684782541 attempt 1, seed 1, failure at collection index
  3697; the log line covering it is stamped 05:00:04Z — 4s past local midnight
  in `America/Chicago`.

Changes:

- `tests/django_settings.py`: `TIME_ZONE = "UTC"`, mirroring production.
- `tests/conftest.py`: `CYCLE_MIDPOINT` + a `pinned_clock` fixture; every
  cycle-scoped cost test (statusline chip, statusline segments, `t3 cost`)
  now pins both the stamp and the read to one instant.
- `pyproject.toml`: `--ds=tests.django_settings` in `addopts`. pytest-django
  ranks an ambient `DJANGO_SETTINGS_MODULE` above the ini key, so a shell that
  exports it ran the whole suite against production settings — the existing
  conftest pop was too late to stop it. `addopts` is prepended, so the e2e
  lane's trailing `--ds=e2e.dash.settings` still wins.
- `cost_chip_lines` now logs the exception it swallows. Failing open is
  intended; doing it silently made an empty chip indistinguishable from "no
  spend this cycle", which is why this cost a full investigation.

Proven RED:

- The flake itself: with the two clock reads placed either side of a cycle
  start, HEAD's `test_meta_carries_period_labelled_chip` fails with the exact
  CI symptom, `IndexError: list index out of range`, plus two siblings.
- `test_timezone_matches_production` on HEAD: `assert None == 'UTC'`.
- `test_the_active_settings_are_the_suite_settings` with the env var exported
  and `--ds` removed: `assert 'teatree.settings' == 'tests.django_settings'`.
- `TestChipAssertionsAreClockIndependent` with the pin dropped: 2 failed.

Open questions & assumptions:

- No production defect exists here, so no test can be RED-pre/GREEN-post on
  `src/`: excluding a pre-boundary attempt is the intended cycle reset. The
  committed guards therefore pin the environment (TIME_ZONE parity, active
  settings module) and the pin itself; the flake's own RED is reproduced by
  the recorded command above rather than committed as a test. (assumed)
- `--ds` in `addopts` assumes nobody deliberately runs this suite against
  another settings module via the env var; a CLI `--ds` still overrides. (assumed)
- `CYCLE_MIDPOINT` assumes the calendar-month cycle (`billing_cycle_anchor_day`
  default 0). A test that sets a custom anchor must pick its own instant;
  `test_pinned_clock_sits_well_inside_its_cycle` guards the default. (assumed)
- Whether the remaining curated shuffle directories hold other wall-clock
  couplings of this shape is not established — only cycle-scoped cost readers
  were audited. (open)

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.