### PR TITLE
fix(gates): fail the banned-terms scan CLOSED on an unreadable term store (#4008)

### DIFF
--- a/scripts/hooks/check-banned-terms.sh
+++ b/scripts/hooks/check-banned-terms.sh
@@ -19,6 +19,9 @@
 # banned_terms row and no env) WARNS loud and exits 0 by default — an unset list
 # is not a banned-term violation on a dev/solo box (#3247); it exits 2 (fail
 # loud) only when banned_terms_required is set (a deployment that MUST scrub).
+# A store that could not be READ (locked, corrupt, table-less) is NOT an unset
+# list and exits 2 whatever banned_terms_required says: an errored read carries
+# no information about what the operator configured (#4008).
 #
 # This is a THIN wrapper: all matching is delegated to
 # ``teatree.hooks.banned_terms_cli`` (which uses ``teatree.hooks.term_match``),
@@ -30,8 +33,8 @@
 #
 # Exit-code contract (consumed by ``teatree.hooks.banned_terms_scanner`` and
 # prek): 0 = clean (incl. an unset list when banned_terms_required is off, #3247),
-# 1 = banned term found, 2 = the scanner COULD NOT RUN (or an unset list when
-# banned_terms_required is on).
+# 1 = banned term found, 2 = the scanner COULD NOT RUN, the term store could not
+# be READ, or an unset list when banned_terms_required is on.
 # A security gate that fails OPEN on a crash is the bug class: the codebase
 # requires Python >= 3.13, so under an old system ``python3`` the matcher
 # import crashes (PEP-604 unions) and exits 1 — colliding with "banned term

--- a/src/teatree/config/cold_db.py
+++ b/src/teatree/config/cold_db.py
@@ -135,11 +135,26 @@ def _execute_readonly(db: Path, query: str, parameters_bindings: tuple[object, .
 def fetch_one(db: Path, query: str, parameters_bindings: tuple[object, ...]) -> tuple[object, ...] | None:
     """Read-only single-row `query`; fails open to `None` on any error or a missing row.
 
-    The shared single-row fetch: `cold_reader._fetch_value_row` and `loop_status`
-    both read one row through it, collapsing the `_QUERY_ERROR` sentinel to `None`.
+    The shared single-row fetch, collapsing the `_QUERY_ERROR` sentinel to `None`.
+    """
+    return fetch_one_confirmed(db, query, parameters_bindings)[0]
+
+
+def fetch_one_confirmed(
+    db: Path, query: str, parameters_bindings: tuple[object, ...]
+) -> tuple[tuple[object, ...] | None, bool]:
+    """`(row, ran)` — the row, plus whether the read actually RAN.
+
+    `fetch_one`'s confirming sibling, for a caller that must tell a clean "no such row" from a
+    store it could not read at all (a locked DB, a corrupt file, an absent table). `fetch_one`
+    collapses both to `None`, which is right for a fail-open caller and exactly wrong for a
+    security gate: the banned-terms scanner read "no `banned_terms` row" out of a DB that was
+    merely busy, and opened (#4008). `ran` is `False` only when sqlite itself errored.
     """
     row = _execute_readonly(db, query, parameters_bindings)
-    return None if row is _QUERY_ERROR else cast("tuple[object, ...] | None", row)
+    if row is _QUERY_ERROR:
+        return (None, False)
+    return (cast("tuple[object, ...] | None", row), True)
 
 
 def fetch_all(db: Path, query: str, parameters_bindings: tuple[object, ...]) -> list[tuple[object, ...]]:

--- a/src/teatree/config/cold_hook_settings.py
+++ b/src/teatree/config/cold_hook_settings.py
@@ -62,6 +62,9 @@ COLD_HOOK_SETTINGS: dict[str, ColdHookSetting] = {
     "mcp_slack_write_gate_enabled": ColdHookSetting(_parse_strict_bool, default=True),
     "dispatch_quote_gate_on_task_create_enabled": ColdHookSetting(_parse_strict_bool, default=False),
     "banned_terms_gate_enabled": ColdHookSetting(_parse_strict_bool, default=True),
+    # Not a gate kill-switch: the banned-terms scanner's UNSET-list posture. False (the
+    # dev/solo default) warns and allows; True is the deployment that MUST scrub (#3247).
+    "banned_terms_required": ColdHookSetting(_parse_strict_bool, default=False),
     "orchestrator_boundary_agent_gate_enabled": ColdHookSetting(_parse_strict_bool, default=True),
     "out_of_band_merge_gate_enabled": ColdHookSetting(_parse_strict_bool, default=True),
     "standing_goal_stop_gate_enabled": ColdHookSetting(_parse_strict_bool, default=True),

--- a/src/teatree/config/cold_reader.py
+++ b/src/teatree/config/cold_reader.py
@@ -22,13 +22,15 @@ import json
 import os
 import sys
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
 from teatree.config import value_coercion
-from teatree.config.cold_db import canonical_config_db, fetch_one, loop_status, row_exists
+from teatree.config.cold_db import canonical_config_db, fetch_one_confirmed, loop_status, row_exists
 
 __all__ = [
+    "SettingRead",
     "bool_setting",
     "canonical_config_db",
     "int_setting",
@@ -38,6 +40,7 @@ __all__ = [
     "mapping_setting",
     "overlay_then_global",
     "read_setting",
+    "read_setting_confirmed",
     "row_exists",
     "str_setting",
 ]
@@ -45,13 +48,17 @@ __all__ = [
 _GLOBAL_SCOPE = ""
 
 
-def _fetch_value_row(db: Path, scope: str, key: str) -> tuple[object, ...] | None:
-    """Read the `(scope, key)` value row from `teatree_config_setting`, fail-open to `None`."""
-    return fetch_one(
-        db,
-        "SELECT value FROM teatree_config_setting WHERE scope=? AND key=?",
-        (scope, key),
-    )
+@dataclass(frozen=True)
+class SettingRead:
+    """One cold read's outcome: the decoded `value`, and whether the store could be READ.
+
+    `readable` is `False` only when sqlite itself errored. Confirmed ABSENCE — no DB file, no
+    row, an undecodable value — is `readable=True` with a `None` value: there was nothing to
+    read, which is a legitimate answer rather than a failure.
+    """
+
+    value: object | None
+    readable: bool
 
 
 def read_setting(
@@ -66,21 +73,45 @@ def read_setting(
     Fails open to `None` for every path: missing DB file, absent table (fresh
     install), locked DB (within `busy_timeout`), corrupt JSON, and a missing row.
     The open strategy (and the quiescent-WAL `immutable=1` fallback) lives in
-    `cold_db._execute_readonly`.
+    `cold_db._execute_readonly`. A caller that must NOT fail open reads through
+    `read_setting_confirmed`, of which this is the value half.
+    """
+    return read_setting_confirmed(key, scope=scope, env=env, db_path=db_path).value
+
+
+def read_setting_confirmed(
+    key: str,
+    *,
+    scope: str = _GLOBAL_SCOPE,
+    env: Mapping[str, str] = os.environ,
+    db_path: Path | None = None,
+) -> SettingRead:
+    """The `(scope, key)` read as a value PLUS whether the store was readable at all.
+
+    The one read both views share, so a fail-open caller and a fail-closed one can never
+    disagree about what the store said. Readability travels WITH the value rather than being
+    a second probe a caller runs afterwards: under the lock contention that motivated this
+    (#4008), a probe fired microseconds after the failed read can succeed and mask it.
     """
     db = db_path if db_path is not None else canonical_config_db(env=env)
     if not db.exists():
-        return None
-    row = _fetch_value_row(db, scope, key)
+        return SettingRead(None, readable=True)
+    row, ran = fetch_one_confirmed(
+        db,
+        "SELECT value FROM teatree_config_setting WHERE scope=? AND key=?",
+        (scope, key),
+    )
+    if not ran:
+        return SettingRead(None, readable=False)
     if row is None:
-        return None
+        return SettingRead(None, readable=True)
     raw = row[0]
     if not isinstance(raw, str | bytes | bytearray):
-        return None
+        return SettingRead(None, readable=True)
     try:
-        return json.loads(raw)
+        return SettingRead(json.loads(raw), readable=True)
     except json.JSONDecodeError:
-        return None
+        return SettingRead(None, readable=True)
 
 
 def _read_chain(name: str, scope_chain: Sequence[str], *, db_path: Path | None) -> object | None:

--- a/src/teatree/config/defaults.toml
+++ b/src/teatree/config/defaults.toml
@@ -217,6 +217,7 @@ solo_repo_url_pattern = "" # regex matching repos the operator works on alone
 
 [teatree.Gates."Pre-Django hooks"]
 banned_terms_gate_enabled = true # run the banned-term scan before a publish
+banned_terms_required = false # refuse to scan when no banned-term list is configured, instead of warning
 completion_claim_gate_enabled = true # refuse a multi-deliverable completion claim carrying no evidence map
 config_overwrite_gate_enabled = true # refuse a blind overwrite of a config file that was not read first
 deny_circuit_breaker_enabled = true # pause dispatch after repeated classifier denials instead of retrying

--- a/src/teatree/config/schema.py
+++ b/src/teatree/config/schema.py
@@ -388,6 +388,7 @@ class TeatreeSettingsSchema(BaseSettings):
 
     # --- COLD_HOOK_SETTINGS (pre-Django hook gate flags) ---
     banned_terms_gate_enabled: Annotated[bool, BeforeValidator(_parse_strict_bool), _DEFAULT_COLD_HOOK]
+    banned_terms_required: Annotated[bool, BeforeValidator(_parse_strict_bool), _DEFAULT_COLD_HOOK]
     completion_claim_gate_enabled: Annotated[bool, BeforeValidator(_parse_strict_bool), _DEFAULT_COLD_HOOK]
     config_overwrite_gate_enabled: Annotated[bool, BeforeValidator(_parse_strict_bool), _DEFAULT_COLD_HOOK]
     deny_circuit_breaker_enabled: Annotated[bool, BeforeValidator(_parse_strict_bool), _DEFAULT_COLD_HOOK]

--- a/src/teatree/config/setting_help.py
+++ b/src/teatree/config/setting_help.py
@@ -66,6 +66,7 @@ SETTING_HELP: dict[str, str] = {
     "banned_terms": "terms refused in anything published to a public surface",
     "banned_terms_allowlist": "phrases exempted from the banned-term scan despite matching a term",
     "banned_terms_gate_enabled": "run the banned-term scan before a publish",
+    "banned_terms_required": "refuse to scan when no banned-term list is configured, instead of warning",
     "billing_cycle_anchor_day": "day of the month the subscription's usage window resets",
     "boost_concurrency": "extra concurrent units allowed while the box is in boost",
     "bulk_close_threshold": "how many closes in one run count as a bulk action needing approval",

--- a/src/teatree/core/gates/privacy_gate.py
+++ b/src/teatree/core/gates/privacy_gate.py
@@ -262,17 +262,21 @@ def _db_banned_terms() -> tuple[str, ...] | None:
         (``None``) only when ``banned_terms_required``, else the dev/solo no-op (``()``);
     * any OTHER read failure → fail CLOSED (``None``): an unreadable ban source
         must never silently degrade to "no terms" on a public target.
+
+    The unset-vs-fail-closed choice is :func:`resolve_unset_verdict`, the same disposition the
+    pre-commit scanner reports through, so the two gates cannot drift apart (#4008).
     """
     from teatree.hooks.banned_terms_cli import (  # noqa: PLC0415 — deferred hooks edge
-        banned_terms_required,
+        UnsetVerdict,
         resolve_banned_terms,
+        resolve_unset_verdict,
     )
     from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError  # noqa: PLC0415 — deferred hooks edge
 
     try:
         return resolve_banned_terms()
-    except BannedTermsUnsetError:
-        return None if banned_terms_required() else ()
+    except BannedTermsUnsetError as unset:
+        return () if resolve_unset_verdict(unset) is UnsetVerdict.ALLOW else None
     except Exception as exc:  # noqa: BLE001 — an unreadable ban source fails CLOSED, never scan-less.
         warn_throttled(
             logger,

--- a/src/teatree/hooks/banned_terms_cli.py
+++ b/src/teatree/hooks/banned_terms_cli.py
@@ -31,7 +31,10 @@ unset list is not a banned-term violation on a dev/solo box (#3247).
 value) AND ``banned_terms_required`` is True — a deployment that MUST scrub
 customer names keeps the fail-LOUD behaviour (an unset list is indistinguishable
 from a load bug). An explicit ``banned_terms = []`` is the deliberate no-op
-(exit 0), not an unset.
+(exit 0), not an unset. Also exit 2, whatever ``banned_terms_required`` says,
+when the store could not be READ at all (``BannedTermsUnreadableError``): a
+locked or corrupt DB says nothing about what the operator configured, and reading
+that silence as "unset" is what let a busy DB open the gate (#4008).
 
 The email carve-out lives in ``term_match`` so it, too, is shared rather than
 duplicated.
@@ -50,10 +53,11 @@ term is still caught before it leaves the machine.
 import argparse
 import os
 import sys
+from enum import StrEnum
 from pathlib import Path
 
 from teatree.config import cold_reader
-from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError
+from teatree.hooks.banned_terms_tree_scan import BannedTermsUnreadableError, BannedTermsUnsetError
 from teatree.hooks.term_match import file_matches as _file_matches
 from teatree.hooks.term_match import line_matches, matched_term, strip_emails
 from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
@@ -82,6 +86,14 @@ _TERMS_REQUIRED_ENV = "T3_BANNED_TERMS_REQUIRED"
 _TRUTHY_ENV = frozenset({"1", "true", "yes", "on"})
 
 
+class UnsetVerdict(StrEnum):
+    """What a term list that did not resolve means for the gate."""
+
+    ALLOW = "allow"
+    REQUIRED = "required"
+    UNREADABLE = "unreadable"
+
+
 def _db_array(key: str, db_path: Path | None) -> tuple[str, ...] | None:
     """Return the DB-home ``key`` list, or ``None`` when the row is genuinely UNSET.
 
@@ -92,11 +104,18 @@ def _db_array(key: str, db_path: Path | None) -> tuple[str, ...] | None:
     never ``None``. Reads the canonical ``ConfigSetting`` store via the
     Django-free :mod:`teatree.config.cold_reader`; *db_path* overrides the DB
     path (else the canonical DB / ``T3_CONFIG_DB``).
+
+    A store that could not be READ at all raises
+    :class:`BannedTermsUnreadableError` rather than returning the unset ``None``:
+    an errored read says nothing about what the operator configured, and reading
+    it as "unset" is what let a busy DB open the gate (#4008).
     """
-    raw = cold_reader.read_setting(key, db_path=db_path)
-    if not isinstance(raw, list):
+    read = cold_reader.read_setting_confirmed(key, db_path=db_path)
+    if not read.readable:
+        raise BannedTermsUnreadableError.for_store(key, _TERMS_ENV)
+    if not isinstance(read.value, list):
         return None
-    return tuple(str(e).strip() for e in raw if str(e).strip())
+    return tuple(str(e).strip() for e in read.value if str(e).strip())
 
 
 def resolve_banned_terms(
@@ -165,20 +184,34 @@ def _unset_warning() -> str:
     )
 
 
+def resolve_unset_verdict(exc: BannedTermsUnsetError, *, db_path: Path | None = None) -> UnsetVerdict:
+    """Why a term list that did not resolve allows or fails closed — the ONE shared disposition.
+
+    Both no-list gates read it — the pre-commit scanner (:func:`report_unset`) and the
+    publication gate (``privacy_gate._db_banned_terms``) — so they cannot drift into
+    disagreeing about when a missing list is safe. ``UNREADABLE`` is decided by the
+    exception's own type, since readability travelled with the failed read.
+    """
+    if isinstance(exc, BannedTermsUnreadableError):
+        return UnsetVerdict.UNREADABLE
+    return UnsetVerdict.REQUIRED if banned_terms_required(db_path=db_path) else UnsetVerdict.ALLOW
+
+
 def report_unset(exc: BannedTermsUnsetError, *, db_path: Path | None = None) -> int:
-    """Write the unset-list message and return the process exit code (#3247).
+    """Write the unresolved-list message and return the process exit code (#3247, #4008).
 
     An unset ``banned_terms`` list warns LOUD and returns 0 (the clean diff
     proceeds) UNLESS :func:`banned_terms_required` — then it keeps the fail-loud
     exit 2 (the ``exc`` message, indistinguishable from a load bug on a
-    deployment that must scrub). A CONFIGURED list is never routed here; it always
-    enforces (a real term still exits 1).
+    deployment that must scrub). A store that could not be READ fails closed the
+    same way whatever ``banned_terms_required`` says. A CONFIGURED list is never
+    routed here; it always enforces (a real term still exits 1).
     """
-    if banned_terms_required(db_path=db_path):
-        sys.stderr.write(f"{exc}\n")
-        return 2
-    sys.stderr.write(_unset_warning())
-    return 0
+    if resolve_unset_verdict(exc, db_path=db_path) is UnsetVerdict.ALLOW:
+        sys.stderr.write(_unset_warning())
+        return 0
+    sys.stderr.write(f"{exc}\n")
+    return 2
 
 
 def _load_allowlist(db_path: Path | None = None) -> tuple[str, ...]:

--- a/src/teatree/hooks/banned_terms_scanner.py
+++ b/src/teatree/hooks/banned_terms_scanner.py
@@ -317,9 +317,10 @@ def _run_shell_scanner(text: str, config_path: Path | None) -> str | None:
     try:
         # check-banned-terms.sh contract: exit 0 = clean, exit 1 = banned term
         # found (with a BANNED TERM report on stdout), exit 2 = the scanner
-        # could not run (an old interpreter / import crash) OR the term list is
-        # genuinely unset. Any other code is also a scanner failure. A failed
-        # scanner fails CLOSED, never ALLOW.
+        # could not run (an old interpreter / import crash), the term store could
+        # not be read, OR the term list is genuinely unset on a deployment that
+        # requires one. Any other code is also a scanner failure. A failed scanner
+        # fails CLOSED, never ALLOW.
         result = run_allowed_to_fail(
             [str(script), str(scan_file)],
             expected_codes=(0, 1),

--- a/src/teatree/hooks/banned_terms_tree_scan.py
+++ b/src/teatree/hooks/banned_terms_tree_scan.py
@@ -117,6 +117,25 @@ class BannedTermsUnsetError(RuntimeError):
         )
 
 
+class BannedTermsUnreadableError(BannedTermsUnsetError):
+    """The term list could not be READ — a locked, corrupt, or table-less config store.
+
+    Distinct from a genuinely-unset list, which a dev/solo box may legitimately warn-and-allow
+    on (#3247): an errored read carries no information about what the operator configured, so
+    it can only fail CLOSED. A SUBCLASS so every existing ``except BannedTermsUnsetError``
+    handler keeps catching it — the two differ only where the warn-and-allow disposition has
+    to choose (#4008).
+    """
+
+    @classmethod
+    def for_store(cls, key: str, env_var: str) -> "BannedTermsUnreadableError":
+        return cls(
+            f"{key} could not be READ from the config store (locked, corrupt, or missing its "
+            f"table) — indistinguishable from an unset list, so the scan fails CLOSED. Retry; "
+            f"if it persists, repair the store or supply ${env_var}."
+        )
+
+
 @dataclass(frozen=True)
 class TreeFinding:
     """A single banned-brand hit in a committed file."""

--- a/tests/config/test_cold_reader.py
+++ b/tests/config/test_cold_reader.py
@@ -101,6 +101,66 @@ class TestReadSettingFailsOpen:
             writer.close()
 
 
+class TestReadSettingConfirmed:
+    """`read_setting_confirmed` separates an ABSENT value from an UNREADABLE store (#4008).
+
+    `read_setting` collapses both to `None`, which is right for a caller that fails open — and
+    exactly wrong for a security gate, which read "no banned_terms row" out of a DB that was
+    merely locked and opened itself.
+    """
+
+    def test_present_value_is_readable(self, tmp_path: Path) -> None:
+        db = tmp_path / "db.sqlite3"
+        _make_db(db, [("", "mode", "auto")])
+        read = cold_reader.read_setting_confirmed("mode", db_path=db)
+        assert (read.value, read.readable) == ("auto", True)
+
+    def test_missing_db_file_is_readable_absence(self, tmp_path: Path) -> None:
+        # Nothing to read is CONFIRMED absence (a fresh/solo box), not a read failure.
+        read = cold_reader.read_setting_confirmed("mode", db_path=tmp_path / "nope.sqlite3")
+        assert (read.value, read.readable) == (None, True)
+
+    def test_missing_row_is_readable_absence(self, tmp_path: Path) -> None:
+        db = tmp_path / "db.sqlite3"
+        _make_db(db, [("", "mode", "auto")])
+        read = cold_reader.read_setting_confirmed("absent_key", db_path=db)
+        assert (read.value, read.readable) == (None, True)
+
+    def test_invalid_json_is_readable_absence(self, tmp_path: Path) -> None:
+        db = tmp_path / "db.sqlite3"
+        conn = sqlite3.connect(db)
+        conn.execute("CREATE TABLE teatree_config_setting (id INTEGER PRIMARY KEY, scope TEXT, key TEXT, value TEXT)")
+        conn.execute("INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', 'mode', '{not json')")
+        conn.commit()
+        conn.close()
+        read = cold_reader.read_setting_confirmed("mode", db_path=db)
+        assert (read.value, read.readable) == (None, True)
+
+    def test_missing_table_is_unreadable(self, tmp_path: Path) -> None:
+        db = tmp_path / "fresh.sqlite3"
+        sqlite3.connect(db).close()  # exists but has no teatree_config_setting table
+        assert cold_reader.read_setting_confirmed("mode", db_path=db).readable is False
+
+    def test_corrupt_file_is_unreadable(self, tmp_path: Path) -> None:
+        db = tmp_path / "corrupt.sqlite3"
+        db.write_bytes(b"this is not a sqlite database")
+        assert cold_reader.read_setting_confirmed("mode", db_path=db).readable is False
+
+    def test_locked_db_is_unreadable(self, tmp_path: Path) -> None:
+        # The #4008 field report: a busy writer makes a CONFIGURED list read as absent.
+        db = tmp_path / "db.sqlite3"
+        _make_db(db, [("", "banned_terms", ["acme"])])
+        writer = sqlite3.connect(db)
+        writer.isolation_level = None
+        writer.execute("BEGIN EXCLUSIVE")
+        try:
+            read = cold_reader.read_setting_confirmed("banned_terms", db_path=db)
+            assert (read.value, read.readable) == (None, False)
+        finally:
+            writer.rollback()
+            writer.close()
+
+
 class TestTypedWrappers:
     @pytest.fixture
     def db(self, tmp_path: Path) -> Path:

--- a/tests/config/test_remediation_advice_keys.py
+++ b/tests/config/test_remediation_advice_keys.py
@@ -1,0 +1,56 @@
+# test-path: cross-cutting
+"""Runtime advice naming ``config_setting set <key>`` must name a SETTABLE key (#4008).
+
+A gate that refuses an action and prints "fix it with
+``t3 <overlay> config_setting set <key> <value>``" is only useful if that command works. The
+banned-terms scanner printed exactly that advice for ``banned_terms_required`` — a key read
+straight from the ``ConfigSetting`` store but never registered in any config registry — so the CLI
+answered ``refusing: 'banned_terms_required' is not a known config setting`` and the operator had
+no way to follow the instruction at the moment it mattered.
+
+This is the whole class, not the one key: any in-code string that tells an operator to set a key
+is checked against :data:`ALL_KNOWN_CONFIG_SETTINGS`, the same union ``config_setting set``
+resolves key-ness through. Scoped to ``src/`` (the advice teatree EMITS at runtime); markdown
+docs are out of scope because they legitimately carry templated placeholders
+(``require_human_approval_to_*``) that name no single key.
+"""
+
+import re
+from pathlib import Path
+
+from teatree.config.known_settings import ALL_KNOWN_CONFIG_SETTINGS
+
+_SRC = Path(__file__).resolve().parents[2] / "src"
+
+# ``config_setting set <key>`` as it appears in an error/warning string, with or without the
+# ``t3 <overlay>`` prefix. A trailing ``<``/``*`` placeholder key is not captured — the character
+# class stops at the key's own name.
+_ADVICE = re.compile(r"config_setting set ([a-z][a-z0-9_]*)")
+
+
+def _advised_keys() -> dict[str, list[str]]:
+    """Every key named by a ``config_setting set`` instruction in ``src/``, → the files naming it."""
+    found: dict[str, list[str]] = {}
+    for module in _SRC.rglob("*.py"):
+        for key in _ADVICE.findall(module.read_text(encoding="utf-8")):
+            found.setdefault(key, []).append(str(module.relative_to(_SRC)))
+    return found
+
+
+def test_enumeration_is_not_vacuous() -> None:
+    # Guard the guard: a moved src tree or a broken regex must not let the coverage assertion
+    # below pass against an empty enumeration.
+    advised = _advised_keys()
+    assert _SRC.is_dir()
+    assert len(advised) >= 20
+    assert "banned_terms_required" in advised
+
+
+def test_every_advised_key_is_settable() -> None:
+    unsettable = {
+        key: sorted(set(files)) for key, files in _advised_keys().items() if key not in ALL_KNOWN_CONFIG_SETTINGS
+    }
+    assert not unsettable, (
+        f"advice names keys `config_setting set` refuses: {unsettable}. "
+        "Register each in the schema (and so in a config registry), or stop advising it."
+    )

--- a/tests/teatree_core/gates/test_privacy_gate_banned_terms_source.py
+++ b/tests/teatree_core/gates/test_privacy_gate_banned_terms_source.py
@@ -1,0 +1,48 @@
+"""The publication gate's banned-terms source fails CLOSED on an unreadable store (#4008).
+
+``_db_banned_terms`` feeds the PUBLIC-target scan vocabulary. Its unset disposition mirrors the
+shell scanner's: a genuinely-unset list is the dev/solo no-op (``()``), a deployment that MUST
+scrub gets ``None`` (fail closed). A store that could not be READ is neither — it is a broken
+control plane, and scanning a public body against no terms because sqlite was busy is the leak
+the gate exists to stop. Both gates now route through the ONE
+``banned_terms_cli.resolve_unset_verdict`` disposition, so they cannot diverge.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from teatree.core.gates.privacy_gate import _db_banned_terms
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_banned_terms_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+    monkeypatch.delenv("T3_BANNED_TERMS_REQUIRED", raising=False)
+
+
+def test_unreadable_store_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    corrupt = tmp_path / "corrupt.sqlite3"
+    corrupt.write_bytes(b"this is not a sqlite database")
+    monkeypatch.setenv("T3_CONFIG_DB", str(corrupt))
+    assert _db_banned_terms() is None
+
+
+def test_absent_store_is_the_dev_solo_no_op(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("T3_CONFIG_DB", str(tmp_path / "absent.sqlite3"))
+    assert _db_banned_terms() == ()
+
+
+def test_configured_list_is_returned(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "db.sqlite3"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "CREATE TABLE teatree_config_setting ("
+        "id INTEGER PRIMARY KEY, scope TEXT NOT NULL DEFAULT '', key TEXT NOT NULL, value TEXT NOT NULL)"
+    )
+    conn.execute("INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', 'banned_terms', '[\"acme\"]')")
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("T3_CONFIG_DB", str(db))
+    assert _db_banned_terms() == ("acme",)

--- a/tests/teatree_core/management/test_config_setting_command.py
+++ b/tests/teatree_core/management/test_config_setting_command.py
@@ -38,6 +38,12 @@ class TestConfigSettingSet(TestCase):
         assert ConfigSetting.objects.filter(key="issue_implementer_enabled").count() == 1
         assert ConfigSetting.objects.get_effective("issue_implementer_enabled") is False
 
+    def test_set_banned_terms_required(self) -> None:
+        # The exact command the banned-terms scanner's unset warning tells the operator to run.
+        # It was refused as an unknown key, so the only available behaviour was the fail-open (#4008).
+        call_command("config_setting", "set", "banned_terms_required", "true")
+        assert ConfigSetting.objects.get_effective("banned_terms_required") is True
+
     def test_set_string_value(self) -> None:
         call_command("config_setting", "set", "issue_implementer_label", '"ready"')
         assert ConfigSetting.objects.get_effective("issue_implementer_label") == "ready"

--- a/tests/teatree_hooks/test_banned_terms_cli.py
+++ b/tests/teatree_hooks/test_banned_terms_cli.py
@@ -19,14 +19,16 @@ from pathlib import Path
 import pytest
 
 from teatree.hooks.banned_terms_cli import (
+    UnsetVerdict,
     _diff_only_report,
     _full_file_report,
     banned_terms_required,
     main,
     report_unset,
     resolve_banned_terms,
+    resolve_unset_verdict,
 )
-from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError
+from teatree.hooks.banned_terms_tree_scan import BannedTermsUnreadableError, BannedTermsUnsetError
 
 _SYNTHETIC_TERMS = ("acme", "widget-margin")
 
@@ -200,6 +202,71 @@ class TestMainUnsetDisposition:
         offender = tmp_path / "leak.txt"
         offender.write_text("the acme deal closes friday\n", encoding="utf-8")
         assert main([str(offender)]) == 1
+
+
+def _corrupt_db(tmp_path: Path) -> Path:
+    """A store that EXISTS but every read of it errors — a locked/corrupt DB's signature."""
+    db = tmp_path / "corrupt.sqlite3"
+    db.write_bytes(b"this is not a sqlite database")
+    return db
+
+
+class TestUnreadableStoreFailsClosed:
+    """A store that could not be READ is not an unset list — it fails CLOSED regardless (#4008).
+
+    The field report: on a box where ``banned_terms`` IS configured, one invocation printed the
+    unset warning and exited 0 while the invocations either side of it read the full list and
+    correctly exited 1. A read that errors is indistinguishable from an absent row, so the
+    warn-and-allow disposition (#3247) opened the gate on a transient DB failure.
+    """
+
+    def _exc(self) -> BannedTermsUnsetError:
+        return BannedTermsUnsetError.for_key("banned_terms", "T3_BANNED_TERMS")
+
+    def test_resolve_raises_unreadable_not_plain_unset(self, tmp_path: Path) -> None:
+        with pytest.raises(BannedTermsUnreadableError):
+            resolve_banned_terms(db_path=_corrupt_db(tmp_path))
+
+    def test_report_unset_fails_closed_without_banned_terms_required(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # banned_terms_required is FALSE here (no row) — an unreadable store still fails closed.
+        exc = BannedTermsUnreadableError.for_store("banned_terms", "T3_BANNED_TERMS")
+        assert report_unset(exc, db_path=_corrupt_db(tmp_path)) == 2
+        assert "could not be READ" in capsys.readouterr().err
+
+    def test_verdict_is_unreadable_not_allow(self, tmp_path: Path) -> None:
+        unreadable = BannedTermsUnreadableError.for_store("banned_terms", "T3_BANNED_TERMS")
+        assert resolve_unset_verdict(unreadable, db_path=_corrupt_db(tmp_path)) is UnsetVerdict.UNREADABLE
+        assert resolve_unset_verdict(self._exc(), db_path=_empty_db(tmp_path)) is UnsetVerdict.ALLOW
+
+    def test_main_fails_closed_exit_2(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+        monkeypatch.setenv("T3_CONFIG_DB", str(_corrupt_db(tmp_path)))
+        assert main([]) == 2
+
+    def test_locked_store_fails_closed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The reported cause verbatim: a busy writer holding the DB while the hook reads.
+        monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+        db = _seed(tmp_path, ["acme"])
+        monkeypatch.setenv("T3_CONFIG_DB", str(db))
+        writer = sqlite3.connect(str(db))
+        writer.isolation_level = None
+        writer.execute("BEGIN EXCLUSIVE")
+        try:
+            assert main([]) == 2
+        finally:
+            writer.rollback()
+            writer.close()
+
+    def test_absent_store_still_warns_and_allows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The preserved #3247 case: nothing to read is CONFIRMED absence, not a read failure.
+        monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+        monkeypatch.setenv("T3_CONFIG_DB", str(tmp_path / "absent.sqlite3"))
+        assert main([]) == 0
+        assert "WARNING" in capsys.readouterr().err
 
 
 class TestOwnRepoUrlCarveOut:


### PR DESCRIPTION
fix(gates): fail the banned-terms scan CLOSED on an unreadable term store (#4008)

## What
Two defects, both of which left the fail-open as the only reachable behaviour.

1. `banned_terms_required` was readable but not SETTABLE. It is read straight
   from the ConfigSetting store by the scanner, but was in no config registry,
   so the very command the unset warning tells the operator to run —
   `t3 <overlay> config_setting set banned_terms_required true` — answered
   `refusing: 'banned_terms_required' is not a known config setting`.
   Registered as a COLD_HOOK setting (global scope, bool, in-code default
   false): schema, cold_hook_settings, setting_help, defaults.toml.

2. The scanner could not tell "no list configured" from "could not read the
   list", and allowed on both. Observed live on a box where the list IS
   configured: one invocation printed the unset warning and exited 0 while the
   invocations either side read the full list and exited 1 on a seeded term —
   a busy writer is indistinguishable from an absent row, and the gate opens.

   - cold_db.fetch_one_confirmed / cold_reader.read_setting_confirmed report
     the value PLUS whether sqlite actually ran. read_setting is now the value
     half of that one read, so every fail-open caller is unchanged.
   - BannedTermsUnreadableError (a BannedTermsUnsetError subclass, so every
     existing handler keeps catching it) carries readability WITH the failed
     read — not a second probe, which under lock contention can succeed
     microseconds later and mask the failure.
   - UnsetVerdict + resolve_unset_verdict is the one disposition both no-list
     gates read: the pre-commit scanner (exit 0 vs 2) and the publication gate
     (() vs None). They had duplicated the choice and could drift.

Preserved: term found -> 1; explicit [] -> 0; absent DB file, absent row, and
wrong-typed row -> warn + 0; required + unset -> 2. Only the errored read moves.

Enforcement: tests/config/test_remediation_advice_keys.py fails on any
`config_setting set <key>` advice in src/ naming a key the CLI would refuse —
the class the first defect belongs to, not just the one key.

Open questions & assumptions
- Ticket suggestion 3, "default banned_terms_required true once a non-empty
  list has ever existed": DECLINED (assumed). Fix 2 already fail-closes the
  reported scenario, and "has ever had" needs a durable marker whose staleness
  is its own lockout — an operator who deliberately clears the list could never
  get back to allow.
- An absent DB FILE stays warn-and-allow, only a sqlite ERROR fails closed
  (assumed). Nothing to read is confirmed absence — the #3247 dev/solo case.
- A missing `teatree_config_setting` table counts as unreadable (assumed).
  Migrations create it; a DB present without it is a broken store, and the
  ticket asks for a read that errored to fail closed regardless.
- A wrong-typed `banned_terms` row stays warn-and-allow (assumed): behaviour
  preserved, and write-validation makes it unreachable through the CLI.
- Whether the same fail-closed disposition should reach the export/migration
  paths that skip an unset source (`banned_term_registry`): OPEN, left alone —
  those are not gates and the subclass keeps their current behaviour.

Relates-to: https://github.com/souliane/teatree/issues/4008

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.