### PR TITLE
fix(gates): fail the publish-surface banned-terms gate closed on an unreadable store (#4008)

### DIFF
--- a/scripts/privacy_scan.py
+++ b/scripts/privacy_scan.py
@@ -27,7 +27,7 @@ from rich.table import Table
 
 from teatree.hooks.banned_term_registry import allowlist_terms
 from teatree.hooks.banned_terms_cli import resolve_banned_terms
-from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError
+from teatree.hooks.banned_terms_tree_scan import BannedTermsUnreadableError, BannedTermsUnsetError
 from teatree.hooks.opaque_id import find_opaque_ids
 from teatree.hooks.privacy_diff_comments import scan_diff as _scan_diff_comments
 from teatree.hooks.term_match import matched_term
@@ -102,9 +102,26 @@ def _resolve_scan_terms(env_value: str) -> tuple[str, ...]:
     detector is reported INERT on stderr — the other detectors still run, so the
     pre-push gate is never wedged — instead of going silently inert.
     ``banned_terms = []`` is the deliberate, silent opt-out.
+
+    A store that could not be READ at all (:class:`BannedTermsUnreadableError`,
+    locked/corrupt/table-less) is reported with its OWN distinct message rather
+    than the plain-unset wording — an errored read says nothing about whether the
+    operator configured a list, so conflating the two hid the real cause (#4008).
+    Both still leave this detector INERT: the sibling in-process
+    ``fast_push._banned_terms`` core-gate scan runs the same term list on the
+    same push and fails CLOSED on this exact exception, so a push is never
+    silently unscanned end to end.
     """
     try:
         return resolve_banned_terms(env_value=env_value)
+    except BannedTermsUnreadableError:
+        print(
+            "Privacy scan: WARNING — banned-terms detector INERT: the DB-home `banned_terms` "
+            "list could not be READ (locked, corrupt, or missing its table) — indistinguishable "
+            "from unset, so this detector sits out (the other detectors still run).",
+            file=sys.stderr,
+        )
+        return ()
     except BannedTermsUnsetError:
         print(
             "Privacy scan: WARNING — banned-terms detector INERT: the DB-home `banned_terms` "

--- a/src/teatree/hooks/banned_terms_cli.py
+++ b/src/teatree/hooks/banned_terms_cli.py
@@ -395,11 +395,13 @@ def main(argv: list[str]) -> int:  # pragma: no cover — CLI entry point (orche
     try:
         terms = resolve_banned_terms()
     except BannedTermsUnsetError as exc:
-        # The term list is genuinely UNSET (no banned_terms row AND no env). By
-        # default this WARNS loud and allows the commit (exit 0) — an unset list
-        # is not a banned-term violation on a dev/solo box (#3247). Only a
-        # deployment that set ``banned_terms_required`` keeps the fail-loud exit
-        # 2. An explicit ``banned_terms = []`` does not raise and is a no-op.
+        # A genuinely UNSET list (no banned_terms row AND no env) WARNS loud and
+        # allows the commit (exit 0) by default — an unset list is not a
+        # banned-term violation on a dev/solo box (#3247), unless the deployment
+        # set ``banned_terms_required``. A store that could not be READ at all
+        # (``BannedTermsUnreadableError``) fails CLOSED (exit 2) regardless of
+        # ``banned_terms_required`` (#4008) — see ``report_unset``. An explicit
+        # ``banned_terms = []`` does not raise and is a no-op.
         return report_unset(exc)
     if not terms:
         return 0  # explicit empty list ⇒ deliberate no-op

--- a/src/teatree/hooks/banned_terms_scanner.py
+++ b/src/teatree/hooks/banned_terms_scanner.py
@@ -47,6 +47,7 @@ from teatree.hooks._command_parser import is_publish_command as _is_publish_comm
 from teatree.hooks._command_parser import is_unavailable_body_source_sentinel as _is_unavailable_body_source_sentinel
 from teatree.hooks._hook_state import note_env_override_once
 from teatree.hooks._publish_detection import segment_word_lists_raw as _segment_word_lists_raw
+from teatree.hooks.banned_terms_tree_scan import BannedTermsUnreadableError
 from teatree.hooks.term_match import matched_term as _matched_token_term
 from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
 
@@ -109,6 +110,12 @@ def _banned_terms_configured(config_path: Path | None) -> bool:
     gate must still scan rather than silently no-op. *config_path* overrides the
     DB path (else the canonical DB / ``T3_CONFIG_DB``). A malformed registry
     propagates :class:`BannedTermsUnsetError` (fail-loud), never a silent no-op.
+
+    A legacy row that could not be READ at all (locked, corrupt, or missing its
+    table) raises :class:`BannedTermsUnreadableError` rather than resolving to
+    "not configured": an errored read is indistinguishable from an unset row, and
+    treating it as unset let a busy store open this publish-surface gate the same
+    way it opened the commit-only shell scanner (#4008).
     """
     from teatree.hooks.banned_term_registry import load_registry  # noqa: PLC0415  dual-read cycle
 
@@ -116,7 +123,10 @@ def _banned_terms_configured(config_path: Path | None) -> bool:
         return True
     if load_registry(db_path=config_path) is not None:
         return True
-    return isinstance(cold_reader.read_setting(_TERMS_KEY, db_path=config_path), list)
+    read = cold_reader.read_setting_confirmed(_TERMS_KEY, db_path=config_path)
+    if not read.readable:
+        raise BannedTermsUnreadableError.for_store(_TERMS_KEY, _TERMS_ENV)
+    return isinstance(read.value, list)
 
 
 def _scanner_script() -> Path:
@@ -278,6 +288,28 @@ def scan_text(text: str, *, config_path: Path | None = None) -> str | None:
     return _run_shell_scanner(text, config_path)
 
 
+def _configured_or_unreadable(config_path: Path | None) -> bool | None:
+    """``_banned_terms_configured``, or ``None`` when the legacy row could not be READ.
+
+    Isolated from :func:`_run_shell_scanner` so its own unreadable-store handling
+    does not add to that function's return-statement count. ``None`` is the
+    FAIL-CLOSED signal — a legacy row that errored on read (locked, corrupt, or
+    missing its table) is indistinguishable from unset, so it must never resolve
+    to ``False`` ("nothing configured"): that collapse is exactly what let a busy
+    store open this publish-surface gate the same way it opened the commit-only
+    shell scanner (#4008).
+    """
+    try:
+        return _banned_terms_configured(config_path)
+    except BannedTermsUnreadableError:
+        sys.stderr.write(
+            "[teatree] NOTE: banned-terms could not be READ from the config store while "
+            "resolving whether the gate is configured. Failing CLOSED rather than reporting "
+            "a clean scan — retry, or repair the store.\n"
+        )
+        return None
+
+
 def _run_shell_scanner(text: str, config_path: Path | None) -> str | None:
     """Delegate ``text`` to ``check-banned-terms.sh``; return the matched term, else ``None``.
 
@@ -286,13 +318,17 @@ def _run_shell_scanner(text: str, config_path: Path | None) -> str | None:
     configured, so there is nothing to scan. Returns
     :data:`SCANNER_UNAVAILABLE_MARKER` (the gate fails CLOSED) when the scanner
     could not run, INCLUDING a MISSING scanner script while banned-terms IS
-    configured (HLG-7): a missing script is a broken install, not a clean scan, so
-    it is failed loud + closed like a crashing interpreter (#1954) rather than
-    silently reporting clean. *config_path* overrides the DB path the shell scanner
-    reads (forwarded as ``T3_CONFIG_DB`` in the subprocess env).
+    configured (HLG-7), OR the legacy row could not be READ at all (#4008): both
+    are a broken install/store, not a clean scan, so both fail loud + closed like
+    a crashing interpreter (#1954) rather than silently reporting clean.
+    *config_path* overrides the DB path the shell scanner reads (forwarded as
+    ``T3_CONFIG_DB`` in the subprocess env).
     """
-    if not _banned_terms_configured(config_path):
-        return None
+    configured = _configured_or_unreadable(config_path)
+    if configured is not True:
+        # ``None`` (store unreadable) fails CLOSED; ``False`` (nothing configured)
+        # is the genuine no-op — one branch, so the return budget stays sane.
+        return SCANNER_UNAVAILABLE_MARKER if configured is None else None
     script = _scanner_script()
     if not script.is_file():
         # banned-terms IS configured (checked above) but the scanner script is

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -1377,6 +1377,46 @@ class TestScanTextScannerCrashFailsClosed:
         assert banned_terms_scanner.scan_text("ship to acmecorp", config_path=config) == "acmecorp"
 
 
+class TestUnreadableStoreFailsClosedOnThePublishSurface:
+    """A legacy row that could not be READ fails CLOSED here too, not just in the shell hook (#4008).
+
+    ``_banned_terms_configured`` used to read the legacy row through the fail-open
+    ``read_setting`` and collapse "sqlite errored" into "nothing configured" — a
+    corrupt/locked/table-less store made ``scan_text`` return ``None`` (the clean
+    no-op) instead of the ``SCANNER_UNAVAILABLE_MARKER``, on the exact surface
+    (``gh``/``glab`` posting) the shell-only fix in #4008 does not reach.
+    """
+
+    def _corrupt_db(self, tmp_path: Path) -> Path:
+        db = tmp_path / "corrupt.sqlite3"
+        db.write_bytes(b"this is not a sqlite database")
+        return db
+
+    def test_configured_check_raises_unreadable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+        monkeypatch.delenv("TEATREE_TERM_REGISTRY", raising=False)
+        with pytest.raises(banned_terms_scanner.BannedTermsUnreadableError):
+            banned_terms_scanner._banned_terms_configured(self._corrupt_db(tmp_path))
+
+    def test_scan_text_fails_closed_not_none(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+        monkeypatch.delenv("TEATREE_TERM_REGISTRY", raising=False)
+        assert (
+            banned_terms_scanner.scan_text("a perfectly ordinary line", config_path=self._corrupt_db(tmp_path))
+            == banned_terms_scanner.SCANNER_UNAVAILABLE_MARKER
+        )
+
+    def test_table_less_store_also_fails_closed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+        monkeypatch.delenv("TEATREE_TERM_REGISTRY", raising=False)
+        db = tmp_path / "notable.sqlite3"
+        sqlite3.connect(str(db)).close()
+        assert (
+            banned_terms_scanner.scan_text("a perfectly ordinary line", config_path=db)
+            == banned_terms_scanner.SCANNER_UNAVAILABLE_MARKER
+        )
+
+
 class TestMatchedTerm:
     def test_term_in_flagged_line_is_reported(self) -> None:
         report = "BANNED TERM in /tmp/x.txt:\n  1:ship to acmecorp\n\nBanned terms: acmecorp, widgetco\n"

--- a/tests/test_privacy_scan_script.py
+++ b/tests/test_privacy_scan_script.py
@@ -385,6 +385,19 @@ class TestPrivacyScanBannedTermsSource:
         assert result.returncode == 0, result.stdout + result.stderr
         assert "inert" not in result.stderr.lower()
 
+    def test_unreadable_store_reports_could_not_be_read_not_present_but_unset(self, tmp_path: Path) -> None:
+        # A store that could not be READ (locked/corrupt/table-less) is a DISTINCT
+        # cause from a genuinely-unset row — the message must say so, not reuse the
+        # plain-unset wording, else an operator debugging a busy DB is told the
+        # wrong thing (#4008). Still INERT (not a hard failure): the sibling
+        # in-process fast_push core-gate scan covers the same push.
+        corrupt_db = tmp_path / "corrupt.sqlite3"
+        corrupt_db.write_bytes(b"this is not a sqlite database")
+        result = _run_env("a perfectly ordinary line of prose\n", {"T3_CONFIG_DB": str(corrupt_db)})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "could not be read" in result.stderr.lower()
+        assert "present-but-unset" not in result.stderr.lower()
+
 
 class TestPrivacyScanAllowlistFromRegistry:
     """The company-identifier carve-out resolves through the registry ``allow`` class."""


### PR DESCRIPTION
## Follow-up to #4008 / #4011

PR #4011 fixed the commit-only shell scanner (`check-banned-terms.sh` / `banned_terms_cli.py`)
to fail CLOSED on an unreadable `banned_terms` store instead of collapsing it into the
genuinely-unset warn-and-allow path. Cold review of that PR found the same fail-open still
reachable on the non-commit posting surface: `banned_terms_scanner._banned_terms_configured`
resolved the legacy row through the fail-open `read_setting`, so `_run_shell_scanner` returned
the clean no-op instead of `SCANNER_UNAVAILABLE_MARKER` on a locked/corrupt/table-less store —
reopening the gate on `gh`/`glab` posting, the higher blast-radius surface.

This PR:
- Routes `_banned_terms_configured` through `read_setting_confirmed` and fails closed
  (`SCANNER_UNAVAILABLE_MARKER`) on an unreadable legacy row, mirroring the shell scanner.
- Distinguishes the unreadable-store case from a plain unset row in `privacy_scan.py`'s
  stderr message (was misreporting "present-but-unset" for a store that errored on read).
- Refreshes a stale comment in `banned_terms_cli.main`.

## Test plan

- New regression tests observed RED against the pre-fix code (stashed), GREEN after
  (`TestUnreadableStoreFailsClosedOnThePublishSurface`,
  `test_unreadable_store_reports_could_not_be_read_not_present_but_unset`).
- `uv run pytest tests/teatree_hooks/test_banned_terms_scanner.py tests/test_privacy_scan_script.py
  tests/teatree_hooks/test_banned_terms_cli.py tests/config` — 2124 passed.
- `t3 tool verify-gates` — exit 0 (commit + push stage).
