### PR TITLE
fix(config,agents): do not retry a deterministic override read, and name its caller (#3980)

### DIFF
--- a/src/teatree/agents/harness.py
+++ b/src/teatree/agents/harness.py
@@ -62,7 +62,7 @@ from teatree.agents.pydantic_ai_config import (
 )
 from teatree.agents.pydantic_ai_resume import persist_parked_thread, rehydrate_thread_for_resume
 from teatree.agents.pydantic_ai_session import PydanticAiHarnessSession
-from teatree.agents.regulated_path import assert_model_allowed_on_regulated_path
+from teatree.agents.regulated_path import RegulatedPathPolicy
 from teatree.config import AgentHarness, AgentHarnessProvider, get_effective_settings
 
 logger = logging.getLogger(__name__)
@@ -188,7 +188,7 @@ class PydanticAiHarness:
     :class:`~pydantic_ai.models.function.FunctionModel` doubles, with no network
     and no :class:`~teatree.llm.credentials.CredentialError` risk. A resolved
     model name is checked against the regulated-path allowlist policy
-    (:func:`~teatree.agents.regulated_path.assert_model_allowed_on_regulated_path`, #2887)
+    (:class:`~teatree.agents.regulated_path.RegulatedPathPolicy`, #2887)
     before it reaches the provider — a no-op unless the lane sets
     ``enforce_regulated_path``.
 
@@ -230,11 +230,12 @@ class PydanticAiHarness:
         self._phase = phase
         # The model-construction bundle (backend knobs + binding), resolved
         # SYNCHRONOUSLY by :func:`resolve_harness`. Absent → the defaults (router
-        # binding, factory lane, uncapped).
+        # binding, factory lane, uncapped, no pre-resolved regulated-path policy).
         cfg = config or PydanticAiModelConfig()
         self._backend = cfg.backend
         self._binding = cfg.binding
         self._max_tokens = cfg.max_tokens
+        self._regulated_path = cfg.regulated_path
 
     @property
     def history(self) -> "list[ModelMessage] | None":
@@ -268,7 +269,7 @@ class PydanticAiHarness:
         if self._model is not None:
             return self._model
         if self._binding is PydanticAiBinding.NATIVE_ANTHROPIC:
-            return resolve_native_anthropic_model(options)
+            return resolve_native_anthropic_model(options, self._regulated_path)
         # Normalise the resolved id to what the configured endpoint actually serves:
         # ``options.model`` is a teatree-abstract-tier default in Claude DASH-form
         # (the :data:`TIER_MODELS` form) an OpenAI-compatible provider does NOT carry, so it maps
@@ -281,7 +282,7 @@ class PydanticAiHarness:
         # the backend credential is absent. ``options.model`` catches both a bare
         # ineligible name and an explicit provider-prefixed pin (which passes through
         # normalisation unchanged); an absent pin falls back to the resolved id.
-        assert_model_allowed_on_regulated_path(options.model or model_name)
+        RegulatedPathPolicy.resolve(self._regulated_path).assert_allowed(options.model or model_name)
         return OpenAIChatModel(model_name, provider=build_openai_compatible_provider(self._backend))
 
     @asynccontextmanager
@@ -364,6 +365,7 @@ def _build_pydantic_ai_harness(context: HarnessBuildContext) -> Harness:
         config=PydanticAiModelConfig(
             binding=binding,
             max_tokens=settings.pydantic_ai_max_tokens,
+            regulated_path=RegulatedPathPolicy.from_settings(settings),
             backend=OpenAICompatibleLaneConfig(
                 lane=settings.openai_compatible_lane,
                 request_limit=settings.pydantic_ai_request_limit,

--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -145,10 +145,9 @@ def _run_headless_agent(
         logger.warning("Refusing dispatch for task %s: %s", task.pk, budget_breach)
         return _record_failure(task, error=budget_breach)
 
-    backend = _resolve_backend_or_failure(task, phase=phase)
-    if isinstance(backend, TaskAttempt):
-        return backend
-    harness = backend
+    harness = _resolve_backend_or_failure(task, phase=phase)
+    if isinstance(harness, TaskAttempt):
+        return harness
 
     # Resolve the overlay's stage skills ONCE and thread the list into every
     # consumer (#3206). Re-resolving per prompt builder re-warns on a
@@ -167,10 +166,9 @@ def _run_headless_agent(
     provider = resolve_dispatch_provider(task, phase=phase)
     lane = _resolve_dispatch_lane(harness, provider)
 
-    child_env_result = _admission_park_or_child_env(task, harness, provider, lane=lane, phase=phase)
-    if isinstance(child_env_result, TaskAttempt):
-        return child_env_result
-    child_env = child_env_result
+    child_env = _admission_park_or_child_env(task, harness, provider, lane=lane, phase=phase)
+    if isinstance(child_env, TaskAttempt):
+        return child_env
 
     prompt = build_task_prompt(task, skills=skills, stage_skills=stage_skills)
     system_context = build_system_context(
@@ -187,6 +185,11 @@ def _run_headless_agent(
         overrides=SpawnOverrides(env=child_env, turn_ceiling=_turn_ceiling(harness)),
     )
 
+    # Resolved HERE, not inside the coroutine (#3980): Django refuses a synchronous ORM read to a
+    # thread that owns a running event loop, and the config resolver catches that refusal and
+    # resolves the whole DB override tier as unreadable — so a ceiling read from inside
+    # ``asyncio.run`` silently returns shipped defaults on every dispatch instead of failing.
+    watchdog = LoopWatchdog.from_settings()
     try:
         # The quarantined reader (#116) also spawns inside ``reader_env_hermetic`` so its
         # ``os.environ`` is reduced to the allowlist: the SDK merges ``os.environ`` under
@@ -195,7 +198,7 @@ def _run_headless_agent(
         # suspenders). A no-op ``nullcontext`` for every non-reader phase.
         reader_scrub = reader_env_hermetic() if is_reader_phase(phase) else contextlib.nullcontext()
         with git_env_hermetic(), reader_scrub:
-            outcome = asyncio.run(_drive_with_heartbeat(task, prompt, options, harness))
+            outcome = asyncio.run(_drive_with_heartbeat(task, prompt, options, harness, watchdog=watchdog))
     except CredentialError as exc:
         # A non-ClaudeSdkHarness resolves its own credential lazily inside
         # ``harness.open`` — this is the same "fail loud, record it" contract
@@ -364,12 +367,13 @@ async def _drive_with_heartbeat(
     options: ClaudeAgentOptions,
     harness: Harness,
     *,
-    watchdog: LoopWatchdog | None = None,
+    watchdog: LoopWatchdog,
 ) -> HarnessOutcome:
-    """Run the agent in-process while sending lease heartbeats (#882, #997)."""
-    if watchdog is None:
-        watchdog = LoopWatchdog.from_settings()
+    """Run the agent in-process while sending lease heartbeats (#882, #997).
 
+    *watchdog* is REQUIRED rather than resolved here: its ceilings come from the DB-home config
+    tier, and this coroutine runs inside the event loop where that read is refused (#3980).
+    """
     # Sample accumulated deltas once before the run: prior-attempt totals are
     # static for this run. The read runs in a worker thread (so the event loop
     # is never blocked) that gets its OWN Django DB connection; close it in the

--- a/src/teatree/agents/pydantic_ai_config.py
+++ b/src/teatree/agents/pydantic_ai_config.py
@@ -21,7 +21,7 @@ from pydantic_ai.settings import ModelSettings
 from teatree.agents.harness_options import HarnessOptions
 from teatree.agents.harness_registry import HarnessCapabilities
 from teatree.agents.model_tiering import DEFAULT_TIER, resolve_tier
-from teatree.agents.regulated_path import assert_model_allowed_on_regulated_path
+from teatree.agents.regulated_path import RegulatedPathPolicy
 from teatree.llm.credentials import AnthropicApiKeyCredential
 from teatree.llm.openai_compatible import OpenAICompatibleCredential, resolve_openai_compatible_backend
 
@@ -133,6 +133,12 @@ class PydanticAiModelConfig:
         is a base ``ModelSettings`` key both bindings honour), so it lives here rather than on
         the router-only :class:`OpenAICompatibleLaneConfig`. Resolved SYNCHRONOUSLY by :func:`resolve_harness`
         from the ``pydantic_ai_max_tokens`` setting; ``None`` leaves the binding's own default.
+    *   ``regulated_path`` — the regulated-lane allowlist gate's policy, resolved SYNCHRONOUSLY by
+        :func:`resolve_harness` (:class:`~teatree.agents.regulated_path.RegulatedPathPolicy`, #3980).
+        Binding-agnostic for the same reason ``max_tokens`` is: both bindings gate their model id
+        through it. ``None`` means "not resolved here" and the gate reads the stored settings at
+        model-build time — the pre-#3980 behaviour, kept so a harness built without an explicit
+        policy still enforces what the operator stored.
 
     Prompt-cache breakpoints (the :class:`~teatree.agents.context_plan.ContextPlan`
     → ``cache_control`` path, #3157 E2) are NOT wired into the harness here: nothing
@@ -148,6 +154,7 @@ class PydanticAiModelConfig:
     backend: OpenAICompatibleLaneConfig = field(default_factory=OpenAICompatibleLaneConfig)
     binding: PydanticAiBinding = PydanticAiBinding.ROUTER
     max_tokens: int | None = None
+    regulated_path: RegulatedPathPolicy | None = None
 
 
 def native_anthropic_model_name(options: HarnessOptions) -> str:
@@ -165,7 +172,7 @@ def native_anthropic_model_name(options: HarnessOptions) -> str:
     return options.model or resolve_tier(DEFAULT_TIER)
 
 
-def resolve_native_anthropic_model(options: HarnessOptions) -> Model:
+def resolve_native_anthropic_model(options: HarnessOptions, regulated_path: RegulatedPathPolicy | None) -> Model:
     """Construct the direct Anthropic Messages-API model (#3157 E1b) — the cache_control path.
 
     The one branch that makes real ``cache_control`` reachable: a native ``pydantic_ai``
@@ -174,11 +181,12 @@ def resolve_native_anthropic_model(options: HarnessOptions) -> Model:
     dependency (``pydantic-ai-slim[anthropic]``); it is imported lazily so a router-only
     install never pays for it, and its absence fails LOUD with the install hint only when
     this binding is actually selected — the same late-fail contract the OpenAI-compatible
-    credential uses. The model id (:func:`native_anthropic_model_name`) is gated by the regulated-path
-    allowlist first.
+    credential uses. The model id (:func:`native_anthropic_model_name`) is gated by *regulated_path*
+    first — the policy resolved SYNCHRONOUSLY when the harness was built, never read here (this
+    runs inside the async event loop, where the settings read is refused, #3980).
     """
     model_name = native_anthropic_model_name(options)
-    assert_model_allowed_on_regulated_path(model_name)
+    RegulatedPathPolicy.resolve(regulated_path).assert_allowed(model_name)
     try:
         from pydantic_ai.models.anthropic import AnthropicModel  # noqa: PLC0415 — optional extra, imported lazily
         from pydantic_ai.providers.anthropic import AnthropicProvider  # noqa: PLC0415 — optional extra, imported lazily

--- a/src/teatree/agents/regulated_path.py
+++ b/src/teatree/agents/regulated_path.py
@@ -10,8 +10,9 @@ code. Consumed at the harness / eval boundary
 """
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
-from teatree.config import get_effective_settings
+from teatree.config import UserSettings, get_effective_settings
 
 
 def is_regulated_path_eligible(model_id: str, allowlist: Sequence[str]) -> bool:
@@ -72,3 +73,39 @@ def assert_model_allowed_on_regulated_path(
             "`t3 <overlay> config_setting set enforce_regulated_path false --overlay <name>`"
         )
         raise ValueError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class RegulatedPathPolicy:
+    """The gate's two settings, carried as a value so the read happens where it is legal (#3980).
+
+    A harness builds its model inside an ``async open``, and Django refuses a synchronous ORM
+    read to a thread that owns a running event loop; the config resolver catches that refusal
+    and resolves the whole DB override tier as unreadable. Read there, ``enforce_regulated_path``
+    would fall back to its shipped ``False`` and the lane would silently stop being restricted —
+    a gate that fails OPEN under an exception nothing raises. Resolving the policy where the
+    harness is BUILT (synchronously) is what keeps the operator's stored values load-bearing.
+    """
+
+    enforce: bool = False
+    allowlist: tuple[str, ...] = ()
+
+    @classmethod
+    def from_settings(cls, settings: UserSettings | None = None) -> "RegulatedPathPolicy":
+        """Resolve the policy from *settings*, or from the active scope's resolved settings."""
+        resolved = settings if settings is not None else get_effective_settings()
+        return cls(enforce=resolved.enforce_regulated_path, allowlist=tuple(resolved.regulated_path_model_allowlist))
+
+    @classmethod
+    def resolve(cls, policy: "RegulatedPathPolicy | None") -> "RegulatedPathPolicy":
+        """*policy* when a caller resolved one already, else a fresh read of the stored settings.
+
+        The fallback is what keeps the gate from silently narrowing: a harness built without an
+        explicit policy still enforces what the operator stored. Only the caller that resolves
+        the policy SYNCHRONOUSLY buys immunity from the async-frame read.
+        """
+        return policy if policy is not None else cls.from_settings()
+
+    def assert_allowed(self, model_id: str) -> None:
+        """Raise ``ValueError`` when *model_id* is ineligible under THIS resolved policy."""
+        assert_model_allowed_on_regulated_path(model_id, enforce_regulated_path=self.enforce, allowlist=self.allowlist)

--- a/src/teatree/cli/doctor/checks_cold_hooks.py
+++ b/src/teatree/cli/doctor/checks_cold_hooks.py
@@ -226,14 +226,19 @@ def _check_config_override_tier_healthy() -> bool:
         return True
     if report is None:
         return True
+    # The caller is what makes the record actionable (#3980): the deterministic fault this tier
+    # actually hit in production — a sync ORM read from inside an event loop — is settled by WHERE
+    # the read was made, and the traceback at the read holds only the ORM frames.
+    called_from = f" Called from: {'; '.join(report.callers)}." if report.callers else ""
     typer.echo(
         f"FAIL  The ConfigSetting override tier FAILED to read {report.occurrences} time(s) "
         f"(scopes: {', '.join(report.scopes)}; most recent {int(report.age_seconds)}s ago). While "
         "degraded, the autonomy/approval gates resolve to their most RESTRICTIVE value rather "
         "than your stored configuration, so the factory is running more conservatively than you "
-        "configured it to. Typical causes are SQLite lock contention against a large control DB, "
-        "an exhausted file-handle budget, or a full disk. Fix the underlying read fault; the "
-        "record clears itself once no further read fails for "
+        f"configured it to.{called_from} Typical causes are a config read reached from an async "
+        "frame (deterministic — fix the caller, not the DB), SQLite lock contention against a "
+        "large control DB, an exhausted file-handle budget, or a full disk. Fix the underlying "
+        "fault; the record clears itself once no further read fails for "
         f"{MARKER_TTL_SECONDS // 3600}h, or delete {marker_path()} to acknowledge it now."
     )
     return False

--- a/src/teatree/config/override_read_health.py
+++ b/src/teatree/config/override_read_health.py
@@ -61,6 +61,11 @@ MARKER_FILENAME = "config-read-degraded.json"
 #: Sized so a doctor run within the hour still surfaces an overnight degradation.
 MARKER_TTL_SECONDS = 24 * 60 * 60
 
+#: How many DISTINCT calling contexts the marker keeps. A degraded read repeats at whatever rate
+#: its caller runs at, so the record has to be bounded; the callers are what identifies the fault,
+#: and a handful is already more than one fix needs.
+MAX_RECORDED_CALLERS = 5
+
 
 class ConfigOverrideReadError(RuntimeError):
     """Raised where "I could not read the override tier" must NOT resolve to a value.
@@ -81,12 +86,19 @@ class ConfigOverrideReadError(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class DegradedReadReport:
-    """A live record that the ``ConfigSetting`` override tier failed to resolve."""
+    """A live record that the ``ConfigSetting`` override tier failed to resolve.
+
+    ``callers`` names the call sites the failing reads came from (#3980). The traceback the
+    reader captures holds only the ORM frames, which are identical for every fault; the caller
+    is the one fact that makes the record actionable, so it travels with it. Empty for a marker
+    written before the field existed.
+    """
 
     scopes: tuple[str, ...]
     occurrences: int
     first_seen: float
     last_seen: float
+    callers: tuple[str, ...] = ()
 
     @property
     def age_seconds(self) -> float:
@@ -106,8 +118,12 @@ def marker_path() -> Path:
     return ControlDb(os.environ).primary().parent / MARKER_FILENAME
 
 
-def record_degraded_read(scope: str) -> None:
+def record_degraded_read(scope: str, *, caller: str = "") -> None:
     """Record that *scope*'s override read failed, merging into any live marker.
+
+    *caller* is the calling context the reader identified (#3980); it merges the same way the
+    scopes do, capped at :data:`MAX_RECORDED_CALLERS` so a caller in a hot loop cannot grow the
+    file without bound.
 
     Never raises: the caller is a settings resolution that must still return a value, and
     a marker that cannot be written must not become a second outage. A write failure is
@@ -117,8 +133,10 @@ def record_degraded_read(scope: str) -> None:
     try:
         existing = _read_marker()
         scopes = tuple(sorted({*(existing.scopes if existing else ()), scope}))
+        seen_callers = {*(existing.callers if existing else ()), *([caller] if caller else [])}
         payload = {
             "scopes": list(scopes),
+            "callers": sorted(seen_callers)[:MAX_RECORDED_CALLERS],
             "occurrences": (existing.occurrences if existing else 0) + 1,
             "first_seen": existing.first_seen if existing else now,
             "last_seen": now,
@@ -166,6 +184,7 @@ def _read_marker() -> DegradedReadReport | None:
     occurrences = raw.get("occurrences")
     first_seen = raw.get("first_seen")
     last_seen = raw.get("last_seen")
+    callers = raw.get("callers")
     if not isinstance(scopes, list) or not isinstance(occurrences, int):
         return None
     if not isinstance(first_seen, int | float) or not isinstance(last_seen, int | float):
@@ -175,12 +194,14 @@ def _read_marker() -> DegradedReadReport | None:
         occurrences=occurrences,
         first_seen=float(first_seen),
         last_seen=float(last_seen),
+        callers=tuple(str(entry) for entry in callers) if isinstance(callers, list) else (),
     )
 
 
 __all__ = [
     "MARKER_FILENAME",
     "MARKER_TTL_SECONDS",
+    "MAX_RECORDED_CALLERS",
     "SAFETY_FAIL_CLOSED_STORED_VALUES",
     "ConfigOverrideReadError",
     "DegradedReadReport",

--- a/src/teatree/config/override_reader.py
+++ b/src/teatree/config/override_reader.py
@@ -19,6 +19,8 @@ call-time import.
 
 import logging
 import time
+import traceback
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from teatree.config.override_read_health import record_degraded_read
@@ -34,6 +36,13 @@ _logger = logging.getLogger("teatree.config")
 #: label carries no overlay NAME (the name goes in the log line instead).
 GLOBAL_SCOPE_LABEL = "global"
 OVERLAY_SCOPE_LABEL = "overlay"
+
+#: Frames of :func:`_calling_context`. One frame is often a memo shim or a settings helper that
+#: merely forwards; three reach the site that actually decided to read the config tier.
+_CALLER_FRAMES_NAMED = 3
+
+#: This package's directory — the frames :func:`_calling_context` walks PAST to find the caller.
+_PACKAGE_DIR = str(Path(__file__).parent)
 
 
 def _app_registry_ready() -> bool:
@@ -71,15 +80,51 @@ def _override_read_degrades_silently(exc: BaseException) -> bool:
     return False
 
 
+def _read_fault_is_deterministic(exc: BaseException) -> bool:
+    """Whether *exc* is settled by WHERE the read was made, so every attempt fails identically.
+
+    ``SynchronousOnlyOperation`` is Django refusing a synchronous ORM read to a thread that owns
+    a running event loop. That is a property of the CALL SITE, not of the database's state, so
+    the contention budget below cannot help: it adds its full backoff to a failure that was
+    certain, and dresses a programming error up as a flaky one.
+    """
+    from django.core.exceptions import SynchronousOnlyOperation  # noqa: PLC0415 — deferred: Django import at call time
+
+    return isinstance(exc, SynchronousOnlyOperation)
+
+
+def _calling_context() -> str:
+    """The nearest frames ABOVE this package — the call site that asked for the read.
+
+    The traceback captured at the read holds only the frames from here inward (the ORM call
+    chain), which is identical for every fault and names nothing an operator can act on. The
+    frame that settles it sits above :mod:`teatree.config`: for a deterministic fault it IS the
+    async frame. Innermost first, so the immediate caller leads.
+    """
+    outside = [frame for frame in traceback.extract_stack() if not frame.filename.startswith(_PACKAGE_DIR)]
+    named = reversed(outside[-_CALLER_FRAMES_NAMED:])
+    return " <- ".join(f"{Path(frame.filename).name}:{frame.lineno} in {frame.name}" for frame in named)
+
+
 # The loud SIGNAL for a non-bootstrap ``ConfigSetting`` read fault. Such a failure is a
 # fail-OPEN of the ENTIRE DB override tier — it drops the ``autonomy`` /
 # ``require_human_approval_to_merge`` safety gates back to the dataclass defaults — so it
 # is logged ``ERROR`` + traceback (the "raise or log-and-signal, not SILENTLY fail-open"
 # contract) rather than swallowed: operator error-monitoring surfaces the real fault.
 _OVERRIDE_READ_FAILURE_MSG = (
-    "ConfigSetting %s-scope override read FAILED unexpectedly — resolving with NO DB override tier for this "
-    "read (safety gates fall back to dataclass defaults). This is a real read fault, not a bootstrap no-op; "
-    "fix the DB/read error."
+    "ConfigSetting %s-scope override read FAILED unexpectedly, called from %s — resolving with NO DB override "
+    "tier for this read (safety gates fall back to dataclass defaults). This is a real read fault, not a "
+    "bootstrap no-op; fix the DB/read error."
+)
+
+# The DETERMINISTIC counterpart. Same consequence, opposite remedy: nothing about the database
+# is wrong, so pointing the operator at the DB wastes the one line they read. The caller is the
+# fault, and naming it is the whole point — the ORM frames in the traceback never do.
+_DETERMINISTIC_READ_FAILURE_MSG = (
+    "ConfigSetting %s-scope override read is UNREACHABLE from its call site, called from %s — resolving with "
+    "NO DB override tier for this read (safety gates fall back to dataclass defaults). This fault is "
+    "deterministic rather than contention, so it was NOT retried: fix the CALLER — hoist the settings read "
+    "out of the async frame, or run it in a worker thread."
 )
 
 
@@ -105,9 +150,11 @@ def _read_scope_rows(
 
     A genuine bootstrap state (:func:`_override_read_degrades_silently`) is neither retried
     nor reported — it is a no-op by construction, and retrying it would put the backoff on
-    every cold-start read. Any other exception is a real fault: retried while the budget
-    lasts, then logged loud (:data:`_OVERRIDE_READ_FAILURE_MSG`) and RECORDED where an
-    operator can see it without reading this log.
+    every cold-start read. A DETERMINISTIC fault (:func:`_read_fault_is_deterministic`) is
+    reported on its FIRST exception, since the budget can only delay it. Any other exception is
+    a real fault: retried while the budget lasts, then logged loud
+    (:data:`_OVERRIDE_READ_FAILURE_MSG`) and RECORDED where an operator can see it without
+    reading this log. Both loud paths name the CALLER (:func:`_calling_context`).
     """
     for attempt in range(_READ_ATTEMPTS):
         try:
@@ -115,9 +162,12 @@ def _read_scope_rows(
         except Exception as exc:
             if _override_read_degrades_silently(exc):
                 return {}, False
-            if attempt + 1 >= _READ_ATTEMPTS:
-                _logger.exception(_OVERRIDE_READ_FAILURE_MSG, log_label or scope_label)
-                record_degraded_read(scope_label)
+            deterministic = _read_fault_is_deterministic(exc)
+            if deterministic or attempt + 1 >= _READ_ATTEMPTS:
+                caller = _calling_context()
+                message = _DETERMINISTIC_READ_FAILURE_MSG if deterministic else _OVERRIDE_READ_FAILURE_MSG
+                _logger.exception(message, log_label or scope_label, caller)
+                record_degraded_read(scope_label, caller=caller)
                 return {}, True
             time.sleep(_READ_RETRY_BACKOFF[min(attempt, len(_READ_RETRY_BACKOFF) - 1)])
     return {}, True  # pragma: no cover — the loop always returns

--- a/tests/teatree_agents/test_async_frame_config_reads.py
+++ b/tests/teatree_agents/test_async_frame_config_reads.py
@@ -1,0 +1,97 @@
+"""No dispatch may read the ``ConfigSetting`` override tier from inside the event loop (#3980).
+
+Django refuses a synchronous ORM read from a thread that owns a running event loop
+(``SynchronousOnlyOperation``), and the config resolver catches that refusal and resolves the
+whole DB override tier as unreadable. So a settings read placed inside ``asyncio.run`` does not
+fail the dispatch — it silently drops every operator override for that read, and the factory runs
+to values nobody set. The two reads that did it were the per-dispatch watchdog ceiling and the
+regulated-path allowlist gate, both reachable on every headless run.
+
+Each case here drives the REAL async frame (``run_headless`` → ``asyncio.run``, and
+``PydanticAiHarness._resolve_model`` under a live loop) rather than asserting where a call sits,
+because "the read happens synchronously" is only interesting as the observable it buys: the
+override tier stays readable, and a stored policy still applies.
+"""
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+from pydantic_ai.models.test import TestModel
+
+import teatree.agents.headless as headless_mod
+from teatree.agents.harness import PydanticAiHarness, resolve_harness
+from teatree.agents.harness_options import HarnessOptions
+from teatree.agents.headless import TaskUsage, run_headless
+from teatree.config.override_read_health import degraded_read_report
+from teatree.core.models import ConfigSetting, Session, Task, Ticket
+
+_RESULT_ENVELOPE = '{"summary": "test summary", "files_modified": ["a.py"]}'
+
+
+async def _resolve_under_a_live_loop(harness: PydanticAiHarness, model: str) -> None:
+    """Resolve *model* from a frame that owns a running loop — where Django refuses ORM reads.
+
+    The ``await`` is the point: it proves the call below genuinely runs on the loop thread rather
+    than merely inside a coroutine object nobody drove.
+    """
+    await asyncio.sleep(0)
+    harness._resolve_model(HarnessOptions(model=model))
+
+
+class TestADispatchLeavesTheOverrideTierReadable(TestCase):
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create()
+        self.session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
+        self.task = Task.objects.create(ticket=self.ticket, session=self.session, phase="coding")
+        self.marker = Path(tempfile.mkdtemp()) / "config-read-degraded.json"
+        self.addCleanup(lambda: self.marker.unlink(missing_ok=True))
+
+    def test_running_a_dispatch_degrades_no_scope(self) -> None:
+        harness = PydanticAiHarness(model=TestModel(custom_output_text=_RESULT_ENVELOPE))
+        with (
+            patch("teatree.config.override_read_health.marker_path", return_value=self.marker),
+            patch.object(headless_mod, "resolve_harness", return_value=harness),
+            patch.object(headless_mod.TaskUsage, "for_task", classmethod(lambda cls, task: TaskUsage(0, 0.0))),
+        ):
+            attempt = run_headless(self.task, phase="coding", overlay_skill_metadata={})
+            report = degraded_read_report()
+
+        assert attempt.exit_code == 0
+        assert report is None, f"a config read reached an async frame, degrading {report and report.scopes}"
+
+
+class TestTheRegulatedPathGateStillSeesTheStoredPolicyUnderALiveLoop(TestCase):
+    """The gate reads two DB-home settings; the harness builds its model inside ``async open``.
+
+    Resolved there, a degraded read resolves ``enforce_regulated_path`` to its shipped ``False``
+    and the refusal never fires — an ineligible model runs on a lane the operator restricted.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _backend_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_COMPATIBLE_BASE_URL", "https://api.example.invalid/v1")
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "dummy-backend-test-value")
+
+    def setUp(self) -> None:
+        ConfigSetting.objects.set_value("agent_harness", "pydantic_ai")
+        ConfigSetting.objects.set_value("enforce_regulated_path", value=True)
+        ConfigSetting.objects.set_value("regulated_path_model_allowlist", ["anthropic/"])
+
+    def test_an_ineligible_model_is_still_refused_inside_the_event_loop(self) -> None:
+        with pytest.raises(ValueError, match="regulated path"):
+            asyncio.run(_resolve_under_a_live_loop(self._harness(), "vendor/ineligible-model"))
+
+    def test_an_eligible_model_is_not_refused(self) -> None:
+        # The foil: a policy resolved at build time must still ALLOW what the allowlist covers,
+        # or the fix would read as correct while refusing everything.
+        asyncio.run(_resolve_under_a_live_loop(self._harness(), "anthropic/claude-opus-5"))
+
+    @staticmethod
+    def _harness() -> PydanticAiHarness:
+        harness = resolve_harness()
+        assert isinstance(harness, PydanticAiHarness)
+        return harness

--- a/tests/teatree_agents/test_regulated_path.py
+++ b/tests/teatree_agents/test_regulated_path.py
@@ -7,7 +7,12 @@ resolution) into ``teatree.agents.regulated_path``. These pins mirror that move.
 import pytest
 from django.test import TestCase
 
-from teatree.agents.regulated_path import assert_model_allowed_on_regulated_path, is_regulated_path_eligible
+from teatree.agents.regulated_path import (
+    RegulatedPathPolicy,
+    assert_model_allowed_on_regulated_path,
+    is_regulated_path_eligible,
+)
+from teatree.config import UserSettings
 from teatree.core.models import ConfigSetting
 
 
@@ -68,3 +73,38 @@ class TestAssertModelAllowedDefaultSettings(TestCase):
         ConfigSetting.objects.set_value("enforce_regulated_path", value=True)
         ConfigSetting.objects.set_value("regulated_path_model_allowlist", value=["anthropic/", "claude"])
         assert_model_allowed_on_regulated_path("anthropic/claude-opus-4.8")
+
+
+class TestRegulatedPathPolicy(TestCase):
+    """The policy carried as a VALUE (#3980) — resolved once, applied where the read is illegal."""
+
+    def test_the_shipped_default_enforces_nothing(self) -> None:
+        RegulatedPathPolicy().assert_allowed("deepseek/deepseek-v4-pro")
+
+    def test_it_resolves_from_the_stored_settings(self) -> None:
+        ConfigSetting.objects.set_value("enforce_regulated_path", value=True)
+        ConfigSetting.objects.set_value("regulated_path_model_allowlist", value=["anthropic/"])
+        assert RegulatedPathPolicy.from_settings() == RegulatedPathPolicy(enforce=True, allowlist=("anthropic/",))
+
+    def test_supplied_settings_win_over_a_fresh_resolution(self) -> None:
+        # The dispatch path passes the settings it ALREADY resolved for the task's overlay scope,
+        # so the transport and the gate can never read two different scopes.
+        supplied = UserSettings(enforce_regulated_path=True, regulated_path_model_allowlist=["google/"])
+        assert RegulatedPathPolicy.from_settings(supplied) == RegulatedPathPolicy(enforce=True, allowlist=("google/",))
+
+    def test_a_resolved_policy_still_refuses_an_ineligible_model(self) -> None:
+        policy = RegulatedPathPolicy(enforce=True, allowlist=("anthropic/",))
+        with pytest.raises(ValueError, match="not eligible for the regulated path"):
+            policy.assert_allowed("deepseek/deepseek-v4-pro")
+
+    def test_resolve_keeps_a_supplied_policy(self) -> None:
+        supplied = RegulatedPathPolicy(enforce=True, allowlist=("google/",))
+        assert RegulatedPathPolicy.resolve(supplied) is supplied
+
+    def test_resolve_falls_back_to_the_stored_settings(self) -> None:
+        # Without this fallback an unresolved policy would silently STOP enforcing — a
+        # compliance gate narrowed by a construction detail.
+        ConfigSetting.objects.set_value("enforce_regulated_path", value=True)
+        ConfigSetting.objects.set_value("regulated_path_model_allowlist", value=["anthropic/"])
+        with pytest.raises(ValueError, match="not eligible for the regulated path"):
+            RegulatedPathPolicy.resolve(None).assert_allowed("deepseek/deepseek-v4-pro")

--- a/tests/teatree_cli/doctor/test_config_tier_health_check.py
+++ b/tests/teatree_cli/doctor/test_config_tier_health_check.py
@@ -38,6 +38,36 @@ class TestTheDegradedTierIsReported:
         assert "restrictive" in out.lower()
         assert "global" in out
 
+    def test_the_recorded_caller_is_named(self, tmp_path: Path, capsys) -> None:
+        # #3980: the fault this tier actually hit is deterministic — a sync ORM read from an
+        # async frame — so "which call site" is the whole diagnosis, and the traceback at the
+        # read never carries it.
+        marker = _marker(
+            tmp_path,
+            {
+                "scopes": ["global"],
+                "callers": ["headless.py:198 in _run_headless_agent"],
+                "occurrences": 4,
+                "first_seen": time.time(),
+                "last_seen": time.time(),
+            },
+        )
+        with mock.patch("teatree.config.override_read_health.marker_path", return_value=marker):
+            assert _check_config_override_tier_healthy() is False
+        out = capsys.readouterr().out
+        assert "headless.py:198 in _run_headless_agent" in out
+        assert "async frame" in out
+
+    def test_a_marker_without_callers_still_reports(self, tmp_path: Path, capsys) -> None:
+        # The foil: a marker written before the field existed must not break the surface.
+        marker = _marker(
+            tmp_path,
+            {"scopes": ["global"], "occurrences": 1, "first_seen": time.time(), "last_seen": time.time()},
+        )
+        with mock.patch("teatree.config.override_read_health.marker_path", return_value=marker):
+            assert _check_config_override_tier_healthy() is False
+        assert "Called from" not in capsys.readouterr().out
+
     def test_no_marker_passes_silently(self, tmp_path: Path, capsys) -> None:
         with mock.patch("teatree.config.override_read_health.marker_path", return_value=tmp_path / "absent.json"):
             assert _check_config_override_tier_healthy() is True

--- a/tests/teatree_config/test_override_read_degradation.py
+++ b/tests/teatree_config/test_override_read_degradation.py
@@ -19,13 +19,14 @@ from typing import Any
 from unittest import mock
 
 import pytest
-from django.core.exceptions import AppRegistryNotReady
+from django.core.exceptions import AppRegistryNotReady, SynchronousOnlyOperation
 from django.db.utils import OperationalError
 from django.test import TestCase
 
 from teatree.config import get_effective_settings
 from teatree.config.enums import Autonomy, Mode, OnBehalfPostMode
 from teatree.config.override_read_health import (
+    MAX_RECORDED_CALLERS,
     SAFETY_FAIL_CLOSED_STORED_VALUES,
     ConfigOverrideReadError,
     clear_degraded_read,
@@ -171,6 +172,75 @@ class TestATransientLockIsRetriedRatherThanDegradedStraightAway(TestCase):
             layers = read_setting_layers("")
         assert _GLOBAL in layers.degraded_scopes
         assert manager.calls < 10, "the retry budget is unbounded"
+
+
+class TestADeterministicFaultIsNotSpentOnTheContentionBudget(TestCase):
+    """#3980: the retry exists for CONTENTION; a deterministic fault must skip it entirely.
+
+    ``SynchronousOnlyOperation`` is a property of WHERE the read was called from, so it fails
+    identically on every attempt. Retrying it adds the full backoff to a failure that was
+    certain, and makes a programming error read like a flaky one.
+    """
+
+    def test_a_synchronous_only_operation_is_attempted_exactly_once(self) -> None:
+        patcher, manager = _with_failing_reads(SynchronousOnlyOperation("You cannot call this from an async context"))
+        with patcher:
+            layers = read_setting_layers("")
+        assert manager.calls == 1, "a deterministic fault was retried under the contention budget"
+        assert _GLOBAL in layers.degraded_scopes
+
+    def test_a_contended_read_still_spends_the_budget(self) -> None:
+        # The foil: narrowing the retry must not disarm it for the fault it was built for.
+        patcher, manager = _with_failing_reads(OperationalError("database is locked"))
+        with patcher:
+            read_setting_layers("")
+        assert manager.calls > 1, "the contention retry was disarmed"
+
+
+class TestTheRecordedFailureNamesTheCallingContext(TestCase):
+    """#3980: the traceback holds only the ORM frames, which is the same for every fault.
+
+    The one fact that makes the failure actionable — which call site read the config tier — is
+    ABOVE this module in the stack, so it has to be captured deliberately and recorded where an
+    operator reads it, not only in a log line nobody tails.
+    """
+
+    def test_the_marker_records_the_frame_that_asked_for_the_read(self) -> None:
+        patcher, _ = _with_failing_reads(SynchronousOnlyOperation("You cannot call this from an async context"))
+        with mock.patch("teatree.config.override_read_health.marker_path", return_value=self._tmp_marker()), patcher:
+            read_setting_layers("")
+            report = degraded_read_report()
+        assert report is not None
+        assert any(__name__.rsplit(".", 1)[-1] in caller for caller in report.callers), report.callers
+
+    def test_the_loud_log_names_the_caller_and_says_it_was_not_retried(self) -> None:
+        patcher, _ = _with_failing_reads(SynchronousOnlyOperation("You cannot call this from an async context"))
+        with (
+            mock.patch("teatree.config.override_read_health.marker_path", return_value=self._tmp_marker()),
+            patcher,
+            self.assertLogs("teatree.config", level="ERROR") as logs,
+        ):
+            read_setting_layers("")
+        message = "\n".join(logs.output)
+        assert __name__.rsplit(".", 1)[-1] in message
+        assert "not retried" in message.lower()
+
+    def test_the_recorded_callers_are_bounded(self) -> None:
+        # A degraded read repeats at whatever rate its caller runs at, so an unbounded record
+        # would grow the marker file for as long as the fault lasts.
+        tmp = self._tmp_marker()
+        with mock.patch("teatree.config.override_read_health.marker_path", return_value=tmp):
+            for index in range(MAX_RECORDED_CALLERS + 4):
+                record_degraded_read("global", caller=f"caller_{index}.py:1 in f")
+            report = degraded_read_report()
+        assert report is not None
+        assert len(report.callers) == MAX_RECORDED_CALLERS
+        assert report.occurrences == MAX_RECORDED_CALLERS + 4
+
+    def _tmp_marker(self) -> Path:
+        tmp = Path(tempfile.mkdtemp()) / "config-read-degraded.json"
+        self.addCleanup(lambda: tmp.unlink(missing_ok=True))
+        return tmp
 
 
 class TestTheDivergenceIsObservable(TestCase):


### PR DESCRIPTION
fix(config,agents): do not retry a deterministic override read, and name its caller (#3980)

## What
The ConfigSetting override-tier degradation on the worker was never lock
contention: every occurrence was SynchronousOnlyOperation — Django refusing a
synchronous ORM read to a thread that owns a running event loop. That is settled
by WHERE the read is made, so all three attempts failed identically and the
bounded retry only added its backoff before recording the tier degraded anyway.
A degraded tier drops the entire DB override tier for that read, so the factory
ran to values the operator never set, at a steady rate, with no load required.

- override_reader: classify a deterministic fault and degrade on its FIRST
  exception. The bootstrap-silent branch and the retried OperationalError /
  ProgrammingError contention branch are unchanged.
- override_reader: name the calling context. The traceback captured at the read
  holds only the ORM frames — identical for every fault — so the frames ABOVE
  teatree.config are walked and reported; the deterministic message points at
  the caller rather than at the DB.
- override_read_health / doctor: the marker carries the callers (bounded at 5)
  and the config-tier check names them, so the next occurrence is actionable
  without reconstructing the call site by hand.
- headless: LoopWatchdog.from_settings() ran INSIDE asyncio.run on every
  dispatch — the measured fault. Hoisted to the sync caller; watchdog is now a
  required argument, so the async frame cannot resolve it again.
- harness / pydantic_ai_config / regulated_path: the regulated-path allowlist
  gate read its two settings inside PydanticAiHarness.open, where a degraded
  read resolves enforce_regulated_path to its shipped False and the restricted
  lane silently stops being restricted. The policy is now resolved as a
  RegulatedPathPolicy at harness BUILD time and carried on PydanticAiModelConfig,
  the same shape OpenAICompatibleLaneConfig already uses.

The gate is not narrowed: PydanticAiModelConfig.regulated_path defaults to None
and RegulatedPathPolicy.resolve(None) falls back to reading the stored settings,
so a harness built without an explicit policy enforces exactly what it enforced
before. Only the synchronously-resolved production build path gains immunity
from the async-frame read.

Open questions & assumptions
- assumed: SynchronousOnlyOperation is the only deterministic read fault worth
  special-casing today; every other exception keeps the contention retry.
- assumed: three stack frames is the right width for the recorded caller. Proven
  on the real fault: frame 1 is the request_cache memo shim, frames 2-3 are
  headless_watchdog.from_settings and the async caller — one frame would have
  named only the shim.
- assumed: the marker caps distinct callers at 5; a degraded read repeats at its
  caller's rate, so the record has to be bounded, and a handful is more than one
  fix needs.
- decided-by-user (issue #3980): do not retry a deterministic fault, fix the
  async caller, and make the record name the caller.
- open: whether other lanes (eval, dream, ci-eval-heal) hold async-frame config
  reads. The two on the worker dispatch path are fixed and pinned by tests; the
  eval runner's model build was checked and is already synchronous.

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.