### PR TITLE
fix(agents): absorb an unverifiable worktree probe instead of discarding the run (#4016)

### DIFF
--- a/src/teatree/agents/attempt_recorder.py
+++ b/src/teatree/agents/attempt_recorder.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, cast
 from django.utils import timezone
 
 from teatree.agents.envelope_refusal import NO_ENVELOPE_ERROR
-from teatree.agents.landing_verification import landing_verification_error
+from teatree.agents.landing_verification import commits_ahead_or_unknown, landing_verification_error
 from teatree.agents.outage_classifier import outage_signature
 from teatree.agents.reactive_envelope_recorders import record_reactive_envelopes
 from teatree.agents.result_schema import RESULT_JSON_SCHEMA, AgentResultBlob, ReviewVerdictEnvelope, check_evidence
@@ -30,7 +30,6 @@ from teatree.core.gates.directive_interpret_gate import record_returned_directiv
 from teatree.core.modelkit.phases import normalize_phase
 from teatree.core.models import Finding, ReviewVerdict, ReviewVerdictError, Task, TaskAttempt, Worktree
 from teatree.core.models.auto_review_dispatch import LOOP_SCANNER_HOLDER
-from teatree.core.models.ticket_worktree_checks import worktree_has_commits_ahead
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError
 
@@ -366,9 +365,14 @@ def _salvage_coding_result(task: Task, result: AgentResultBlob, *, phase: str) -
 
 
 def _committed_file_changes(task: Task) -> list[dict[str, str]]:
-    """``files_modified`` entries for the first ticket worktree with a commit ahead, else ``[]``."""
+    """``files_modified`` entries for the first ticket worktree with a commit ahead, else ``[]``.
+
+    A worktree whose probe cannot answer is one nothing can be salvaged FROM, so
+    it is skipped like a commit-less one — never allowed to abort the scan before
+    it reaches the sibling that did land the work.
+    """
     for worktree in Worktree.objects.for_ticket(task.ticket):
-        if not worktree_has_commits_ahead(worktree):
+        if commits_ahead_or_unknown(worktree) is not True:
             continue
         paths = _committed_paths(worktree)
         if paths:
@@ -377,7 +381,7 @@ def _committed_file_changes(task: Task) -> list[dict[str, str]]:
 
 
 def _committed_paths(worktree: Worktree) -> list[str]:
-    # Reached only after ``worktree_has_commits_ahead`` proved a valid path + branch.
+    # Reached only after ``commits_ahead_or_unknown`` proved a valid path + branch.
     repo_path = (worktree.extra or {}).get("worktree_path") or worktree.repo_path
     base = _base_ref(repo_path)
     try:

--- a/src/teatree/agents/landing_verification.py
+++ b/src/teatree/agents/landing_verification.py
@@ -12,13 +12,25 @@ disk (a headless run with no checkout, a pre-provision task), there is nothing
 to verify, so the gate returns ``""`` and completion proceeds as before —
 "couldn't determine" is never "did not land" (the same posture as
 :func:`teatree.core.models.ticket_worktree_checks.worktree_tracked_dirty_path`).
+
+A worktree that IS on disk but whose commit-count probe cannot answer is the
+same fail-open case, reached by a different route. The probe raises
+``WorktreeProbeUnverifiableError`` there so its FSM consumer can hold the tick
+and retry; this gate runs *after* the agent finished, so it has no tick to hold
+— letting the error escape would record the completed run as a crash and throw
+its work away. UNKNOWN is therefore absorbed here: the gate refuses only when
+every checkable worktree is VERIFIABLY not ahead.
 """
 
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from teatree.core.modelkit.phases import normalize_phase
-from teatree.core.models.ticket_worktree_checks import worktree_has_commits_ahead, worktree_tracked_dirty_path
+from teatree.core.models.ticket_worktree_checks import (
+    WorktreeProbeUnverifiableError,
+    worktree_has_commits_ahead,
+    worktree_tracked_dirty_path,
+)
 from teatree.core.models.worktree import Worktree
 
 if TYPE_CHECKING:
@@ -33,9 +45,10 @@ def landing_verification_error(task: "Task", *, phase: str = "") -> str:
     """Return a ``landing_unverified:`` error if a coding/debugging result did not land, else ``""``.
 
     Refuses when a checkable ticket worktree has uncommitted tracked changes (the
-    files were edited but never committed) or no commit ahead of its base (HEAD
-    never advanced). A non-coding/debugging phase, or a ticket with no checkable
-    worktree, is a no-op (``""``).
+    files were edited but never committed) or every checkable worktree is
+    verifiably not ahead of its base (HEAD never advanced). A non-coding/debugging
+    phase, a ticket with no checkable worktree, or any worktree whose probe cannot
+    answer, is a no-op (``""``).
     """
     if normalize_phase(phase or task.phase) not in _LANDING_VERIFIED_PHASES:
         return ""
@@ -46,10 +59,25 @@ def landing_verification_error(task: "Task", *, phase: str = "") -> str:
         dirty_path = worktree_tracked_dirty_path(wt)
         if dirty_path is not None:
             return f"{_UNVERIFIED_PREFIX} uncommitted tracked changes in {dirty_path} — files_modified never committed"
-    if not any(worktree_has_commits_ahead(wt) for wt in checkable):
-        branch = checkable[0].branch or "(detached)"
-        return f"{_UNVERIFIED_PREFIX} no new commit on {branch} — HEAD has not advanced past the base"
-    return ""
+    if not all(commits_ahead_or_unknown(wt) is False for wt in checkable):
+        return ""
+    branch = checkable[0].branch or "(detached)"
+    return f"{_UNVERIFIED_PREFIX} no new commit on {branch} — HEAD has not advanced past the base"
+
+
+def commits_ahead_or_unknown(worktree: "Worktree") -> bool | None:
+    """Whether *worktree* has commits ahead, or ``None`` when its probe cannot answer.
+
+    The tri-state accessor for consumers that run after an agent has finished, so
+    they cannot hold the tick the raising probe is designed for. It lives here
+    rather than beside the probe deliberately: flattening UNKNOWN on the FSM path
+    is the #F1.4 defect that terminally abandons a live ticket, and a helper that
+    does it must not be within easy reach of that caller.
+    """
+    try:
+        return worktree_has_commits_ahead(worktree)
+    except WorktreeProbeUnverifiableError:
+        return None
 
 
 def _on_disk_repo(worktree: "Worktree") -> bool:

--- a/tests/teatree_agents/test_attempt_recorder.py
+++ b/tests/teatree_agents/test_attempt_recorder.py
@@ -193,6 +193,46 @@ class TestLandingVerifiedCompletion(TestCase):
         )
         return repo_dir
 
+    def _attach_unverifiable_worktree(self, ticket: Ticket) -> Path:
+        """Attach a checkout PRESENT on disk whose commit-count probe cannot answer.
+
+        A real directory that is not a git repository reproduces the venue-split
+        condition without a mock: ``git rev-list`` exits 128 there exactly as it
+        does for a checkout whose admin dir was written by another execution
+        context and is unreachable from this one.
+        """
+        repo_dir = self._tmp_path / f"unverifiable-{ticket.pk}"
+        repo_dir.mkdir()
+        Worktree.objects.create(
+            ticket=ticket,
+            repo_path=str(repo_dir),
+            branch=f"unverifiable-{ticket.pk}",
+            extra={"worktree_path": str(repo_dir)},
+        )
+        return repo_dir
+
+    def test_unverifiable_sibling_worktree_still_completes_a_landed_run(self) -> None:
+        # The recorder runs after the agent finished, so there is no tick left to
+        # hold: an unprobeable sibling must not crash it and discard the run.
+        task = self._claimed()
+        self._attach_unverifiable_worktree(task.ticket)
+        self._attach_worktree(task.ticket, commits_ahead=1)
+        record_result_envelope(
+            task,
+            {"summary": "done", "files_modified": [{"path": "f0.txt", "action": "created"}]},
+        )
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+
+    def test_salvage_skips_an_unverifiable_worktree(self) -> None:
+        task = self._claimed()
+        self._attach_unverifiable_worktree(task.ticket)
+        self._attach_worktree(task.ticket, commits_ahead=1)
+        attempt = record_result_envelope(task, {"summary": "committed in one repo, no envelope"})
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+        assert attempt.result.get("files_modified") == [{"path": "f0.txt", "action": "modified"}]
+
     def test_files_modified_without_commit_is_refused(self) -> None:
         task = self._claimed()
         self._attach_worktree(task.ticket, commits_ahead=0)

--- a/tests/teatree_agents/test_landing_verification.py
+++ b/tests/teatree_agents/test_landing_verification.py
@@ -41,6 +41,24 @@ class TestLandingVerification(TestCase):
         )
         return repo_dir
 
+    def _attach_unverifiable_worktree(self, ticket: Ticket) -> Path:
+        """Attach a checkout PRESENT on disk whose commit-count probe cannot answer.
+
+        A real directory that is not a git repository reproduces the venue-split
+        condition without a mock: ``git rev-list`` exits 128 there exactly as it
+        does for a checkout whose admin dir was written by another execution
+        context and is unreachable from this one.
+        """
+        repo_dir = self._tmp_path / f"unverifiable-{ticket.pk}"
+        repo_dir.mkdir()
+        Worktree.objects.create(
+            ticket=ticket,
+            repo_path=str(repo_dir),
+            branch=f"unverifiable-{ticket.pk}",
+            extra={"worktree_path": str(repo_dir)},
+        )
+        return repo_dir
+
     def test_commit_landed_and_clean_is_verified(self) -> None:
         task = self._task()
         self._attach_worktree(task.ticket, commits_ahead=1)
@@ -73,4 +91,23 @@ class TestLandingVerification(TestCase):
 
     def test_no_worktree_fails_open(self) -> None:
         task = self._task()
+        assert landing_verification_error(task) == ""
+
+    def test_unverifiable_probe_fails_open(self) -> None:
+        task = self._task()
+        self._attach_unverifiable_worktree(task.ticket)
+        assert landing_verification_error(task) == ""
+
+    def test_unverifiable_sibling_suppresses_the_no_commit_refusal(self) -> None:
+        # One worktree is verifiably commit-less, the other cannot be probed at
+        # all — so "nothing landed" is not proved and the gate must not refuse.
+        task = self._task()
+        self._attach_worktree(task.ticket, commits_ahead=0)
+        self._attach_unverifiable_worktree(task.ticket)
+        assert landing_verification_error(task) == ""
+
+    def test_unverifiable_sibling_does_not_mask_a_landed_commit(self) -> None:
+        task = self._task()
+        self._attach_unverifiable_worktree(task.ticket)
+        self._attach_worktree(task.ticket, commits_ahead=1)
         assert landing_verification_error(task) == ""


### PR DESCRIPTION
Closes [#4016](https://github.com/souliane/teatree/issues/4016).

## What

A **completed** headless `coding`/`debugging` run was recorded as `crash` (exit 1) and its result envelope discarded, whenever any of the ticket's registered worktrees was present on disk but its commit-count probe could not be verified.

`WorktreeProbeUnverifiableError` is raised in exactly one place and was caught in **zero** places across `src/`:

```
$ rg -n "WorktreeProbeUnverifiableError" src/
core/models/ticket_worktree_checks.py:25:  class WorktreeProbeUnverifiableError(RuntimeError):
core/models/ticket_worktree_checks.py:98:      raise WorktreeProbeUnverifiableError(msg) from exc
```

The typed error's intent — let a caller tell "could not verify" from "verified: nothing to ship" and **hold the tick** — is right, but no consumer implemented it. The two `agents/` consumers cannot hold a tick at all: they run *after* the agent finished, envelope in hand. There, the uncaught raise does the opposite of holding — it throws the work away.

`landing_verification.py`'s own module docstring already mandated the correct policy while the code contradicted it:

> Fail-open on the unverifiable: ... "couldn't determine" is never "did not land".

## Why it fires in practice

A linked checkout records its admin dir as an absolute path written by whichever execution context created it. Read from a context that reaches the owning clone elsewhere, `git rev-list` exits 128 with `fatal: not a git repository: <admin-dir>` — the venue-split condition of [#3912](https://github.com/souliane/teatree/issues/3912) / [#3853](https://github.com/souliane/teatree/issues/3853), where the settled doctrine is already **UNKNOWN is never a verdict**.

Not rare: **20+ registered worktrees** are in this state, so each of those tickets silently discards any coding run dispatched against it. One ticket burned three consecutive dispatches this way, every attempt dying at the same frame with no agent output.

## Changes — both scoped to `src/teatree/agents/`

- **`commits_ahead_or_unknown`** — tri-state accessor (`True` / `False` / `None`). Deliberately placed in `landing_verification` rather than beside the probe: flattening UNKNOWN on the FSM path is the #F1.4 defect that terminally abandons a live ticket, and a helper that does it must not be within easy reach of that caller.
- **`landing_verification_error`** refuses only when **every** checkable worktree is verifiably not ahead. Any UNKNOWN fails open.
- **`_committed_file_changes`** skips an unverifiable worktree like a commit-less one, so the scan reaches the sibling that did land the work.

## Behavior preservation

Deliberately unchanged, each still pinned by its existing test:

- `worktree_has_commits_ahead` still raises on a present-but-unverifiable checkout (`test_ticket_worktree_checks.py::test_raises_when_present_checkout_probe_fails`).
- `Ticket.has_shippable_diff` still propagates it (`test_ticket.py::test_raises_when_present_checkout_probe_is_unverifiable`) — there, raising **is** the hold, and the FSM transition correctly does not fire.
- The gate still refuses on verifiable non-landing: tracked-dirty path, and all-verifiable-none-ahead. **No must-block assertion was inverted or deleted.**

## Test evidence

Five new tests, observed **RED on the pre-fix code** with the exact production exception, then GREEN:

- pre-fix: `5 failed, 45 passed`
- post-fix: `50 passed`

The unverifiable state is reproduced with a real on-disk directory that is not a git repo — `git rev-list` exits 128 there exactly as in production — not a mock.

Full lane (`bash dev/test-affected.sh`, escalated to the whole tree by the `agents/` diff): **14100 passed, 10 failed**. All 10 reproduce identically on unmodified `origin/main` in a separate clone — `tests/cli_doctor/test_doctor_check_command.py` asserts against real host doctor state, and two others make live `gh` calls. None touch the changed modules.

## Architecture pre-check — [#4016](https://github.com/souliane/teatree/issues/4016)

**1. BLUEPRINT § alignment** — §17.1 invariant "no work-bearing state is terminal". A completed run whose commits exist but whose record is destroyed is precisely work stranded with no durable record; this restores the invariant at the recording chokepoint.

**2. FSM phase boundaries** — n/a to the change itself. It removes a crash *before* `task.complete` fires, so the coding-phase advance now happens where it already should have. No transition method or condition altered.

**3. Extension-point contracts** — none. No `OverlayBase` hook, scanner registration, or `*Backend` Protocol touched.

**4. Component boundaries** — both edits live in `src/teatree/agents/` (sub-agent dispatch + result recording), which is where the "agent already finished" policy belongs. `core/models/ticket_worktree_checks.py` is deliberately untouched so the raising primitive stays the single source of the UNKNOWN signal.

**5. Dependency direction** — no new cross-module import. `attempt_recorder` already imported from `landing_verification`; that edge is reused and one `core.models.ticket_worktree_checks` import is dropped. `tach` passed in the commit hooks.

**6. Test surface** — `tests/teatree_agents/test_landing_verification.py` (unverifiable-only fails open; unverifiable sibling suppresses the no-commit refusal; unverifiable sibling does not mask a landed commit) and `tests/teatree_agents/test_attempt_recorder.py` (a landed run with an unverifiable sibling records COMPLETED; salvage skips the unverifiable worktree). Each fails on the pre-fix code.

**7. Resilience invariants** — no new external write. This *repairs* one: the sub-agent return contract was being destroyed at the recording chokepoint, so a structured result never reached the orchestrator. Idempotency, heartbeat and fallback-transport are unaffected.

**8. Identity and key normalization** — n/a. No bare-vs-qualified identity; no strip/split introduced to make a comparison succeed.

**9. Behavior preservation / capability deletion** — see the section above. Nothing removed; the only semantic change is UNKNOWN no longer being read as "did not land". No privacy/leak/security matcher narrowed.

**10. Removability / harness-vs-data** — `commits_ahead_or_unknown` is a six-line module function with two call sites; deleting it reverts to the pre-change behaviour by inlining the raise back. This is harness, not data: a fixed policy about an error class, with nothing per-item to vary.

## Open questions & assumptions

- **(assumed)** Fail-open is right for the landing gate. It exists to catch a coder that did not commit; an unprobeable worktree is no evidence of that. Refusing on UNKNOWN would fail a completed run — the very damage being fixed.
- **(assumed)** `has_shippable_diff` is deliberately left raising. Its raise is a hold on an FSM path that *can* retry, and two tests pin it; changing it is a separate decision with a different blast radius.
- **(open)** The venue-split worktrees themselves are not repaired here. This stops them destroying agent work; it does not make their probes answerable. Reaper/doctor handling of those rows stays with [#3912](https://github.com/souliane/teatree/issues/3912) / [#3853](https://github.com/souliane/teatree/issues/3853).
- **(open)** The 10 environment-dependent failures above are pre-existing on `main` and out of scope here, but `tests/cli_doctor/test_doctor_check_command.py` asserting against real host doctor state is its own latent flakiness worth a ticket.
