### PR TITLE
fix(eval): a not-run regression corpus reports NOT VALIDATED, never a bare green (#4005)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1852,8 +1852,17 @@ Usage: t3 eval pinned-regressions [OPTIONS]
  pid-anchored loop lease, the migration-graph leaf count) on a must-block and
  a must-allow input. Any violated invariant exits non-zero.
 
+ ``--strict`` additionally demands a VALIDATED green (#4005), matching the
+ suite's
+ own ``t3 eval --strict``. The default stays lenient because the pre-push hook
+ runs
+ on the host, where the container-owned control DB is unreachable by design and
+ blocking every push there is the false red the skip exists to end.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --format        TEXT  Report format: text or json. [default: text]           │
+│ --strict              Also exit non-zero when a check could not run (a green │
+│                       with skips asserted nothing).                          │
 │ --help                Show this message and exit.                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/docs/testing-skill-evals.md
+++ b/docs/testing-skill-evals.md
@@ -146,6 +146,21 @@ t3 eval run --backend api --require-executed
 `--require-executed` makes an all-skipped run exit non-zero, so it can never pass
 green with zero coverage.
 
+The deterministic corpus has the same escape from a vacuous green
+([#4005](https://github.com/souliane/teatree/issues/4005)). A check the lane could not
+run is recorded `skipped` and still carries `ok=True`, so a topology fault (the
+container-owned control DB, unreachable from the host) never reddens the pre-push hook —
+which leaves `ok` alone unable to say whether the pins asserted anything. The report's
+second axis answers that: `validated` is true only when every check ran, the text summary
+says `NOT a validated green` otherwise, `render_json` emits it beside `ok`, and:
+
+```bash
+t3 eval pinned-regressions --strict   # non-zero unless every check actually ran
+```
+
+The default stays lenient for the host pre-push hook; `--strict` (like the suite's own
+`t3 eval --strict`) is for a caller that needs the pins to have asserted something.
+
 ## What CI does
 
 - **Model-free lanes — every PR.** `pinned-regressions` (prek hook)

--- a/src/teatree/cli/eval/all.py
+++ b/src/teatree/cli/eval/all.py
@@ -93,15 +93,14 @@ REGRESSION_SKIPPED_HINT = (
 
 
 def regression_lane(report: RegressionReport) -> LaneResult:
-    skipped = sum(1 for r in report.results if r.skipped)
-    detail = f"{len(report.results)} checks, {len(report.failures)} failed, {skipped} skipped"
+    detail = f"{len(report.results)} checks, {len(report.failures)} failed, {len(report.skipped)} skipped"
     return LaneResult(
         name="pinned-regressions",
         cost="model-free",
         passed=report.ok,
         skipped=False,
         detail=detail,
-        setup_hint=REGRESSION_SKIPPED_HINT if skipped > 0 else None,
+        setup_hint=None if report.validated else REGRESSION_SKIPPED_HINT,
     )
 
 

--- a/src/teatree/cli/eval/lanes.py
+++ b/src/teatree/cli/eval/lanes.py
@@ -49,6 +49,11 @@ def coverage(
 
 def pinned_regressions(
     output_format: str = typer.Option("text", "--format", help="Report format: text or json."),
+    strict: bool = typer.Option(  # noqa: FBT001 — typer boolean flag, not a positional bool foot-gun.
+        False,
+        "--strict",
+        help="Also exit non-zero when a check could not run (a green with skips asserted nothing).",
+    ),
 ) -> None:
     """Run the deterministic regression corpus over the real gate/checker code paths.
 
@@ -57,10 +62,15 @@ def pinned_regressions(
     bare-reference gate, the substrate-merge and maker≠checker floors, the
     pid-anchored loop lease, the migration-graph leaf count) on a must-block and
     a must-allow input. Any violated invariant exits non-zero.
+
+    ``--strict`` additionally demands a VALIDATED green (#4005), matching the suite's
+    own ``t3 eval --strict``. The default stays lenient because the pre-push hook runs
+    on the host, where the container-owned control DB is unreachable by design and
+    blocking every push there is the false red the skip exists to end.
     """
     ensure_django()
     require_valid_format(output_format)
     report = run_regression_corpus()
     typer.echo(render_regression_json(report) if output_format == "json" else render_regression_text(report))
-    if not report.ok:
+    if not report.ok or (strict and not report.validated):
         sys.exit(1)

--- a/src/teatree/eval/regression_corpus.py
+++ b/src/teatree/eval/regression_corpus.py
@@ -51,8 +51,7 @@ from teatree.eval.regression_corpus_predicates import (
     _check_ship_branch_reconcile_renamed,
 )
 from teatree.eval.regression_corpus_report import render_json, render_text
-from teatree.eval.regression_corpus_schema import schema_preflight_result
-from teatree.paths import DB_FILENAME, control_db_dir
+from teatree.eval.regression_corpus_schema import schema_preflight_result, skipped_preflight_result
 
 __all__ = [
     "CheckResult",
@@ -200,16 +199,6 @@ def _django_ready() -> bool:
     return apps.ready
 
 
-def _canonical_control_db_unreachable_reason() -> str | None:
-    """The topology answer for the CANONICAL control DB — this lane's DB-backed checks.
-
-    Every ``needs_db`` check queries the one control database, so the question this
-    lane asks is about that database specifically, named here rather than inferred
-    from whatever the process happens to be configured with.
-    """
-    return control_db_unreachable_reason(control_db_dir(os.environ) / DB_FILENAME, env=os.environ)
-
-
 def _configured_db_unreachable_reason() -> str | None:
     """Why this process cannot reach the database its DB-backed checks will actually query.
 
@@ -242,8 +231,11 @@ def run_regression_corpus(checks: tuple[RegressionCheck, ...] = _CHECKS) -> Regr
     # self-DB, which (for a worktree's auto-isolated copy) is a stale-schema
     # snapshot never migrated. Bring it current in-process before any ORM check
     # so a migration-adding PR can't red the pre-push lane with OperationalError.
-    if db_ready and unreachable is None and any(check.needs_db for check in checks):
-        results.append(schema_preflight_result())
+    # When it cannot run it is still REPORTED (#4005) — omitting the row is what let a
+    # failed migration pass silently, with nothing naming the pre-flight as not-run.
+    if any(check.needs_db for check in checks):
+        blocked = "Django not configured" if not db_ready else unreachable
+        results.append(schema_preflight_result() if blocked is None else skipped_preflight_result(blocked))
     for check in checks:
         if check.needs_db and not db_ready:
             results.append(CheckResult(check=check, ok=True, skipped=True, detail="Django not configured"))

--- a/src/teatree/eval/regression_corpus_models.py
+++ b/src/teatree/eval/regression_corpus_models.py
@@ -40,3 +40,18 @@ class RegressionReport:
     @property
     def failures(self) -> tuple[CheckResult, ...]:
         return tuple(r for r in self.results if not r.ok and not r.skipped)
+
+    @property
+    def skipped(self) -> tuple[CheckResult, ...]:
+        return tuple(r for r in self.results if r.skipped)
+
+    @property
+    def validated(self) -> bool:
+        """Every check actually ran — the axis ``ok`` deliberately cannot carry (#4005).
+
+        A skipped check reports ``ok=True`` so a topology fault never reddens the lane
+        (#4001), which leaves an all-skipped run indistinguishable from a real green to
+        anything reading ``ok`` alone. A caller that needs the pins to have asserted
+        something reads this instead.
+        """
+        return not self.skipped

--- a/src/teatree/eval/regression_corpus_report.py
+++ b/src/teatree/eval/regression_corpus_report.py
@@ -19,8 +19,10 @@ def render_text(report: RegressionReport) -> str:
             line += f" — {r.detail}"
         lines.append(line)
     passed = sum(1 for r in report.results if r.ok and not r.skipped)
-    skipped = sum(1 for r in report.results if r.skipped)
-    lines.append(f"\nsummary: {passed} passed, {len(report.failures)} failed, {skipped} skipped")
+    summary = f"summary: {passed} passed, {len(report.failures)} failed, {len(report.skipped)} skipped"
+    if not report.validated:
+        summary += " — NOT a validated green: the skipped checks asserted nothing"
+    lines.append(f"\n{summary}")
     return "\n".join(lines)
 
 
@@ -28,6 +30,7 @@ def render_json(report: RegressionReport) -> str:
     return json.dumps(
         {
             "ok": report.ok,
+            "validated": report.validated,
             "checks": [
                 {
                     "failure_class": r.check.failure_class,

--- a/src/teatree/eval/regression_corpus_schema.py
+++ b/src/teatree/eval/regression_corpus_schema.py
@@ -58,4 +58,15 @@ def schema_preflight_result() -> CheckResult:
     return CheckResult(check=SCHEMA_PREFLIGHT, ok=True, skipped=False, detail="")
 
 
-__all__ = ["SCHEMA_PREFLIGHT", "migrate_self_db", "schema_preflight_result"]
+def skipped_preflight_result(reason: str) -> CheckResult:
+    """Report the pre-flight as not-run without touching the database (#4005).
+
+    Omitting the row entirely is what made a failed migration pass *silently*: with no
+    row, neither a renderer nor a caller could tell the pre-flight had been meant to run
+    at all. Naming it as skipped costs nothing — building the row opens no connection, so
+    the topology guard still runs strictly before anything reaches the DB.
+    """
+    return CheckResult(check=SCHEMA_PREFLIGHT, ok=True, skipped=True, detail=reason)
+
+
+__all__ = ["SCHEMA_PREFLIGHT", "migrate_self_db", "schema_preflight_result", "skipped_preflight_result"]

--- a/tests/teatree_eval/test_regression_corpus_db_boundary_skip.py
+++ b/tests/teatree_eval/test_regression_corpus_db_boundary_skip.py
@@ -12,10 +12,13 @@ The fix is a SKIP with the reason named, not a bypass — so the tests below pin
 halves: the boundary fault does not redden the lane, AND nothing else got softer.
 """
 
+from unittest.mock import patch
+
 import pytest
 from django.db import connection
 
 from teatree.db.boundary import DbBoundaryError
+from teatree.eval import regression_corpus_schema
 from teatree.eval.regression_corpus import run_regression_corpus
 from teatree.eval.regression_corpus_models import RegressionCheck
 
@@ -109,16 +112,19 @@ class TestUnreachableControlDbSkipsBeforeThePreflight:
         report = run_regression_corpus((self._db_check(),))
         assert report.ok is True
         assert report.failures == ()
-        (result,) = report.results
+        (result,) = [r for r in report.results if r.check.failure_class == "probe"]
         assert result.skipped is True
         assert "container-only mount by design" in result.detail
 
-    def test_the_preflight_is_not_even_appended(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Proof the guard runs FIRST: no pre-flight row is produced at all, so
-        # nothing tried to open the database.
+    def test_the_preflight_never_opens_the_database(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Proof the guard runs FIRST. The pre-flight is REPORTED as skipped (#4005) so a
+        # reader can tell it was meant to run, but nothing tried to open the database.
         _host_pointed_at_the_container_only_db(monkeypatch)
-        report = run_regression_corpus((self._db_check(),))
-        assert len(report.results) == 1
+        with patch.object(regression_corpus_schema, "migrate_self_db") as migrate:
+            report = run_regression_corpus((self._db_check(),))
+        migrate.assert_not_called()
+        (preflight,) = [r for r in report.results if r.check is regression_corpus_schema.SCHEMA_PREFLIGHT]
+        assert preflight.skipped is True
 
     def test_a_non_db_check_still_runs_normally(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # The skip is scoped to DB-backed checks. The git/FSM checks that need no

--- a/tests/teatree_eval/test_regression_corpus_validated.py
+++ b/tests/teatree_eval/test_regression_corpus_validated.py
@@ -1,0 +1,131 @@
+"""A green with skips is reported as NOT VALIDATED, and can be made to exit non-zero.
+
+The skip half of the lane (souliane/teatree#4001) is deliberate: a topology fault is not
+an invariant violation, so a container-owned control DB must not redden the pre-push
+lane. What it left behind is souliane/teatree#4005 — a skipped check carries ``ok=True``,
+so ``report.ok`` and the lane's exit code read identically whether the pins asserted
+everything or nothing, and a caller consumes that green as truth.
+
+The resolution keeps ``ok`` meaning "no failures" (the #4001 pins stay green) and adds the
+missing second axis: ``validated`` says every check actually ran. The schema pre-flight is
+reported as a skipped row rather than silently omitted, so "a failed migration passes
+silently" becomes "the migration pre-flight is named as not-run".
+"""
+
+import json
+from contextlib import AbstractContextManager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.db import connection
+from typer.testing import CliRunner
+
+from teatree.cli import app
+from teatree.cli.eval.all import regression_lane
+from teatree.eval.regression_corpus import render_json, render_text, run_regression_corpus
+from teatree.eval.regression_corpus_models import CheckResult, RegressionCheck, RegressionReport
+
+_CONTAINER_ONLY_DIR = "/nonexistent/container-only/control-db"
+
+
+def _check(name: str = "probe", *, needs_db: bool = False) -> RegressionCheck:
+    return RegressionCheck(
+        failure_class=name,
+        origin="https://example.com/x",
+        invariant="probe",
+        predicate=lambda: True,
+        needs_db=needs_db,
+    )
+
+
+def _report(*results: CheckResult) -> RegressionReport:
+    return RegressionReport(results=results)
+
+
+def _ran(name: str = "probe") -> CheckResult:
+    return CheckResult(check=_check(name), ok=True, skipped=False, detail="")
+
+
+def _skipped(name: str = "probe") -> CheckResult:
+    return CheckResult(check=_check(name), ok=True, skipped=True, detail="container-only mount")
+
+
+def _corpus_returning(report: RegressionReport) -> AbstractContextManager[MagicMock]:
+    return patch("teatree.cli.eval.lanes.run_regression_corpus", return_value=report)
+
+
+def _host_pointed_at_the_container_only_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("T3_CONTROL_DB_DIR", _CONTAINER_ONLY_DIR)
+    monkeypatch.setitem(connection.settings_dict, "NAME", f"{_CONTAINER_ONLY_DIR}/db.sqlite3")
+
+
+class TestValidatedIsTheSecondAxis:
+    def test_a_fully_run_report_is_validated(self) -> None:
+        assert _report(_ran()).validated is True
+
+    def test_a_report_with_a_skip_is_green_but_not_validated(self) -> None:
+        report = _report(_ran("a"), _skipped("b"))
+        assert report.ok is True, "a topology skip must not redden the lane (#4001)"
+        assert report.validated is False
+
+    def test_skipped_exposes_the_checks_that_asserted_nothing(self) -> None:
+        assert [r.check.failure_class for r in _report(_ran("a"), _skipped("b")).skipped] == ["b"]
+
+
+class TestTheRenderersCarryTheDistinction:
+    def test_json_names_validated_alongside_ok(self) -> None:
+        payload = json.loads(render_json(_report(_ran("a"), _skipped("b"))))
+        assert payload["ok"] is True
+        assert payload["validated"] is False
+
+    def test_json_validated_is_true_for_a_fully_run_lane(self) -> None:
+        assert json.loads(render_json(_report(_ran())))["validated"] is True
+
+    def test_text_summary_says_a_skipped_run_is_not_a_validated_green(self) -> None:
+        assert "NOT a validated green" in render_text(_report(_ran("a"), _skipped("b")))
+
+    def test_text_summary_stays_quiet_when_everything_ran(self) -> None:
+        assert "NOT a validated green" not in render_text(_report(_ran()))
+
+
+class TestThePreflightIsNamedNotOmitted:
+    """The migrate pre-flight row must exist even when it could not run.
+
+    Its absence is what made "a failed migration passes silently" literal: with no row,
+    neither a renderer nor a caller could tell the pre-flight had been meant to run.
+    """
+
+    def test_an_unreachable_db_reports_the_preflight_as_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _host_pointed_at_the_container_only_db(monkeypatch)
+        report = run_regression_corpus((_check(needs_db=True),))
+        preflight = [r for r in report.results if "runtime-schema migration" in r.check.failure_class]
+        assert len(preflight) == 1, f"the pre-flight row must not vanish: {report.results}"
+        assert preflight[0].skipped is True
+        assert report.validated is False
+
+
+class TestStrictDemandsAValidatedGreen:
+    def test_default_exit_is_zero_so_the_host_pre_push_lane_still_passes(self) -> None:
+        # Preserved from #4001: the host cannot reach the container-owned DB, and blocking
+        # every push there is the false red the skip was introduced to end.
+        with _corpus_returning(_report(_ran("a"), _skipped("b"))):
+            result = CliRunner().invoke(app, ["eval", "pinned-regressions"])
+        assert result.exit_code == 0, result.output
+
+    def test_strict_exits_nonzero_when_a_check_could_not_run(self) -> None:
+        with _corpus_returning(_report(_ran("a"), _skipped("b"))):
+            result = CliRunner().invoke(app, ["eval", "pinned-regressions", "--strict"])
+        assert result.exit_code == 1, result.output
+
+    def test_strict_exits_zero_on_a_fully_run_green(self) -> None:
+        with _corpus_returning(_report(_ran())):
+            result = CliRunner().invoke(app, ["eval", "pinned-regressions", "--strict"])
+        assert result.exit_code == 0, result.output
+
+
+class TestTheSuiteLaneReadsTheSameAxis:
+    def test_a_skipped_report_is_flagged_as_needing_setup(self) -> None:
+        assert regression_lane(_report(_ran("a"), _skipped("b"))).needs_setup is True
+
+    def test_a_fully_run_report_needs_no_setup(self) -> None:
+        assert regression_lane(_report(_ran())).needs_setup is False


### PR DESCRIPTION
fix(eval): a not-run regression corpus reports NOT VALIDATED, never a bare green (#4005)

## What
A check the lane could not run is recorded `ok=True, skipped=True` so a topology fault
never reddens the pre-push hook (#4001). That left `report.ok`, the JSON `"ok"`, and the
exit code reading identically whether the pins asserted everything or nothing, and the
schema pre-flight row was omitted entirely when the DB was unreachable — so a failed
runtime-schema migrate was invisible rather than merely unproven.

Reproduced on 47f6691c8:
  T3_CONTROL_DB_DIR=/nonexistent/ci-like t3 eval pinned-regressions
  -> "8 passed, 0 failed, 6 skipped", exit 0, no pre-flight row at all.
After:
  -> "8 passed, 0 failed, 7 skipped - NOT a validated green: the skipped checks
     asserted nothing", exit 0 by default, exit 1 under --strict.

- `RegressionReport.skipped` / `.validated` — the second axis `ok` deliberately cannot
  carry. `ok` still means "no failures", so the #4001 pins stay green.
- The schema pre-flight is APPENDED as a skipped row instead of omitted. It still never
  opens the DB, which is the invariant the omission stood in for.
- `render_json` emits `validated` beside `ok`; the text summary names a not-validated run.
- `t3 eval pinned-regressions --strict` exits non-zero unless every check ran, matching
  the suite's own `t3 eval --strict`. The default stays lenient: the pre-push hook runs on
  the host, where the container-owned control DB is unreachable by design.
- `regression_lane` reads `report.validated` rather than recomputing the skip count.
- Deletes `_canonical_control_db_unreachable_reason` — dead since #4001's own fix pointed
  the runner at `_configured_db_unreachable_reason`.

Behaviour preservation: every skip path, reason string and `ok` semantic is unchanged; no
gate is narrowed and no must-block test is inverted. One #4001 pin asserted the pre-flight
row's ABSENCE (`len(results) == 1`) as a proxy for "nothing opened the DB"; it now asserts
that directly (`migrate_self_db` not called) plus the row's skip flag — strictly stronger.

Open questions & assumptions:
- decided-by-evidence: the issue's first claim (CI green having asserted nothing) was
  already fixed on main before #4001 merged — the runner reads the CONFIGURED DB, and both
  formerly-contradicting pin files are green at 47f6691c8. This addresses what remained.
- assumed: `ok` must keep meaning "no failures" rather than flip on a skip; the #4001
  boundary-skip pins encode that as a reviewed decision, so a second axis was added
  instead of inverting them.
- assumed: reporting the pre-flight as skipped beats omitting it; its absence is what made
  a failed migration silent rather than merely unproven.
- open: nothing in-repo passes `--strict` yet. The prek `eval-pinned-regressions` push
  hook is deliberately left lenient — flipping it would block every push from a host
  outside the container. Whether CI should gain a strict invocation is a maintainer call.
- open: naming. The AI lane spells this idea `--require-executed`; `--strict` was chosen to
  match the same lane's suite-level `t3 eval --strict`.

Closes #4005

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.

## Architecture pre-check — #4005

### 1. BLUEPRINT § alignment
§ "Behavioral eval harness (#1160)" (BLUEPRINT.md:795) — the free deterministic
regression-corpus lane. No contradiction: this adds an axis to the lane's report; it does
not move the lane or change what it grades.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition touched.

### 3. Extension-point contracts
`RegressionReport` is consumed by `regression_corpus_report` (both renderers),
`cli.eval.lanes.pinned_regressions` and `cli.eval.all.regression_lane` — all three are in
this diff. No `OverlayBase` hook, scanner registration or `*Backend` Protocol involved.
`render_json` gains a key (additive; no consumer asserts an exact key set).

### 4. Component boundaries
`eval/regression_corpus_models.py` (report shape), `eval/regression_corpus_schema.py` (the
pre-flight's own not-run row — it owns `SCHEMA_PREFLIGHT`), `eval/regression_corpus_report.py`
(presentation only), `cli/eval/{lanes,all}.py` (exit policy + lane summary, no business logic).

### 5. Dependency direction
No new cross-module import. `regression_corpus.py` LOSES two (`teatree.paths`'s
`DB_FILENAME` / `control_db_dir`) with the dead function; `skipped_preflight_result` comes
from a module it already imports. `tach` clean via the push-stage gate.

### 6. Test surface
`tests/teatree_eval/test_regression_corpus_validated.py` — `validated`/`skipped`, both
renderers, the pre-flight row's presence when the DB is unreachable, `--strict` and
default exit codes, `regression_lane`'s `needs_setup`.
`tests/teatree_eval/test_regression_corpus_db_boundary_skip.py` — the #4001 pins, with the
pre-flight one re-anchored on the invariant it encodes.

### 7. Resilience invariants
No external write. The invariant at stake is the ticket's: a lane that could not run must
not be consumable as a validated result. `validated` + `--strict` is the fail-loud seam;
the default exit stays lenient because the host pre-push hook is the sanctioned degraded
path (#4001), and it now says NOT VALIDATED rather than staying silent. Idempotent (pure
read), sub-second (no heartbeat), no sub-agent.

### 8. Identity and key normalization
n/a — no bare/qualified identity pair; no `split`/`strip` normalization added.

### 9. Behavior preservation / capability deletion
- `unreachable is not None` ⇒ every `needs_db` check `ok=True, skipped=True` with the
  topology reason — PRESERVED byte-for-byte.
- `report.ok` stays `all(r.ok)`, so a topology skip still does not redden the lane —
  PRESERVED (the #4001 pins assert it and stay green).
- `db_ready is False` ⇒ "Django not configured" skips — PRESERVED.
- The pre-flight is omitted when the DB is unreachable — CHANGED: appended as a skipped
  row. It still never opens the DB, which is the invariant the omission stood in for.
- `_canonical_control_db_unreachable_reason` — DELETED; no caller on `main`.

No privacy/leak/security matcher is narrowed. No must-block test is inverted: the one
changed assertion (`len(results) == 1`) was a proxy for "nothing opened the DB" and now
asserts that directly plus the row's skip flag — strictly stronger.

### 10. Removability / harness-vs-data
Removable: derived properties with no stored state, a default-off flag, one branch.
Deleting the lot reverts to current behaviour with no call-site cascade. Harness, not
data: this is the lane's own result contract and exit policy — nothing varies per check.

## Verification
- `t3 tool verify-gates` — **exit 0**, all commit-stage and push-stage gates green.
- `uv run pytest tests/test_cli_command_literals_resolve.py tests/teatree_eval/test_regression_corpus_validated.py tests/teatree_eval/test_regression_corpus_db_boundary_skip.py tests/eval_replay/test_regression_corpus.py tests/teatree_cli/test_eval.py` — **236 passed**.
- `bash dev/test-affected.sh` escalated to FULL: 10025 passed, 10 failed. 9 of those 10
  reproduce identically on a pristine `origin/main` worktree at 47f6691c8 (6 `cli_doctor`
  tests reading this container's real `/var/lib/teatree/control-db`, 2 `gh api` network
  tests, 1 remote-issue lookup) — pre-existing/environmental. The 10th was mine (a
  `t3 eval all --strict` docstring literal that does not resolve) and is fixed in this
  commit; that lane is green.
