### PR TITLE
fix(retention): derive the VACUUM reclaim from SQLite's page accounting (#3979)

### DIFF
--- a/src/teatree/core/management/commands/retention.py
+++ b/src/teatree/core/management/commands/retention.py
@@ -24,7 +24,9 @@ rows on SQLite reclaims no disk on its own — the pages move to the free list a
 the file keeps its size — and the control DB is the seed every auto-isolated
 worktree env dir is copied from, so its size is paid once per live checkout. A
 dry run never vacuums: the rebuild rewrites the whole file, which is not
-something a preview may do (#3852).
+something a preview may do (#3852). The reclaim it reports is SQLite's own page
+delta rather than a file-size difference, because a live reader can defer the
+truncation past the rebuild that earned it (#3979).
 """
 
 import logging
@@ -57,7 +59,33 @@ class _TableRow(TypedDict):
 class _VacuumRow(TypedDict):
     ran: bool
     reason: str
+    summary: str
     bytes_reclaimed: int
+    page_size: int
+    pages_before: int
+    pages_after: int
+    free_pages_before: int
+    free_pages_after: int
+    file_bytes_before: int
+    file_bytes_after: int
+    file_caught_up: bool
+
+
+def _vacuum_row(vacuum: VacuumOutcome) -> _VacuumRow:
+    return {
+        "ran": vacuum.ran,
+        "reason": vacuum.reason,
+        "summary": vacuum.summary,
+        "bytes_reclaimed": vacuum.bytes_reclaimed,
+        "page_size": vacuum.page_size,
+        "pages_before": vacuum.pages_before,
+        "pages_after": vacuum.pages_after,
+        "free_pages_before": vacuum.free_pages_before,
+        "free_pages_after": vacuum.free_pages_after,
+        "file_bytes_before": vacuum.file_bytes_before,
+        "file_bytes_after": vacuum.file_bytes_after,
+        "file_caught_up": vacuum.file_caught_up,
+    }
 
 
 class RetentionReport(TypedDict):
@@ -114,7 +142,7 @@ class Command(TyperCommand):
                 }
                 for table in plan.tables
             ],
-            "vacuum": {"ran": vacuum.ran, "reason": vacuum.reason, "bytes_reclaimed": vacuum.bytes_reclaimed},
+            "vacuum": _vacuum_row(vacuum),
         }
         verb = "Pruned" if apply else "Would prune"
         logger.info("retention: %s %d row(s) across %d table(s)", verb.lower(), plan.total_rows, len(plan.tables))
@@ -151,9 +179,7 @@ def _detail(table: _TableRow) -> str:
 def _render(payload: RetentionReport, stream: IO[str], *, applied: bool) -> None:
     verb = "Pruned" if applied else "Would prune"
     rows: list[list[str]] = [[table["table"], _detail(table)] for table in payload["tables"]]
-    vacuum = payload["vacuum"]
-    reclaimed = f"{vacuum['bytes_reclaimed'] / 1024**2:.1f} MiB reclaimed" if vacuum["ran"] else vacuum["reason"]
-    rows.append(["VACUUM", reclaimed])
+    rows.append(["VACUUM", payload["vacuum"]["summary"]])
     title = f"Retention — {verb.lower()} {payload['total_rows']} row(s)"
     if not applied:
         title += " (dry run — pass --apply to delete)"

--- a/src/teatree/utils/django_db/vacuum.py
+++ b/src/teatree/utils/django_db/vacuum.py
@@ -18,6 +18,13 @@ a transaction; it must follow the prune's commit rather than join it. It also
 needs transient free space of roughly the database's own size while the rebuild
 is in flight.
 
+**The reclaim figure is SQLite's page delta, never a difference of file sizes
+(#3979).** The rebuilt page count is committed by the ``VACUUM`` itself, whereas the
+truncation of the file it lives in waits for a checkpoint that any live reader can
+defer — so a file measured here can still be reporting its pre-vacuum size on a
+rebuild that returned 80% of the database, and did. The page and free-list deltas
+are reported alongside as the direct evidence that the rebuild happened.
+
 **Concurrency is left to SQLite's own exclusive lock — a deliberate choice, not an
 oversight.** A second concurrent vacuum loses the race and surfaces as
 ``sqlite3.Error`` → ``ran=False`` with the reason, which is a correct outcome:
@@ -62,6 +69,23 @@ def _required_headroom_bytes(db_size: int) -> int:
 
 
 @dataclass(frozen=True, slots=True)
+class _PageState:
+    """SQLite's own accounting of the database, read through one connection."""
+
+    size: int
+    count: int
+    free: int
+
+
+def _page_state(connection: sqlite3.Connection) -> _PageState:
+    return _PageState(
+        size=int(connection.execute("PRAGMA page_size").fetchone()[0]),
+        count=int(connection.execute("PRAGMA page_count").fetchone()[0]),
+        free=int(connection.execute("PRAGMA freelist_count").fetchone()[0]),
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class VacuumOutcome:
     """What the vacuum did, or the stated reason it did nothing.
 
@@ -72,12 +96,43 @@ class VacuumOutcome:
 
     ran: bool
     reason: str
-    bytes_before: int = 0
-    bytes_after: int = 0
+    file_bytes_before: int = 0
+    file_bytes_after: int = 0
+    page_size: int = 0
+    pages_before: int = 0
+    pages_after: int = 0
+    free_pages_before: int = 0
+    free_pages_after: int = 0
 
     @property
     def bytes_reclaimed(self) -> int:
-        return max(self.bytes_before - self.bytes_after, 0)
+        """The rebuild's own page delta — never a difference of file sizes (#3979)."""
+        return max(self.page_size * (self.pages_before - self.pages_after), 0)
+
+    @property
+    def file_caught_up(self) -> bool:
+        """Is the rebuild's truncation already visible on the filesystem?"""
+        return self.ran and self.file_bytes_after <= self.page_size * self.pages_after
+
+    @property
+    def summary(self) -> str:
+        """The one line every caller reports, so the three outcomes cannot blur."""
+        if not self.ran:
+            return self.reason
+        if not self.bytes_reclaimed:
+            return f"ran — nothing to reclaim ({self.free_pages_before} free page(s) before)"
+        lag = (
+            ""
+            if self.file_caught_up
+            else (
+                f"; file still {self.file_bytes_after / 1024**2:.1f} MiB — the truncation lands at the next checkpoint"
+            )
+        )
+        return (
+            f"{self.bytes_reclaimed / 1024**2:.1f} MiB reclaimed "
+            f"(pages {self.pages_before}→{self.pages_after}, "
+            f"free {self.free_pages_before}→{self.free_pages_after}){lag}"
+        )
 
 
 def vacuum_sqlite(path: Path) -> VacuumOutcome:
@@ -108,19 +163,38 @@ def vacuum_sqlite(path: Path) -> VacuumOutcome:
                 f"{free / 1024**2:.0f} MiB is available on {path.parent} — reclaim space first, "
                 "e.g. `t3 <overlay> workspace reclaim-disk`"
             ),
-            bytes_before=before,
-            bytes_after=before,
+            file_bytes_before=before,
+            file_bytes_after=before,
         )
     try:
         connection = sqlite3.connect(path, isolation_level=None)  # autocommit: VACUUM cannot run in a transaction
         try:
+            start = _page_state(connection)
             connection.execute("VACUUM")
+            end = _page_state(connection)
+            # In WAL the rebuilt pages sit in the -wal until a checkpoint folds them
+            # back, so the file keeps its pre-vacuum size until this runs. Best-effort
+            # by design: a live reader legitimately blocks it, and the pages are
+            # reclaimed either way — this only decides WHEN the filesystem catches up.
+            connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
         finally:
             connection.close()
     except sqlite3.Error as exc:
         logger.warning("db_vacuum: VACUUM on %s failed: %s", path, exc)
-        return VacuumOutcome(ran=False, reason=f"VACUUM failed: {exc}", bytes_before=before, bytes_after=before)
-    return VacuumOutcome(ran=True, reason="rebuilt", bytes_before=before, bytes_after=path.stat().st_size)
+        return VacuumOutcome(
+            ran=False, reason=f"VACUUM failed: {exc}", file_bytes_before=before, file_bytes_after=before
+        )
+    return VacuumOutcome(
+        ran=True,
+        reason="rebuilt",
+        file_bytes_before=before,
+        file_bytes_after=path.stat().st_size,
+        page_size=end.size,
+        pages_before=start.count,
+        pages_after=end.count,
+        free_pages_before=start.free,
+        free_pages_after=end.free,
+    )
 
 
 def vacuum_control_db(*, using: str = DEFAULT_DB_ALIAS) -> VacuumOutcome:

--- a/tests/teatree_core/management/test_retention_command.py
+++ b/tests/teatree_core/management/test_retention_command.py
@@ -13,6 +13,7 @@ either way) is what is under test.
 
 import datetime as dt
 import json
+from dataclasses import replace
 from io import StringIO
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -21,13 +22,27 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
 
-from teatree.core.management.commands.retention import Command, RetentionReport
+from teatree.core.management.commands.retention import Command, RetentionReport, _vacuum_row
 from teatree.core.models import IncomingEvent, Session, Task, TaskAttempt, Ticket
 from teatree.utils.django_db.vacuum import VacuumOutcome
 
 _OLD = timezone.now() - dt.timedelta(days=60)
 _COMMAND = "teatree.core.management.commands.retention"
-_RECLAIMED = VacuumOutcome(ran=True, reason="rebuilt", bytes_before=1_200_000, bytes_after=600_000)
+_PAGE_SIZE = 4096
+_RECLAIMED = VacuumOutcome(
+    ran=True,
+    reason="rebuilt",
+    file_bytes_before=_PAGE_SIZE * 293,
+    file_bytes_after=_PAGE_SIZE * 146,
+    page_size=_PAGE_SIZE,
+    pages_before=293,
+    pages_after=146,
+    free_pages_before=147,
+    free_pages_after=0,
+)
+#: The rebuild landed but a live reader deferred the truncation, so the file still
+#: reads at its pre-vacuum size — the #3979 shape that reported 0.0 MiB.
+_RECLAIMED_FILE_LAGGING = replace(_RECLAIMED, file_bytes_after=_PAGE_SIZE * 293)
 
 
 def _prune_json(outcome: VacuumOutcome, *args: str) -> tuple[dict[str, Any], MagicMock]:
@@ -64,7 +79,7 @@ class RetentionCommandStructureTestCase(TestCase):
             "applied": False,
             "total_rows": 0,
             "tables": [],
-            "vacuum": {"ran": False, "reason": "dry run", "bytes_reclaimed": 0},
+            "vacuum": _vacuum_row(VacuumOutcome(ran=False, reason="dry run")),
         }
         assert set(report) == {"applied", "total_rows", "tables", "vacuum"}
 
@@ -111,11 +126,42 @@ class RetentionPruneCommandTestCase(TestCase):
 class RetentionPruneVacuumTestCase(TestCase):
     """Rows are only half a prune — the freed pages must reach the filesystem (#3852)."""
 
-    def test_apply_vacuums_and_reports_the_reclaimed_bytes(self) -> None:
+    def test_apply_vacuums_and_reports_the_page_derived_reclaim(self) -> None:
         payload, vacuum = _prune_json(_RECLAIMED, "--apply")
 
         vacuum.assert_called_once_with()
-        assert payload["vacuum"] == {"ran": True, "reason": "rebuilt", "bytes_reclaimed": 600_000}
+        assert payload["vacuum"] == {
+            "ran": True,
+            "reason": "rebuilt",
+            "summary": _RECLAIMED.summary,
+            "bytes_reclaimed": _PAGE_SIZE * 147,
+            "page_size": _PAGE_SIZE,
+            "pages_before": 293,
+            "pages_after": 146,
+            "free_pages_before": 147,
+            "free_pages_after": 0,
+            "file_bytes_before": _PAGE_SIZE * 293,
+            "file_bytes_after": _PAGE_SIZE * 146,
+            "file_caught_up": True,
+        }
+
+    def test_a_reclaim_the_file_has_not_applied_yet_is_still_reported(self) -> None:
+        """The #3979 shape: the rebuild landed, the truncation is still pending."""
+        payload, _ = _prune_json(_RECLAIMED_FILE_LAGGING, "--apply")
+
+        assert payload["vacuum"]["bytes_reclaimed"] == _PAGE_SIZE * 147
+        assert payload["vacuum"]["file_caught_up"] is False
+        assert "next checkpoint" in payload["vacuum"]["summary"]
+
+    def test_the_human_row_carries_the_page_and_freelist_deltas(self) -> None:
+        """The direct evidence the rebuild happened, and it does not depend on a stat."""
+        err = StringIO()
+        with patch(f"{_COMMAND}.vacuum_control_db", return_value=_RECLAIMED):
+            call_command("retention", "prune", "--apply", stderr=err)
+
+        rendered = err.getvalue()
+        assert "pages 293" in rendered
+        assert "free 147" in rendered
 
     def test_dry_run_never_vacuums(self) -> None:
         """VACUUM rewrites the whole file — a preview that mutates 1.12 GB is not a preview."""
@@ -133,3 +179,4 @@ class RetentionPruneVacuumTestCase(TestCase):
         assert payload["vacuum"]["ran"] is False
         assert "not applicable" in payload["vacuum"]["reason"]
         assert payload["vacuum"]["bytes_reclaimed"] == 0
+        assert payload["vacuum"]["summary"] == payload["vacuum"]["reason"]

--- a/tests/teatree_utils/django_db/test_vacuum.py
+++ b/tests/teatree_utils/django_db/test_vacuum.py
@@ -43,6 +43,26 @@ def _free_pages(path: Path) -> int:
         con.close()
 
 
+def _page_counts(path: Path) -> tuple[int, int]:
+    con = sqlite3.connect(path)
+    try:
+        return (
+            int(con.execute("PRAGMA page_count").fetchone()[0]),
+            int(con.execute("PRAGMA freelist_count").fetchone()[0]),
+        )
+    finally:
+        con.close()
+
+
+def _wal_journalled(path: Path) -> None:
+    """WAL is a file-header property, so every later connection inherits it."""
+    con = sqlite3.connect(path)
+    try:
+        con.execute("PRAGMA journal_mode=WAL")
+    finally:
+        con.close()
+
+
 class TestVacuumSqlite:
     def test_control_a_delete_alone_leaves_the_file_size_untouched(self, tmp_path: Path) -> None:
         """The premise this whole item rests on — deleted rows become free pages, not free disk."""
@@ -67,6 +87,65 @@ class TestVacuumSqlite:
         assert db.stat().st_size < before
         assert outcome.bytes_reclaimed == before - db.stat().st_size
         assert _free_pages(db) == 0
+
+    def test_a_live_reader_defers_the_truncation_and_the_reclaim_is_still_reported(self, tmp_path: Path) -> None:
+        """The figure comes from SQLite's accounting, never from a file size (#3979).
+
+        A reader holding an open snapshot blocks the checkpoint that truncates the
+        file, so the rebuilt page count lands while the file keeps its old size —
+        and a stat-derived figure reads zero on a rebuild that reclaimed most of
+        the database.
+        """
+        db = tmp_path / "control.sqlite3"
+        _wal_journalled(db)
+        _bloated_db(db)
+        _delete_most_rows(db)
+        before = db.stat().st_size
+        reader = sqlite3.connect(db, isolation_level=None)
+        reader.execute("BEGIN")
+        reader.execute("SELECT count(*) FROM attempt").fetchone()
+        try:
+            outcome = vacuum_sqlite(db)
+            size_while_deferred = db.stat().st_size
+        finally:
+            reader.close()
+
+        assert size_while_deferred == before, "control: the file has caught up, so nothing was deferred"
+        assert outcome.ran
+        assert outcome.bytes_reclaimed > 0
+        assert outcome.pages_after < outcome.pages_before
+        assert not outcome.file_caught_up
+        assert "next checkpoint" in outcome.summary
+
+    def test_the_reported_counts_match_an_independent_read_of_the_pragmas(self, tmp_path: Path) -> None:
+        db = tmp_path / "control.sqlite3"
+        _bloated_db(db)
+        _delete_most_rows(db)
+        pages_before, free_before = _page_counts(db)
+
+        outcome = vacuum_sqlite(db)
+
+        pages_after, free_after = _page_counts(db)
+        assert (outcome.pages_before, outcome.free_pages_before) == (pages_before, free_before)
+        assert (outcome.pages_after, outcome.free_pages_after) == (pages_after, free_after)
+        assert outcome.bytes_reclaimed == outcome.page_size * (pages_before - pages_after)
+        assert free_before > 0, "fixture never bloated — the reclaim assertion would be vacuous"
+
+    def test_a_compact_database_reports_ran_with_nothing_to_reclaim(self, tmp_path: Path) -> None:
+        """A vacuum that found nothing must not read like one that never ran — the #3979 ambiguity."""
+        db = tmp_path / "control.sqlite3"
+        _bloated_db(db)
+        _delete_most_rows(db)
+        vacuum_sqlite(db)
+
+        outcome = vacuum_sqlite(db)
+        missing = vacuum_sqlite(tmp_path / "nope.sqlite3")
+
+        assert outcome.ran
+        assert outcome.bytes_reclaimed == 0
+        assert "nothing to reclaim" in outcome.summary
+        assert missing.summary == missing.reason
+        assert outcome.summary != missing.summary
 
     def test_the_surviving_rows_are_still_readable(self, tmp_path: Path) -> None:
         """VACUUM rebuilds the file — the guard that it rebuilt it correctly."""


### PR DESCRIPTION
fix(retention): derive the VACUUM reclaim from SQLite's page accounting (#3979)

## What
`retention prune --apply` reported `VACUUM — 0.0 MiB reclaimed` on a run that
returned most of the control database. The figure was a difference of
`path.stat().st_size` taken before and after, and that observation is not tied
to the rebuild: VACUUM commits the rebuilt page count immediately, while the
file holding it is truncated only at a checkpoint any live reader can defer —
so the stat still reads the pre-vacuum size and the delta is zero.

- derive `bytes_reclaimed` from `page_size * (page_count delta)`, read through
  the same connection that runs the VACUUM
- report the page and free-list deltas alongside: the direct evidence the
  rebuild happened, independent of when the file is stat'ed
- best-effort `wal_checkpoint(TRUNCATE)` so the filesystem catches up — the
  control DB is the seed copied into every isolated worktree env dir, so the
  file size is what the command exists to reduce
- one `VacuumOutcome.summary` seam, so "did not run", "ran, nothing to reclaim"
  and "reclaimed N" cannot read the same
- rename `bytes_before`/`bytes_after` to `file_bytes_before`/`file_bytes_after`,
  making the stat-means-reclaim reading structurally unavailable

Proven RED: the new WAL-plus-live-reader spec reports
`VacuumOutcome(ran=True, bytes_before=2359296, bytes_after=2359296)` →
`bytes_reclaimed == 0` on the pre-fix code, while `page_count` fell 15037→3009.
It carries an in-test control asserting the file genuinely had not caught up, so
a green cannot come from the scenario failing to defer the truncation.

Open questions & assumptions

- The exact mechanism of the reported incident is not proven (assumed). The
  control DB is rollback-journal today, so the WAL-plus-reader spec pins the
  defect CLASS rather than replaying that run. Every candidate mechanism —
  deferred truncation, or a concurrent prune winning the race — is cured by
  measuring what THIS VACUUM did through the connection that ran it.
- The best-effort checkpoint is new behaviour, not only reporting (assumed in
  scope). Reporting pages returned while the file stays large does not help the
  per-worktree seed copy this command exists to shrink.
- One `page_size` field is correct (decided). The connection is opened fresh and
  never issues `PRAGMA page_size`, so the page size cannot change across the
  VACUUM and a per-side field would be untested dead weight.
- The `retention prune --json` payload gains keys (assumed safe). A repo-wide
  grep finds no consumer of that payload outside the command's own tests.

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.