### PR TITLE
test(hooks): pin the authoring gate's worktree carve-out at a primary-clone cwd (#3965)

### DIFF
--- a/tests/test_hook_router_headless_authoring_gate.py
+++ b/tests/test_hook_router_headless_authoring_gate.py
@@ -344,6 +344,46 @@ class TestACommitCanFollowTheEditThatProducedIt:
         assert _run_gate(_bash("git log --oneline -5", str(clone))) is False
 
 
+class TestTheWorktreeCarveOutIsReachableFromAPrimaryCloneCwd:
+    """The carve-out must fire for the actor it was written for: a dispatched sub-agent.
+
+    Such an agent is launched AT a primary clone and cannot move: a ``cd`` in one call does
+    not persist to the next, and ``EnterWorktree`` only switches a session already inside a
+    worktree. So the two shapes below are the ONLY ones it can commit its in-flight work
+    with, and a probe read off the ambient cwd refused both — leaving the exemption reachable
+    solely by the sessions that never needed it. The cases above split these two dimensions
+    apart: the carve-out is exercised with the cwd already in the worktree, and target
+    resolution between two primary clones. Neither asks for their intersection.
+    """
+
+    def test_a_dash_c_commit_into_a_live_worktree_is_allowed(
+        self, headless_interactive: None, clone_and_live_worktree: tuple[Path, Path]
+    ) -> None:
+        clone, worktree = clone_and_live_worktree
+        assert _run_gate(_bash(f"git -C {worktree} commit -m 'fix the thing'", str(clone))) is False
+
+    def test_a_cd_then_commit_into_a_live_worktree_is_allowed(
+        self, headless_interactive: None, clone_and_live_worktree: tuple[Path, Path]
+    ) -> None:
+        clone, worktree = clone_and_live_worktree
+        assert _run_gate(_bash(f"cd {worktree} && git commit -m 'fix the thing'", str(clone))) is False
+
+    def test_a_dash_c_commit_into_the_primary_clone_is_still_refused(
+        self, headless_interactive: None, clone_and_live_worktree: tuple[Path, Path]
+    ) -> None:
+        # The control, in the mirror direction: resolving the target must be able to pull the
+        # verdict toward a refusal too, or it is a permanently-open carve-out rather than one
+        # that discriminates.
+        clone, worktree = clone_and_live_worktree
+        assert _run_gate(_bash(f"git -C {clone} commit -m 'new work'", str(worktree))) is True
+
+    def test_a_cd_then_commit_into_the_primary_clone_is_still_refused(
+        self, headless_interactive: None, clone_and_live_worktree: tuple[Path, Path]
+    ) -> None:
+        clone, worktree = clone_and_live_worktree
+        assert _run_gate(_bash(f"cd {clone} && git commit -m 'new work'", str(worktree))) is True
+
+
 class TestTheOverrideIsReachableFromACommitMessage:
     """The audited escape must be reachable from the calls most likely to need it.
 


### PR DESCRIPTION
test(hooks): pin the authoring gate's worktree carve-out at a primary-clone cwd (#3965)

The production half of this ticket already landed in 682660a46 (#4001): `_bash_repo_probe`
takes the command and resolves the landing dir through the shared sibling resolver
`teatree.hooks._commit_repo_dir.resolve_commit_dir`, so a leading `cd <dir> &&` and a
`git -C <dir>` both move the probe. What was never pinned is the exact combination the
ticket names — a LIVE WORKTREE target resolved from a PRIMARY-CLONE cwd — which is the only
shape a dispatched sub-agent can reach: a `cd` does not persist across its calls, and
`EnterWorktree` only switches a session already inside a worktree.

Existing coverage splits those two dimensions apart and never asks for their intersection:

- `TestACommitCanFollowTheEditThatProducedIt` exercises the carve-out with cwd == worktree
- `TestTheBashArmJudgesTheRepoTheCommandTargets` exercises target resolution between two
  primary clones

So a regression re-breaking the dispatched agent's only two reachable shapes lands green.

Four cases on the existing real-git fixtures (the `.git` file-vs-dir distinction stays
unmocked — it is the whole question):

- `git -C <worktree> commit` from the clone cwd — allowed
- `cd <worktree> && git commit` from the clone cwd — allowed
- both shapes aimed at the primary clone from the worktree cwd — still refused, the
  mirror-direction control that keeps this a carve-out rather than a permanent opening

Anti-vacuity: with `_bash_repo_probe` reverted to the pre-#4001 cwd-only form all four go
RED; restored, the module's 43 cases pass.

## Open questions & assumptions

- (assumed) Acceptance criteria 1-4 are already satisfied by code on main, so this change is
  test-only and no production edit was made. Verified by running the four new cases against
  an unmodified `hooks/scripts/headless_authoring_gate.py`.
- (assumed) Criterion 4 ("the probe resolution is shared with the sibling gates, not
  reimplemented") is met by `resolve_commit_dir` — the issue named
  `_body_file_resolution.commit_body_file_base`, and that wrapper delegates to exactly this
  resolver, so the seam is shared one level down.
- (open) `tests/cli_doctor/test_doctor_check_command.py` fails 7 cases on this host with the
  doctor module byte-identical to origin/main: the check reads the box's real
  `/var/lib/teatree/control-db`, so it is not hermetic. Unrelated to this diff, not fixed
  here, reported separately.

## What

## Why