### PR TITLE
fix(deploy,hooks): make host t3 a real shim — refuse a wrong tree, name the hook venv (#3964)

### DIFF
--- a/deploy/t3
+++ b/deploy/t3
@@ -164,6 +164,53 @@ fi
 # the command would resolve from the image WORKDIR again — the exact failure this
 # block exists to remove, reappearing only on some hosts. `-P` on a path that is
 # already physical is a no-op, so the common case is unchanged.
+# The host roots the container can see. Shared by the invisible-checkout refusal
+# below and the unreachable-argument note further down, so the two can never name
+# different sets — they are answering the same question.
+print_visible_host_roots() {
+    local root
+    for root in "${TEATREE_SOURCE_MOUNT:-}" "${DATA_MOUNT_SOURCES[@]}" "${CREDENTIAL_MOUNT_SOURCES[@]}"; do
+        if [ -n "$root" ]; then
+            echo "             $root" >&2
+        fi
+    done
+}
+
+# The checkout enclosing $1, or nothing when $1 is not inside one. A `.git` entry
+# is what git itself looks for, and it is a FILE in a linked worktree — teatree's
+# own worktrees are exactly that shape. Pure expansion, no `git`: the wrapper's
+# whole contract is that the host needs no teatree toolchain, and a hook subprocess
+# inherits a restricted PATH where shelling out silently yields nothing.
+enclosing_checkout_root() {
+    local dir="$1"
+    while [ -n "$dir" ] && [ "$dir" != / ]; do
+        if [ -e "$dir/.git" ]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+        dir="${dir%/*}"
+    done
+    if [ -e /.git ]; then
+        printf '%s\n' /
+    fi
+    return 0
+}
+
+refuse_invisible_checkout() {
+    echo "deploy/t3: refusing to run — this checkout is not visible inside the container." >&2
+    echo "           cwd:      $1" >&2
+    echo "           checkout: $2" >&2
+    echo "           The container carries its OWN copy of the teatree source (a Docker" >&2
+    echo "           volume, a separate tree from this one), so dispatching from here would" >&2
+    echo "           silently operate on that copy instead of the checkout you are in." >&2
+    echo "           The container sees only these host roots:" >&2
+    print_visible_host_roots
+    echo "           Fix: work from a checkout under one of them — \`t3 <overlay> workspace" >&2
+    echo "           ticket <id>\` creates one — or export TEATREE_INVOCATION_CWD to the" >&2
+    echo "           container-side path when you know this tree is reachable there." >&2
+    exit 1
+}
+
 if [ -z "${TEATREE_INVOCATION_CWD:-}" ]; then
     HOST_CWD="$(pwd -P)"
     PHYSICAL_HOST_HOME="$(cd "$TEATREE_HOST_HOME" 2>/dev/null && pwd -P)" || PHYSICAL_HOST_HOME="$TEATREE_HOST_HOME"
@@ -191,6 +238,28 @@ if [ -z "${TEATREE_INVOCATION_CWD:-}" ]; then
             ;;
         esac
     done
+
+    # WHEN THE UNTRANSLATED CWD IS A WRONG TREE, NOT MERELY AN UNKNOWN ONE. An
+    # untranslated cwd degrades to the image WORKDIR, and under it sits the
+    # container's own source volume — so a cwd-sensitive command run from a host
+    # checkout outside every mount resolves against that copy and reports success
+    # having touched a different tree. Nothing downstream can detect this: both
+    # trees are real teatree checkouts, so there is no error to surface.
+    #
+    # Scoped to a CHECKOUT because that is the only cwd a tree can be wrong about.
+    # `~`, `/tmp` and the like carry no tree, and every cwd-insensitive command
+    # (`t3 doctor`, `t3 info`, `t3 notify send`) must keep running from them — the
+    # pre-existing degrade-to-container-cwd behaviour, unchanged.
+    #
+    # A refusal, where an unreachable path ARGUMENT below only warns: the wrapper
+    # cannot know whether the CLI will open that argument, but the cwd is read by
+    # the CLI on every invocation, so the wrong-tree resolution is certain.
+    if [ -z "${TEATREE_INVOCATION_CWD:-}" ]; then
+        CHECKOUT_ROOT="$(enclosing_checkout_root "$HOST_CWD")"
+        if [ -n "$CHECKOUT_ROOT" ]; then
+            refuse_invisible_checkout "$HOST_CWD" "$CHECKOUT_ROOT"
+        fi
+    fi
 fi
 
 # WHEN A HOST PATH CANNOT CROSS THE BOUNDARY. The container sees only the bind
@@ -234,7 +303,7 @@ unreachable_host_paths() {
 }
 
 warn_unreachable_host_paths() {
-    local unreachable root path
+    local unreachable path
     unreachable="$(unreachable_host_paths "$@")"
     if [ -z "$unreachable" ]; then
         return 0
@@ -246,12 +315,8 @@ warn_unreachable_host_paths() {
         echo "             $path" >&2
     done <<<"$unreachable"
     echo "           The container sees only these host roots:" >&2
-    for root in "${TEATREE_SOURCE_MOUNT:-}" "${DATA_MOUNT_SOURCES[@]}" "${CREDENTIAL_MOUNT_SOURCES[@]}"; do
-        if [ -n "$root" ]; then
-            echo "             $root" >&2
-        fi
-    done
-    echo "           Move the path under one of them, or run the host t3 (~/.local/bin/t3)." >&2
+    print_visible_host_roots
+    echo "           Move the path under one of them." >&2
     return 0
 }
 
@@ -356,6 +421,44 @@ if [ -n "$(compose ps --status running --quiet "$SERVICE" 2>/dev/null)" ]; then
     exec docker compose -f "$COMPOSE_FILE" exec -T ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} "$SERVICE" t3 "$@"
 fi
 
-# Nothing running — one-off container on the shared volumes. `--entrypoint t3`
-# bypasses the TEATREE_ROLE dispatcher so we run the CLI directly, not a server.
+# Nothing running. Two different worlds reach this line: a merely STOPPED stack,
+# where the one-off below is the intended path and works, and a stack that was
+# never deployed here (or a dead daemon), where the one-off cannot run at all.
+# Only the second needs saying, and docker says it in its own vocabulary —
+# "Cannot connect to the Docker daemon", or a pull attempt against an image that
+# was only ever built locally — which names nothing an operator can act on. The
+# host `t3` is a shim, so this is the whole of what a stopped deployment can
+# report; leaving it as docker's own text is the traceback-shaped failure the
+# shim exists to remove.
+#
+# Preflighted HERE rather than at the top so the cost lands only on the path that
+# can hit it: a running worker already proved both facts by answering `ps`.
+refuse_absent_stack() {
+    echo "deploy/t3: refusing to run — the teatree stack is not available on this host." >&2
+    echo "           $1" >&2
+    echo "           Start it with: $REPO_ROOT/deploy/deploy.sh" >&2
+    exit 1
+}
+
+if ! docker version --format '{{.Server.Version}}' >/dev/null 2>&1; then
+    refuse_absent_stack "The Docker daemon is not reachable — start Docker first."
+fi
+
+# The image the compose file names for this service, asked of compose rather than
+# assembled here so a renamed or operator-overridden image can never be probed
+# under a stale name. An empty answer means compose could not resolve the service
+# at all, which the one-off is about to report far better than a guess would.
+#
+# The first line is taken by expansion, never `| head`: under `pipefail` the
+# reader closing the pipe early kills the writer with SIGPIPE and the whole
+# assignment fails 141, so a service resolving to more than one image would abort
+# the wrapper instead of dispatching.
+SERVICE_IMAGES="$(compose config --images "$SERVICE" 2>/dev/null || true)"
+SERVICE_IMAGE="${SERVICE_IMAGES%%$'\n'*}"
+if [ -n "$SERVICE_IMAGE" ] && ! docker image inspect "$SERVICE_IMAGE" >/dev/null 2>&1; then
+    refuse_absent_stack "No local image \`$SERVICE_IMAGE\` — this host has never built the stack."
+fi
+
+# `--entrypoint t3` bypasses the TEATREE_ROLE dispatcher so we run the CLI
+# directly, not a server.
 exec docker compose -f "$COMPOSE_FILE" run --rm --no-deps ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} --entrypoint t3 "$SERVICE" "$@"

--- a/hooks/scripts/run-hook.sh
+++ b/hooks/scripts/run-hook.sh
@@ -29,11 +29,19 @@
 # acquire it. So the choice has to move up here, to interpreter selection.
 #
 # Pass 1 therefore requires `import django` as well as the version floor, and
-# considers the interpreter teatree is installed into first — discovered next to
-# the resolved `t3` entry point (a uv-tool / venv layout puts `python` beside it),
-# so nothing is hard-coded to one host. `T3_HOOK_PYTHON` short-circuits the whole
-# search on the version floor alone — an operator naming an interpreter outranks
-# the Django preference.
+# considers the venv teatree is installed into first.
+#
+# That venv is NAMED here rather than discovered beside the resolved `t3` entry
+# point (#3964). Host `t3` is a shell shim that dispatches into the worker
+# container — there is no interpreter beside it to find, and the CLI it reaches is
+# the container's, not this host's. The hook runtime is a separate concern from the
+# CLI install and must not be resolved through it. The entry-point probe survives
+# below the named venv, demoted: it is still the only route to a non-uv host
+# install (pipx, a hand-rolled venv), where deleting it would leave no
+# Django-capable interpreter at all.
+#
+# `T3_HOOK_PYTHON` short-circuits the whole search on the version floor alone — an
+# operator naming an interpreter outranks the Django preference.
 #
 # Fail open: pass 2 repeats the search with the version floor ALONE, so a host
 # with no Django-capable interpreter keeps exactly the pre-existing behaviour —
@@ -55,14 +63,23 @@ probe_interpreter() {
 # Interpreter candidates, most-preferred first, one per line. Paths may not
 # exist; the probe filters them.
 interpreter_candidates() {
-    # The venv teatree itself is installed into, found beside the `t3` entry
-    # point. `command -v` is a shell builtin and `${var%/*}` is expansion, so
-    # this needs no external binary — a hook subprocess inherits a restricted
-    # PATH, and shelling out to `dirname` there silently yields no candidate.
-    # `readlink` IS external, so it is strictly best-effort: `~/.local/bin/t3` is
-    # typically a symlink INTO the venv, so try the resolved dir first, but keep
-    # the unresolved dir as a candidate for when `readlink` is unavailable or
-    # non-GNU (BSD/macOS lack `-f`).
+    # The HOOK RUNTIME venv, named directly (#3964). `$UV_TOOL_DIR` is uv's own
+    # knob for where tool venvs live; hard-coding only the default missed every
+    # host that sets it.
+    uv_tools="${UV_TOOL_DIR:-${HOME:-}/.local/share/uv/tools}"
+    if [ "$uv_tools" != "/.local/share/uv/tools" ]; then
+        printf '%s\n' "$uv_tools/teatree/bin/python" "$uv_tools/teatree/bin/python3"
+    fi
+
+    # LEGACY, and last before the bare PATH pythons: the venv found beside the
+    # resolved `t3` entry point. It is what still reaches a non-uv host install
+    # (pipx, a hand-rolled venv), so removing it would narrow those hosts to no
+    # Django-capable interpreter at all. `command -v` is a shell builtin and
+    # `${var%/*}` is expansion, so this needs no external binary — a hook
+    # subprocess inherits a restricted PATH, and shelling out to `dirname` there
+    # silently yields no candidate. `readlink` IS external, so it is strictly
+    # best-effort: try the resolved dir first, but keep the unresolved dir for
+    # when `readlink` is unavailable or non-GNU (BSD/macOS lack `-f`).
     t3_bin="$(command -v t3 2>/dev/null || true)"
     if [ -n "$t3_bin" ]; then
         t3_resolved="$(readlink -f "$t3_bin" 2>/dev/null || true)"
@@ -71,12 +88,6 @@ interpreter_candidates() {
                 */*) printf '%s\n' "${t3_path%/*}/python" "${t3_path%/*}/python3" ;;
             esac
         done
-    fi
-
-    # The default uv-tool layout, so the venv is still found when `readlink` is
-    # unavailable and `t3` is a symlink from elsewhere.
-    if [ -n "${HOME:-}" ]; then
-        printf '%s\n' "$HOME/.local/share/uv/tools/teatree/bin/python"
     fi
 
     for name in python3.13 python3.12 python3.11 python3; do

--- a/tests/_deploy_wrapper_paths.py
+++ b/tests/_deploy_wrapper_paths.py
@@ -1,0 +1,33 @@
+"""Container-side paths read from ``deploy/t3`` rather than repeated in tests.
+
+The wrapper is the only place that knows how a host root maps onto a container
+path, so a test asserting a translated cwd needs the same value. Copying the
+literal into each test file makes a second thing to update and lets the two
+drift silently — a stale copy asserts a path the wrapper no longer produces.
+"""
+
+import re
+from pathlib import Path
+
+_WRAPPER = Path(__file__).resolve().parents[1] / "deploy" / "t3"
+
+_SOURCE_DIR_PATTERN = r"^CONTAINER_SOURCE_DIR=(\S+)"
+_WORKTREE_ROOT_PATTERN = r'"\$PHYSICAL_HOST_HOME/workspace/t3-workspaces:([^"]+)"'
+
+
+def _capture(pattern: str, what: str) -> str:
+    match = re.search(pattern, _WRAPPER.read_text(encoding="utf-8"), re.MULTILINE)
+    if match is None:
+        message = f"{_WRAPPER} no longer defines {what}"
+        raise AssertionError(message)
+    return match.group(1)
+
+
+def container_source_dir() -> str:
+    """The fixed container path the teatree source mount lands on."""
+    return _capture(_SOURCE_DIR_PATTERN, "the container source dir")
+
+
+def container_worktree_root() -> str:
+    """The container side of the worktree-root bind mount."""
+    return _capture(_WORKTREE_ROOT_PATTERN, "the worktree-root mount")

--- a/tests/teatree_hooks/test_run_hook_interpreter_selection.py
+++ b/tests/teatree_hooks/test_run_hook_interpreter_selection.py
@@ -1,0 +1,187 @@
+"""The hook runtime is resolved without going through the ``t3`` entry point (#3964).
+
+Host ``t3`` is a shell shim that dispatches into the worker container: there is no
+interpreter beside it to discover, and the CLI it reaches is the container's rather
+than this host's. So ``run-hook.sh`` names the hook venv directly. Left resolving
+through the entry point, a shimmed host would fall through to a bare ``python3``
+with no Django — and every ORM-backed handler (the hand-off drain, the away-mode
+question recorder, the standing-goal and unknown-repo-push gates) silently no-ops
+while the session looks healthy.
+
+The entry-point probe is kept as a demoted fallback, because it is the only route
+to a non-uv host install (pipx, a hand-rolled venv). Both halves are pinned here:
+the named venv outranks it, and it still resolves when no named venv exists.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_RUN_HOOK = _REPO_ROOT / "hooks" / "scripts" / "run-hook.sh"
+
+_SHELL_ESSENTIALS = ("bash", "sh", "env", "readlink")
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _fake_interpreter(path: Path, name: str, log: Path, *, has_django: bool) -> None:
+    """A stand-in interpreter that records being CHOSEN, then delegates for real.
+
+    Only a non-``-c`` invocation is logged: ``-c`` is the probe, and every
+    candidate gets probed, so logging those would say nothing about which one the
+    shim actually exec'd.
+    """
+    django_branch = ":" if has_django else "exit 1"
+    _write_executable(
+        path,
+        f"""#!/usr/bin/env bash
+case "$*" in
+*"import django"*) {django_branch} ;;
+esac
+case "${{1:-}}" in
+-c) ;;
+*) printf '%s\\n' {name!r} >>{str(log)!r} ;;
+esac
+exec {sys.executable!r} "$@"
+""",
+    )
+
+
+@pytest.fixture
+def bin_dir(tmp_path: Path) -> Path:
+    """A PATH directory carrying the shell essentials and nothing python-shaped."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for tool in _SHELL_ESSENTIALS:
+        source = shutil.which(tool)
+        if source:
+            (fake_bin / tool).symlink_to(source)
+    return fake_bin
+
+
+@pytest.fixture
+def hook_script(tmp_path: Path) -> Path:
+    script = tmp_path / "hook.py"
+    script.write_text("print('ran')\n", encoding="utf-8")
+    return script
+
+
+def _run(hook_script: Path, bin_dir: Path, **env_extra: str) -> subprocess.CompletedProcess[str]:
+    env = {"PATH": str(bin_dir), "HOME": str(bin_dir.parent / "nonexistent-home")}
+    env.update(env_extra)
+    return subprocess.run(
+        [shutil.which("bash") or "bash", str(_RUN_HOOK), str(hook_script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=60,
+    )
+
+
+def _chosen(log: Path) -> list[str]:
+    return log.read_text(encoding="utf-8").split() if log.exists() else []
+
+
+class TestNamedHookVenvIsUsedWithoutTheEntryPoint:
+    def test_a_shimmed_t3_still_reaches_the_django_capable_hook_venv(
+        self, tmp_path: Path, bin_dir: Path, hook_script: Path
+    ) -> None:
+        log = tmp_path / "chosen.log"
+        uv_tools = tmp_path / "uvtools"
+        _fake_interpreter(uv_tools / "teatree" / "bin" / "python", "hook-venv", log, has_django=True)
+        # The host `t3` a shim leaves behind: no interpreter anywhere beside it.
+        _write_executable(bin_dir / "t3", '#!/usr/bin/env bash\nexec docker compose exec worker t3 "$@"\n')
+
+        proc = _run(hook_script, bin_dir, UV_TOOL_DIR=str(uv_tools))
+
+        assert proc.returncode == 0
+        assert _chosen(log) == ["hook-venv"]
+
+    def test_the_named_venv_outranks_an_interpreter_beside_the_entry_point(
+        self, tmp_path: Path, bin_dir: Path, hook_script: Path
+    ) -> None:
+        log = tmp_path / "chosen.log"
+        uv_tools = tmp_path / "uvtools"
+        _fake_interpreter(uv_tools / "teatree" / "bin" / "python", "hook-venv", log, has_django=True)
+        _write_executable(bin_dir / "t3", "#!/usr/bin/env bash\nexit 0\n")
+        _fake_interpreter(bin_dir / "python", "beside-t3", log, has_django=True)
+
+        proc = _run(hook_script, bin_dir, UV_TOOL_DIR=str(uv_tools))
+
+        assert proc.returncode == 0
+        assert _chosen(log) == ["hook-venv"]
+
+
+class TestEntryPointFallbackIsPreserved:
+    """A non-uv host install is reachable only through the demoted probe."""
+
+    def test_a_venv_beside_the_entry_point_still_resolves(
+        self, tmp_path: Path, bin_dir: Path, hook_script: Path
+    ) -> None:
+        log = tmp_path / "chosen.log"
+        venv_bin = tmp_path / "pipx-venv" / "bin"
+        _write_executable(venv_bin / "t3", "#!/usr/bin/env bash\nexit 0\n")
+        _fake_interpreter(venv_bin / "python", "beside-t3", log, has_django=True)
+        (bin_dir / "t3").symlink_to(venv_bin / "t3")
+
+        proc = _run(hook_script, bin_dir, UV_TOOL_DIR=str(tmp_path / "empty-uvtools"))
+
+        assert proc.returncode == 0
+        assert _chosen(log) == ["beside-t3"]
+
+
+class TestUvToolDirIsHonoured:
+    def test_the_default_uv_layout_is_still_found_without_the_env_var(
+        self, tmp_path: Path, bin_dir: Path, hook_script: Path
+    ) -> None:
+        log = tmp_path / "chosen.log"
+        home = tmp_path / "home"
+        _fake_interpreter(
+            home / ".local" / "share" / "uv" / "tools" / "teatree" / "bin" / "python",
+            "hook-venv",
+            log,
+            has_django=True,
+        )
+
+        env = {"PATH": str(bin_dir), "HOME": str(home)}
+        proc = subprocess.run(
+            [shutil.which("bash") or "bash", str(_RUN_HOOK), str(hook_script)],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+            timeout=60,
+        )
+
+        assert proc.returncode == 0
+        assert _chosen(log) == ["hook-venv"]
+
+    def test_an_unset_home_names_no_candidate_rather_than_a_root_path(
+        self, tmp_path: Path, bin_dir: Path, hook_script: Path
+    ) -> None:
+        """``/.local/share/uv/tools`` is nobody's venv — probing it is noise."""
+        log = tmp_path / "chosen.log"
+        _fake_interpreter(bin_dir / "python3", "path-python", log, has_django=True)
+
+        proc = subprocess.run(
+            [shutil.which("bash") or "bash", str(_RUN_HOOK), str(hook_script)],
+            capture_output=True,
+            text=True,
+            env={"PATH": str(bin_dir)},
+            check=False,
+            timeout=60,
+        )
+
+        assert proc.returncode == 0
+        assert _chosen(log) == ["path-python"]
+        assert os.sep in str(bin_dir)

--- a/tests/test_deploy_host_glab_token_forwarding.py
+++ b/tests/test_deploy_host_glab_token_forwarding.py
@@ -104,7 +104,15 @@ def _run(
     entry = _install_wrapper(tmp_path)
     bash = shutil.which("bash", path=SYSTEM_PATH) or "bash"
     argv = [bash, "-x", str(entry), "--help"] if xtrace else [str(entry), "--help"]
-    return subprocess.run(argv, capture_output=True, text=True, check=True, env=env)
+
+    # Stand OUTSIDE any checkout: the subject is credential forwarding, and
+    # inheriting pytest's cwd would instead trip the invisible-checkout refusal
+    # (this repo is a checkout, and `TEATREE_HOST_HOME` is redirected above so it
+    # sits under none of the mounts the wrapper computes).
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir(parents=True, exist_ok=True)
+
+    return subprocess.run(argv, capture_output=True, text=True, check=True, env=env, cwd=elsewhere)
 
 
 def _invoke(tmp_path: Path, *, with_glab: bool, env_overrides: dict[str, str] | None = None) -> dict[str, str]:

--- a/tests/test_deploy_invisible_checkout_refusal.py
+++ b/tests/test_deploy_invisible_checkout_refusal.py
@@ -1,0 +1,183 @@
+"""``deploy/t3`` must refuse to dispatch from a checkout the container cannot see.
+
+The container carries its OWN copy of the teatree source — a Docker *volume*, not
+the host tree — while the workspace and env roots are bind mounts at identical
+paths. So an untranslatable cwd is not a harmless degradation when the operator is
+standing in a repository: ``docker compose exec`` starts the CLI in the image
+WORKDIR and every cwd-sensitive command then resolves against the container's copy,
+silently operating on the wrong tree while reporting success.
+
+The refusal is scoped to a cwd inside a *checkout* on purpose. A cwd with no
+enclosing checkout (``~``, ``/tmp``) has no tree to be wrong about, and every
+cwd-insensitive command run from there must keep working exactly as before —
+refusing those would break ``t3 doctor`` / ``t3 info`` from an operator's home
+directory to guard a hazard that cannot arise there.
+
+The wrapper is exercised for real, with a ``docker`` stub reporting what it was
+handed — docker being the one unstoppable external.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests._deploy_wrapper_paths import container_source_dir, container_worktree_root
+
+DEPLOY_DIR = Path(__file__).resolve().parents[1] / "deploy"
+WRAPPER = DEPLOY_DIR / "t3"
+
+CONTAINER_SOURCE_DIR = container_source_dir()
+CONTAINER_WORKTREE_ROOT = container_worktree_root()
+
+DISPATCHED = "DISPATCHED"
+UNSET = "<unset>"
+
+DOCKER_STUB = f"""#!/usr/bin/env bash
+for arg in "$@"; do
+    [ "$arg" = ps ] && exit 0
+done
+printf '{DISPATCHED} TEATREE_INVOCATION_CWD=%s\\n' "${{TEATREE_INVOCATION_CWD-{UNSET}}}"
+"""
+
+
+def _build_fork(root: Path) -> Path:
+    """A vendored fork carrying the real wrapper — the layout an operator runs."""
+    fork = root / "fork"
+    deploy = fork / "vendor" / "teatree" / "deploy"
+    deploy.mkdir(parents=True, exist_ok=True)
+    entry = deploy / "t3"
+    shutil.copy2(WRAPPER, entry)
+    entry.chmod(entry.stat().st_mode | stat.S_IXUSR)
+    (fork / "pyproject.toml").write_text('[project]\nname = "fork"\n', encoding="utf-8")
+    return fork
+
+
+def _run(fork: Path, home: Path, cwd: Path, **env_extra: str) -> subprocess.CompletedProcess[str]:
+    stub_dir = home / "stub-bin"
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    docker = stub_dir / "docker"
+    docker.write_text(DOCKER_STUB, encoding="utf-8")
+    docker.chmod(0o755)
+
+    env = {k: v for k, v in os.environ.items() if k not in {"TEATREE_SOURCE_MOUNT", "TEATREE_INVOCATION_CWD"}}
+    env["PATH"] = f"{stub_dir}{os.pathsep}{env['PATH']}"
+    env["TEATREE_HOST_HOME"] = str(home)
+    env.update(env_extra)
+
+    return subprocess.run(
+        [str(fork / "vendor" / "teatree" / "deploy" / "t3"), "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd,
+        check=False,
+    )
+
+
+@pytest.fixture
+def home(tmp_path: Path) -> Path:
+    return tmp_path / "home"
+
+
+class TestHostOnlyCheckoutIsRefused:
+    def test_a_checkout_outside_every_mount_never_reaches_docker(self, tmp_path: Path, home: Path) -> None:
+        fork = _build_fork(tmp_path)
+        home.mkdir(parents=True, exist_ok=True)
+        checkout = tmp_path / "host-only-clone"
+        (checkout / ".git").mkdir(parents=True)
+
+        proc = _run(fork, home, checkout)
+
+        assert proc.returncode != 0
+        assert DISPATCHED not in proc.stdout
+        assert str(checkout) in proc.stderr
+
+    def test_the_refusal_names_the_roots_the_container_can_see(self, tmp_path: Path, home: Path) -> None:
+        fork = _build_fork(tmp_path)
+        home.mkdir(parents=True, exist_ok=True)
+        checkout = tmp_path / "host-only-clone"
+        (checkout / ".git").mkdir(parents=True)
+
+        proc = _run(fork, home, checkout)
+
+        assert str(home / "workspace" / "t3-workspaces") in proc.stderr
+        assert "TEATREE_INVOCATION_CWD" in proc.stderr
+
+    def test_a_subdirectory_of_the_checkout_is_refused_too(self, tmp_path: Path, home: Path) -> None:
+        fork = _build_fork(tmp_path)
+        home.mkdir(parents=True, exist_ok=True)
+        checkout = tmp_path / "host-only-clone"
+        (checkout / ".git").mkdir(parents=True)
+        nested = checkout / "src" / "teatree"
+        nested.mkdir(parents=True)
+
+        proc = _run(fork, home, nested)
+
+        assert proc.returncode != 0
+        assert DISPATCHED not in proc.stdout
+
+    def test_a_linked_worktree_whose_dot_git_is_a_file_is_a_checkout(self, tmp_path: Path, home: Path) -> None:
+        """Teatree's own worktrees carry a ``.git`` FILE, not a directory."""
+        fork = _build_fork(tmp_path)
+        home.mkdir(parents=True, exist_ok=True)
+        linked = tmp_path / "host-only-worktree"
+        linked.mkdir(parents=True)
+        (linked / ".git").write_text("gitdir: /elsewhere/.git/worktrees/x\n", encoding="utf-8")
+
+        proc = _run(fork, home, linked)
+
+        assert proc.returncode != 0
+        assert DISPATCHED not in proc.stdout
+
+
+class TestVisibleCheckoutsStillDispatch:
+    def test_a_checkout_under_the_worktree_root_dispatches_translated(self, tmp_path: Path, home: Path) -> None:
+        fork = _build_fork(tmp_path)
+        worktree = home / "workspace" / "t3-workspaces" / "1234-ticket" / "teatree"
+        (worktree / ".git").mkdir(parents=True)
+
+        proc = _run(fork, home, worktree)
+
+        assert proc.returncode == 0
+        assert f"{DISPATCHED} TEATREE_INVOCATION_CWD={CONTAINER_WORKTREE_ROOT}/1234-ticket/teatree" in proc.stdout
+
+    def test_the_mounted_source_checkout_dispatches_translated(self, tmp_path: Path, home: Path) -> None:
+        fork = _build_fork(tmp_path)
+        home.mkdir(parents=True, exist_ok=True)
+        (fork / ".git").mkdir(parents=True)
+
+        proc = _run(fork, home, fork)
+
+        assert proc.returncode == 0
+        assert f"{DISPATCHED} TEATREE_INVOCATION_CWD={CONTAINER_SOURCE_DIR}" in proc.stdout
+
+
+class TestNonCheckoutCwdIsUnchanged:
+    """Behaviour preservation: only a *checkout* can be the wrong tree."""
+
+    def test_a_plain_directory_outside_every_mount_still_dispatches(self, tmp_path: Path, home: Path) -> None:
+        fork = _build_fork(tmp_path)
+        home.mkdir(parents=True, exist_ok=True)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir(parents=True)
+
+        proc = _run(fork, home, elsewhere)
+
+        assert proc.returncode == 0
+        assert f"{DISPATCHED} TEATREE_INVOCATION_CWD={UNSET}" in proc.stdout
+
+    def test_an_explicit_invocation_cwd_defeats_the_refusal(self, tmp_path: Path, home: Path) -> None:
+        """The operator named the container-side tree, so nothing is being guessed."""
+        fork = _build_fork(tmp_path)
+        home.mkdir(parents=True, exist_ok=True)
+        checkout = tmp_path / "host-only-clone"
+        (checkout / ".git").mkdir(parents=True)
+
+        proc = _run(fork, home, checkout, TEATREE_INVOCATION_CWD=CONTAINER_SOURCE_DIR)
+
+        assert proc.returncode == 0
+        assert f"{DISPATCHED} TEATREE_INVOCATION_CWD={CONTAINER_SOURCE_DIR}" in proc.stdout

--- a/tests/test_deploy_no_host_python_required.py
+++ b/tests/test_deploy_no_host_python_required.py
@@ -1,0 +1,114 @@
+"""``deploy/t3`` must run with no Python of any kind on the host (#3964).
+
+The whole point of the shim is that a host needs no interpreter, no uv, and no
+teatree install to invoke ``t3`` — the CLI lives in the image. A wrapper that
+quietly grew a ``python``/``uv``/``t3`` dependency would keep working on the
+maintainer's box (where all three exist) and fail only on the hosts the shim was
+written for, so the absence is pinned rather than assumed.
+
+PATH here carries the shell essentials and the ``docker`` stub, and nothing else.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests._deploy_wrapper_paths import container_worktree_root
+
+DEPLOY_DIR = Path(__file__).resolve().parents[1] / "deploy"
+WRAPPER = DEPLOY_DIR / "t3"
+
+CONTAINER_WORKTREE_ROOT = container_worktree_root()
+DISPATCHED = "DISPATCHED"
+
+# Every external the wrapper legitimately reaches for. Deliberately excludes
+# python/python3/uv/t3 — their absence is the subject.
+_SHELL_ESSENTIALS = (
+    "bash",
+    "sh",
+    "env",
+    "uname",
+    "stat",
+    "install",
+    "dirname",
+    "basename",
+    "head",
+    "awk",
+    "readlink",
+    "mkdir",
+    "cat",
+)
+
+DOCKER_STUB = f"""#!/usr/bin/env bash
+case "$1" in
+version | image) exit 0 ;;
+esac
+for arg in "$@"; do
+    case "$arg" in
+    ps) exit 0 ;;
+    config) printf 'teatree-worker:local\\n'; exit 0 ;;
+    run | exec) printf '{DISPATCHED} %s\\n' "${{TEATREE_INVOCATION_CWD-unset}}"; exit 0 ;;
+    esac
+done
+exit 0
+"""
+
+
+@pytest.fixture
+def bare_bin(tmp_path: Path) -> Path:
+    """A PATH directory with the shell essentials and nothing python-shaped."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for tool in _SHELL_ESSENTIALS:
+        source = shutil.which(tool)
+        if source:
+            (fake_bin / tool).symlink_to(source)
+    docker = fake_bin / "docker"
+    docker.write_text(DOCKER_STUB, encoding="utf-8")
+    docker.chmod(0o755)
+    return fake_bin
+
+
+@pytest.fixture
+def wrapper(tmp_path: Path) -> Path:
+    deploy = tmp_path / "checkout" / "deploy"
+    deploy.mkdir(parents=True, exist_ok=True)
+    entry = deploy / "t3"
+    shutil.copy2(WRAPPER, entry)
+    entry.chmod(entry.stat().st_mode | stat.S_IXUSR)
+    return entry
+
+
+class TestTheHostNeedsNoPythonToolchain:
+    def test_a_bind_mounted_worktree_dispatches_on_a_python_free_path(
+        self, tmp_path: Path, bare_bin: Path, wrapper: Path
+    ) -> None:
+        home = tmp_path / "home"
+        worktree = home / "workspace" / "t3-workspaces" / "4242-ticket" / "teatree"
+        (worktree / ".git").mkdir(parents=True)
+
+        proc = subprocess.run(
+            [str(wrapper), "--help"],
+            capture_output=True,
+            text=True,
+            env={"PATH": str(bare_bin), "HOME": str(home), "TEATREE_HOST_HOME": str(home)},
+            cwd=worktree,
+            check=False,
+        )
+
+        assert proc.returncode == 0, proc.stderr
+        assert f"{DISPATCHED} {CONTAINER_WORKTREE_ROOT}/4242-ticket/teatree" in proc.stdout
+
+    def test_no_interpreter_is_reachable_from_that_path(self, bare_bin: Path) -> None:
+        """Guards the guard: a PATH that still leaks a python proves nothing."""
+        env_path = str(bare_bin)
+
+        for absent in ("python", "python3", "uv", "t3"):
+            assert shutil.which(absent, path=env_path) is None
+
+        assert shutil.which("bash", path=env_path) is not None
+        assert os.sep in env_path

--- a/tests/test_deploy_stopped_stack_diagnostic.py
+++ b/tests/test_deploy_stopped_stack_diagnostic.py
@@ -1,0 +1,147 @@
+"""``deploy/t3`` must name how to start the stack, never leave docker to explain (#3964).
+
+Host ``t3`` is a shim, so a host with no deployment has nothing else to report
+with. Docker's own text for the two ways that happens — a dead daemon, or an
+image this host never built — names no teatree command, and on the never-built
+path it reads as a failed registry pull for an image that only ever existed
+locally.
+
+A merely STOPPED stack is deliberately NOT an error: the one-off container is the
+intended path there and works, so it must keep dispatching.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+DEPLOY_DIR = Path(__file__).resolve().parents[1] / "deploy"
+WRAPPER = DEPLOY_DIR / "t3"
+
+DISPATCHED_ONE_OFF = "DISPATCHED-RUN"
+DISPATCHED_EXEC = "DISPATCHED-EXEC"
+SERVICE_IMAGE = "teatree-worker:local"
+
+# Reports which hop it was handed, and fails the daemon / image probes on demand
+# so a test can put the host in either unavailable state.
+DOCKER_STUB = f"""#!/usr/bin/env bash
+case "$1" in
+version) exit "${{STUB_DAEMON_EXIT:-0}}" ;;
+image) exit "${{STUB_IMAGE_EXIT:-0}}" ;;
+esac
+for arg in "$@"; do
+    case "$arg" in
+    ps) printf '%s' "${{STUB_RUNNING_ID:-}}"; exit 0 ;;
+    config) printf '%s\\n' "${{STUB_SERVICE_IMAGE:-}}"; exit 0 ;;
+    run) printf '{DISPATCHED_ONE_OFF}\\n'; exit 0 ;;
+    exec) printf '{DISPATCHED_EXEC}\\n'; exit 0 ;;
+    esac
+done
+exit 0
+"""
+
+
+@pytest.fixture
+def home(tmp_path: Path) -> Path:
+    host_home = tmp_path / "home"
+    host_home.mkdir(parents=True, exist_ok=True)
+    return host_home
+
+
+@pytest.fixture
+def wrapper(tmp_path: Path) -> Path:
+    """The real wrapper, copied out so the checkout it runs from is ours."""
+    deploy = tmp_path / "checkout" / "deploy"
+    deploy.mkdir(parents=True, exist_ok=True)
+    entry = deploy / "t3"
+    shutil.copy2(WRAPPER, entry)
+    entry.chmod(entry.stat().st_mode | stat.S_IXUSR)
+    return entry
+
+
+def _run(wrapper: Path, home: Path, tmp_path: Path, **env_extra: str) -> subprocess.CompletedProcess[str]:
+    stub_dir = home / "stub-bin"
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    docker = stub_dir / "docker"
+    docker.write_text(DOCKER_STUB, encoding="utf-8")
+    docker.chmod(0o755)
+
+    env = {k: v for k, v in os.environ.items() if k not in {"TEATREE_SOURCE_MOUNT", "TEATREE_INVOCATION_CWD"}}
+    env["PATH"] = f"{stub_dir}{os.pathsep}{env['PATH']}"
+    env["TEATREE_HOST_HOME"] = str(home)
+    # Short-circuits the host `glab` resolution — irrelevant here and not always present.
+    env["GITLAB_TOKEN"] = "unused"
+    env["STUB_SERVICE_IMAGE"] = SERVICE_IMAGE
+    env.update(env_extra)
+
+    # A plain directory, so the invisible-checkout refusal has no tree to fire on.
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir(parents=True, exist_ok=True)
+
+    return subprocess.run(
+        [str(wrapper), "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=elsewhere,
+        check=False,
+    )
+
+
+class TestAnUnavailableStackIsNamed:
+    def test_an_unreachable_daemon_names_the_deploy_script(self, wrapper: Path, home: Path, tmp_path: Path) -> None:
+        proc = _run(wrapper, home, tmp_path, STUB_DAEMON_EXIT="1")
+
+        assert proc.returncode != 0
+        assert DISPATCHED_ONE_OFF not in proc.stdout
+        assert "deploy/deploy.sh" in proc.stderr
+        assert "Docker daemon" in proc.stderr
+
+    def test_a_never_built_image_names_the_deploy_script_and_the_image(
+        self, wrapper: Path, home: Path, tmp_path: Path
+    ) -> None:
+        proc = _run(wrapper, home, tmp_path, STUB_IMAGE_EXIT="1")
+
+        assert proc.returncode != 0
+        assert DISPATCHED_ONE_OFF not in proc.stdout
+        assert "deploy/deploy.sh" in proc.stderr
+        assert SERVICE_IMAGE in proc.stderr
+
+    def test_the_named_deploy_script_is_the_wrappers_own_checkout(
+        self, wrapper: Path, home: Path, tmp_path: Path
+    ) -> None:
+        """A vendored fork must be told about ITS deploy.sh, not a path from elsewhere."""
+        proc = _run(wrapper, home, tmp_path, STUB_DAEMON_EXIT="1")
+
+        assert str(tmp_path / "checkout" / "deploy" / "deploy.sh") in proc.stderr
+
+    def test_an_unresolvable_service_image_is_left_to_the_one_off_to_report(
+        self, wrapper: Path, home: Path, tmp_path: Path
+    ) -> None:
+        """Compose answering nothing is not evidence of an absent image."""
+        proc = _run(wrapper, home, tmp_path, STUB_SERVICE_IMAGE="", STUB_IMAGE_EXIT="1")
+
+        assert proc.returncode == 0
+        assert DISPATCHED_ONE_OFF in proc.stdout
+
+
+class TestAStoppedStackStillDispatches:
+    """Behaviour preservation: only an UNAVAILABLE stack is an error."""
+
+    def test_a_stopped_stack_with_a_built_image_runs_the_one_off(
+        self, wrapper: Path, home: Path, tmp_path: Path
+    ) -> None:
+        proc = _run(wrapper, home, tmp_path)
+
+        assert proc.returncode == 0
+        assert DISPATCHED_ONE_OFF in proc.stdout
+
+    def test_a_running_worker_execs_without_preflighting(self, wrapper: Path, home: Path, tmp_path: Path) -> None:
+        """The `ps` answer already proves the daemon and the image, so neither is re-probed."""
+        proc = _run(wrapper, home, tmp_path, STUB_RUNNING_ID="abc123", STUB_DAEMON_EXIT="1", STUB_IMAGE_EXIT="1")
+
+        assert proc.returncode == 0
+        assert DISPATCHED_EXEC in proc.stdout

--- a/tests/test_deploy_unreachable_path_diagnostic.py
+++ b/tests/test_deploy_unreachable_path_diagnostic.py
@@ -60,7 +60,11 @@ def _run(tmp_path: Path, *args: str, source_mount: Path | None = None) -> subpro
     if source_mount is not None:
         env["TEATREE_SOURCE_MOUNT"] = str(source_mount)
 
-    return subprocess.run([str(entry), *args], capture_output=True, text=True, check=True, env=env)
+    # Stand OUTSIDE any checkout: the subject here is an unreachable path ARGUMENT,
+    # and inheriting pytest's cwd would instead trip the invisible-checkout refusal
+    # (this repo is a checkout, and `TEATREE_HOST_HOME` is redirected above so it
+    # sits under none of the mounts the wrapper computes).
+    return subprocess.run([str(entry), *args], capture_output=True, text=True, check=True, env=env, cwd=tmp_path)
 
 
 class TestUnreachablePathDiagnostic:

--- a/tests/test_deploy_vendored_fork_source_mount.py
+++ b/tests/test_deploy_vendored_fork_source_mount.py
@@ -94,7 +94,14 @@ def _invoke(entry: Path, home: Path, env_overrides: dict[str, str] | None = None
     env["TEATREE_HOST_HOME"] = str(home)
     env.update(env_overrides or {})
 
-    proc = subprocess.run([str(entry), "--help"], capture_output=True, text=True, check=True, env=env)
+    # Stand OUTSIDE any checkout: the subject is the source-mount wiring, and
+    # inheriting pytest's cwd would instead trip the invisible-checkout refusal
+    # (this repo is a checkout, and `TEATREE_HOST_HOME` is redirected above so it
+    # sits under none of the mounts the wrapper computes).
+    elsewhere = home / "elsewhere"
+    elsewhere.mkdir(parents=True, exist_ok=True)
+
+    proc = subprocess.run([str(entry), "--help"], capture_output=True, text=True, check=True, env=env, cwd=elsewhere)
     return dict(line.split("=", 1) for line in proc.stdout.splitlines() if "=" in line)
 
 


### PR DESCRIPTION
Closes #3964 partially — see "What is NOT here" below.

## What

Three of the four acceptance bullets in #3964, each RED-proven.

- **`deploy/t3` refuses an invisible checkout.** An untranslated cwd degrades to the image WORKDIR, under which sits the container's *own* source volume — so a cwd-sensitive command run from a host-only checkout resolved against that copy and reported success having touched a different tree. Both trees are real teatree checkouts, so nothing downstream could detect it. Scoped to a *checkout*: `~`, `/tmp` and the like carry no tree to be wrong about, so every cwd-insensitive command keeps its pre-existing degrade-to-container-cwd behaviour, and `TEATREE_INVOCATION_CWD` remains the explicit escape.
- **`hooks/scripts/run-hook.sh` names the hook venv directly.** Host `t3` is a shim — a shell script with no interpreter beside it — so the old "discover the venv beside the resolved `t3` entry point" probe fell through to a bare `python3` with no Django, and every ORM-backed handler silently no-opped while the session looked healthy. The venv is now named via `$UV_TOOL_DIR` (uv's own knob) with the default uv-tool layout as the fallback. The entry-point probe survives, **demoted**, because it is the only route to a non-uv host install (pipx, a hand-rolled venv).
- **An unavailable stack is named, not left to docker.** The one-off `run --rm` fallback cannot run on a host with a dead daemon or an image it never built, and docker explains both in its own vocabulary naming no teatree command. Both are now preflighted with an actionable refusal pointing at the wrapper's own `deploy/deploy.sh`. Preflighted on the fallback path only — a running worker already proved both facts by answering `ps`, so the exec hot path pays nothing. A merely **stopped** stack stays a success: the one-off is the intended path there.
- **The host-needs-no-Python contract is pinned**, with its own control proving `python`/`python3`/`uv`/`t3` are genuinely unreachable from the test PATH.

## What is NOT here — needs an owner decision

The fourth acceptance bullet — *"the uv-tool install sites are reconciled so they target the image, not the host"* — is deliberately not in this branch.

Under end-state **A** (which this branch implements, per the issue's own framing), the host venv **must survive**: it is the hook runtime, and 16 hook scripts need Django. So "reconcile the install sites" cannot mean "delete the uv tool". What is actually left is narrower and sharper:

> `~/.local/bin/t3` is uv's entry point into that venv. The `t3` **alias** (#3232) shadows it in interactive shells only — scripts, agents and hooks on a non-interactive PATH still get the host Python CLI.

Making the host `t3` on PATH be the shim needs a decision this branch should not take unilaterally:

1. **Who installs the host shim?** `t3 setup` cannot: reached through the shim it runs *inside* the container, where `DockerAliasInstaller` correctly no-ops and the host `~/.local/bin` is not mounted. That leaves `deploy/deploy.sh` (host-side) or a documented manual bootstrap.
2. **Does the hook venv stop shipping a `t3` entry point?** The clean form of "re-scoped: the hook runtime, not a CLI install" is a plain venv rather than a uv *tool*. That is a new provisioning path and changes the discovery this branch just added.
3. **What happens to the supported native dev checkout?** `checks_docker.py` documents a plain native `uv tool install --editable` checkout as a mode; a shim that unconditionally wins on PATH removes it.

Each fork changes how every operator and agent invokes `t3` — including the interactive session that maintains this repo — which is exactly what the issue asks to be sequenced deliberately. Getting it wrong bricks `t3` on the box mid-session.

## Test evidence

Diff-scoped lane: `bash dev/test-affected.sh`. Gate parity: `t3 tool verify-gates`.

RED proofs, each by reverting only the source file and re-running:

| Behaviour | Pre-change | Post-change |
|---|---|---|
| invisible-checkout refusal + hook venv | 6 failed, 7 passed | 20 passed |
| unavailable-stack diagnostic | 3 failed, 3 passed | 6 passed |
| host-needs-no-Python pin (control: inject `python3 -c` into the wrapper) | 1 failed, 1 passed | 2 passed |

## Architecture pre-check — #3964

**1. BLUEPRINT § alignment** — the containerized-`t3` workflow (`deploy/t3`, #3232) and the hook chain. No section is contradicted; the change hardens two existing boundaries rather than moving one.

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition is touched.

**3. Extension-point contracts** — n/a. No `OverlayBase` method, scanner registration, hook-handler signature or `*Backend` Protocol changes. `run-hook.sh` changes only *which interpreter* runs the existing handlers, not their contract.

**4. Component boundaries** — `deploy/` (the host↔container wrapper) and `hooks/scripts/` (the hook runtime launcher). No `src/teatree/` module is touched, which is the point: the wrapper is the only layer that knows the mount mapping, and the hook launcher is the only layer that runs before an interpreter exists.

**5. Dependency direction** — no imports added; no Python source changed. `tach` is a no-op here and passed in the commit-stage gate chain.

**6. Test surface** — `tests/test_deploy_invisible_checkout_refusal.py` (refusal fires / does not fire, and the non-checkout + explicit-`TEATREE_INVOCATION_CWD` preservation cases); `tests/teatree_hooks/test_run_hook_interpreter_selection.py` (named venv outranks the entry point; the entry-point fallback still resolves; `UV_TOOL_DIR` honoured; unset `HOME` names no root path); `tests/test_deploy_stopped_stack_diagnostic.py` (both unavailable states refuse; stopped-but-deployed and running-worker still dispatch); `tests/test_deploy_no_host_python_required.py` (python-free PATH, plus the control). All exercise the real wrapper as a subprocess with a `docker` stub — docker being the one unstoppable external.

**7. Resilience invariants** — no external write is added. The refusals are local, deterministic and idempotent (re-running produces the same refusal, nothing is mutated). Fail-direction is deliberate: the cwd refusal fails **closed** because the wrong-tree resolution is certain, whereas the pre-existing unreachable-*argument* path stays a warning because the wrapper cannot know whether the CLI will open that argument. The unresolvable-service-image case fails **open** to the one-off, which reports it better than a guess would.

**8. Identity and key normalization** — host and container paths are the two forms of one identity, and the container-side path stays canonical: `TEATREE_INVOCATION_CWD` is only ever set by translating *up* through the mount table, never by stripping a prefix to force a match. Both sides of every comparison are physical (`pwd -P`), unchanged from before. `print_visible_host_roots` was extracted so the refusal and the unreachable-argument note read the same mount set and cannot drift.

**9. Behavior preservation / capability deletion** — nothing is deleted. The entry-point interpreter probe is *demoted*, not removed, and `TestEntryPointFallbackIsPreserved` pins that a pipx/hand-rolled venv still resolves. `TestNonCheckoutCwdIsUnchanged` and `TestAStoppedStackStillDispatches` pin the two behaviours a naive version of this change would have swallowed. No privacy/leak/security matcher is touched, and no must-block test was inverted. `tests/test_deploy_unreachable_path_diagnostic.py` gained an explicit `cwd=tmp_path` because its subject is an unreachable *argument*, and inheriting pytest's cwd would otherwise trip the new checkout refusal — the assertions themselves are unchanged.

**10. Removability / harness-vs-data** — both additions are self-contained shell functions with a single call site each; deleting either reverts exactly to the prior behaviour with no other edit. Harness is the right side: this is boundary-crossing logic, not per-item policy, and the varying part it does have (which host roots are visible, which image the service uses) is already read from data — the compose mount list and `docker compose config --images` — rather than hard-coded.

## Open questions & assumptions

- **End-state A vs B (#3964).** Chose **A** — shim the CLI, keep a host hook runtime. B (docker-exec hooks) puts per-tool-call latency on the hot path and needs a defined unreachable-container behaviour, neither of which the issue resolves. *Status: assumed.*
- **`UV_TOOL_DIR` is the hook-venv knob.** Hard-coding only the default layout missed every host that sets it. *Status: assumed.*
- **`.git` as the checkout marker**, resolved by pure shell expansion — it is what git itself looks for, it is a *file* in a linked worktree (teatree's own worktrees are that shape), and a hook subprocess inherits a restricted PATH where shelling out to `git` silently yields nothing. *Status: assumed.*
- **`docker compose config --images <service>` as the image-name source**, rather than assembling the name here — the only way to stay correct under an operator image override. *Status: assumed.*
- **A stopped-but-deployed stack stays non-error.** The one-off container works there; the issue's wording covers the case where the container cannot be reached at all. *Status: assumed.*
- **Who installs the host shim, whether the hook venv stops shipping a `t3` entry point, and whether the native dev checkout remains supported.** *Status: open — see "What is NOT here".*
