### PR TITLE
fix(hooks): read the host projection when the control DB is not on this host

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -81,10 +81,29 @@ fi
 # fallback: `mode=ro` first (live writer, sidecars present), then `immutable=1`
 # (quiescent WAL, no sidecars — `mode=ro` then errors). Fails silent (empty) on no
 # sqlite3, a missing DB, or any read error.
+# The host-visible projection of the container-owned control DB (#3499). Every
+# ConfigSetting read below resolves a HOST sqlite path, but a containerized deploy
+# keeps the control DB in a volume the host cannot open at all, so that path is
+# simply absent and each reader returns empty — which reads as "autoload is off"
+# and silently takes the whole statusline with it. The publisher writes this file
+# for exactly this consumer; `teatree.config.cold_db.canonical_projection()` is the
+# Python half of the same fallback. Fails silent (empty) on no jq, no file, or a
+# shape it does not recognise, so a plain-clone host is unaffected.
+_projection_setting() {
+    command -v jq >/dev/null 2>&1 || return 0
+    local proj="${TEATREE_HOST_PROJECTION:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/host-projection.json}"
+    [ -r "$proj" ] || return 0
+    # `settings` is keyed by SCOPE; "" is global. Values are stored decoded, so a
+    # bool arrives as `true`/`false` — the same text the sqlite read yields.
+    jq -r --arg k "$1" '.settings[""][$k] // empty' "$proj" 2>/dev/null || return 0
+}
+
 _autoload_db_value() {
-    command -v sqlite3 >/dev/null 2>&1 || return 0
     local db="${T3_CONFIG_DB:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/db.sqlite3}"
-    [ -f "$db" ] || return 0
+    if ! command -v sqlite3 >/dev/null 2>&1 || [ ! -f "$db" ]; then
+        _projection_setting "autoload"
+        return 0
+    fi
     local q="SELECT value FROM teatree_config_setting WHERE scope='' AND key='autoload' LIMIT 1;"
     sqlite3 "file:${db}?mode=ro" "$q" 2>/dev/null \
         || sqlite3 "file:${db}?immutable=1" "$q" 2>/dev/null \
@@ -97,9 +116,16 @@ _autoload_db_value() {
 # fallback as `_autoload_db_value`. Empty on no sqlite3, a missing DB, no row, or a
 # non-array value.
 _statusline_chain_db() {
-    command -v sqlite3 >/dev/null 2>&1 || return 0
     local db="${T3_CONFIG_DB:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/db.sqlite3}"
-    [ -f "$db" ] || return 0
+    if ! command -v sqlite3 >/dev/null 2>&1 || [ ! -f "$db" ]; then
+        # Same fallback, flattened: the caller wants one pattern per line, and the
+        # projection holds the array whole.
+        command -v jq >/dev/null 2>&1 || return 0
+        local proj="${TEATREE_HOST_PROJECTION:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/host-projection.json}"
+        [ -r "$proj" ] || return 0
+        jq -r '.settings[""].statusline_chain // [] | .[]' "$proj" 2>/dev/null || return 0
+        return 0
+    fi
     local q="SELECT je.value FROM teatree_config_setting t, json_each(t.value) je WHERE t.scope='' AND t.key='statusline_chain';"
     sqlite3 "file:${db}?mode=ro" "$q" 2>/dev/null \
         || sqlite3 "file:${db}?immutable=1" "$q" 2>/dev/null \
@@ -130,9 +156,11 @@ autoload_enabled() {
 # (#3502), JSON-decoded: `true` / `false` / empty. Read-only via the sqlite3 CLI
 # with the same WAL fallback and fail-silent-empty contract as `_autoload_db_value`.
 _statusline_engaged_render_db_value() {
-    command -v sqlite3 >/dev/null 2>&1 || return 0
     local db="${T3_CONFIG_DB:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/db.sqlite3}"
-    [ -f "$db" ] || return 0
+    if ! command -v sqlite3 >/dev/null 2>&1 || [ ! -f "$db" ]; then
+        _projection_setting "statusline_engaged_render"
+        return 0
+    fi
     local q="SELECT value FROM teatree_config_setting WHERE scope='' AND key='statusline_engaged_render' LIMIT 1;"
     sqlite3 "file:${db}?mode=ro" "$q" 2>/dev/null \
         || sqlite3 "file:${db}?immutable=1" "$q" 2>/dev/null \

--- a/tests/conformance/test_cross_tier_artifact_parity.py
+++ b/tests/conformance/test_cross_tier_artifact_parity.py
@@ -91,6 +91,7 @@ PARITY_LANE_ROSTER: dict[str, str] = {
     "consolidation-registry.json": "tests/test_consolidation_registry_parity.py",
     "skill-metadata.json": "tests/test_skill_metadata_cache_parity.py",
     "statusline.txt": "tests/test_statusline_shell_parity.py",
+    "host-projection.json": "tests/test_statusline_shell_parity.py",
 }
 
 #: Cross-tier artifacts with NO both-tier pin yet — the ratchet ledger.

--- a/tests/test_statusline_shell_parity.py
+++ b/tests/test_statusline_shell_parity.py
@@ -35,6 +35,7 @@ from pathlib import Path
 import pytest
 
 import hooks.scripts.hook_router as router
+from teatree.config.host_projection import ProjectionPublisher
 from teatree.config.setting_parsers import _parse_str_list, _parse_strict_bool
 from teatree.loop.statusline_render import StatuslineEntry, StatuslineZones, default_path, render
 
@@ -320,3 +321,74 @@ def test_the_consumer_and_its_dependencies_are_present() -> None:
     assert _SCRIPT.is_file()
     assert shutil.which("jq"), "statusline.sh parses its stdin payload with jq"
     assert shutil.which("sqlite3"), "the settings tier under test IS the sqlite3 CLI read"
+
+
+class TestStatuslineReadsTheProjectionWhenTheDbIsNotOnThisHost:
+    """The Django PUBLISHER's projection is read by the Django-free shell CONSUMER.
+
+    The shell tier resolves a HOST sqlite path. Once the control DB moved into a
+    container-only volume (#4001) that path was absent, every ConfigSetting read returned
+    empty, and an ABSENT store is indistinguishable from ``autoload = false`` — so the bar
+    vanished and claimed "autoload disabled", which is a different and untrue statement.
+    The Python tier already had this fallback (``cold_db.canonical_projection``); the shell
+    did not, which is why ``t3 loop status`` kept working while the statusline went dark.
+
+    This is a real both-tier lane: :class:`ProjectionPublisher` WRITES the artifact and the
+    shell READS it, so a change to either side's shape fails here rather than in production.
+    """
+
+    def _publish(self, sandbox: Path, rows: dict[str, object]) -> None:
+        """Write the projection the way production does — through the real publisher."""
+        db = sandbox / "source.sqlite3"
+        _seed_config_db(db, rows)
+        # The publisher projects the loop/mode tables alongside settings, so the source
+        # has to carry them. Empty is honest here: this lane is about the settings tier
+        # reaching the shell, and an empty loop table projects as no loop state.
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute("CREATE TABLE IF NOT EXISTS teatree_loop_state (name TEXT, status TEXT)")
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS teatree_loop_preset "
+                "(name TEXT, defers_questions INT, pauses_self_pump INT, presence_sensitive INT)"
+            )
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS teatree_loop_preset_override (preset_name TEXT, until TEXT, set_at TEXT)"
+            )
+            conn.execute("CREATE TABLE IF NOT EXISTS teatree_loop_schedule (name TEXT, id INT, timezone TEXT)")
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS teatree_loop_schedule_slot "
+                "(schedule_id INT, days TEXT, start_time TEXT, preset_name TEXT)"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        data_dir = sandbox / "xdg" / "teatree"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        ProjectionPublisher(db, data_dir).publish()
+        # The consumer hardcodes this filename, so the name IS part of the seam: rename it
+        # publisher-side and the shell silently reads nothing, which is the failure this
+        # whole lane exists to catch.
+        assert (data_dir / "host-projection.json").is_file(), "the publisher wrote the file the shell reads"
+
+    def _render(self, sandbox: Path) -> str:
+        target = sandbox / "zones" / "statusline.txt"
+        target.parent.mkdir(exist_ok=True)
+        render(StatuslineZones(anchors=["[acme] projection chip"]), target=target, colorize=False)
+        # A path that does NOT exist: exactly the containerized host's situation.
+        result = _run_shell(sandbox, statusline_file=target, autoload_env=None, config_db=sandbox / "absent.sqlite3")
+        assert result.returncode == 0, result.stderr
+        return _strip_ansi(result.stdout)
+
+    def test_a_published_opt_in_opens_the_gate(self, sandbox: Path) -> None:
+        self._publish(sandbox, {"autoload": True})
+        assert "projection chip" in self._render(sandbox), "the publisher's value reached the shell"
+
+    def test_no_projection_still_refuses(self, sandbox: Path) -> None:
+        # Anti-vacuous: a fallback that ignored its input, or opened the gate whenever the
+        # sqlite path was missing, would pass the test above and fail this one.
+        assert "statusline off" in self._render(sandbox)
+
+    def test_a_published_false_still_refuses(self, sandbox: Path) -> None:
+        # The shell must READ the published value, not merely notice the file exists.
+        self._publish(sandbox, {"autoload": False})
+        assert "projection chip" not in self._render(sandbox)


### PR DESCRIPTION
## What

`hooks/scripts/statusline.sh` resolves the `ConfigSetting` store at a host sqlite path in three
readers (`_autoload_db_value`, `_statusline_chain_db`, `_statusline_engaged_render_db_value`).
Each falls back to `host-projection.json` when that path is absent.

## Why

A containerized deploy keeps the control DB in a volume the host cannot open, so the sqlite path
is simply not there and every read returns empty. An **absent** store is indistinguishable from
`autoload = false`, so the bar disappears and reports "autoload disabled" — a different and untrue
claim. Both arms of the render gate consult the same missing file, so the `.teatree-active`
engagement marker cannot rescue it.

The Python tier already had this fallback (`teatree.config.cold_db.canonical_projection`); the
shell tier did not. That asymmetry is the bug: `t3 loop status` kept rendering while the harness
statusline went dark, which reads as a statusline fault rather than a settings-read fault.

Pointing the shell at the volume is not an option — it has no host bind mount. The projection is
the sanctioned host-side read surface, and the publisher already writes it.

## Tests

`tests/test_statusline_shell_parity.py` gains a real both-tier lane: `ProjectionPublisher` WRITES
the artifact and the shell READS it, so a change to either side's shape fails here instead of in
production. Three cases, two of them anti-vacuity —

- a published opt-in opens the gate
- **no projection at all still refuses** (a fallback ignoring its input would pass the first case)
- **a published `false` still refuses** (the shell must read the value, not notice the file)

plus an assertion that the publisher wrote the filename the consumer hardcodes, since a rename
publisher-side would otherwise leave the shell silently reading nothing.

`host-projection.json` is enrolled in `PARITY_LANE_ROSTER`, so it is now covered by the same
cross-tier discipline as `statusline.txt`.
