### PR TITLE
fix(config): decide credential routing from the stored health, never a live probe

### DIFF
--- a/src/teatree/credential_config.py
+++ b/src/teatree/credential_config.py
@@ -28,8 +28,8 @@ exhausted:
     row upserted, and the first non-exhausted one is pinned as the new sticky pick.
 *   When the overlay's own accounts are all exhausted the selector falls back to ANY
     other configured account (across overlays); when every account's CACHED verdict still
-    reads exhausted, a last-ditch live re-probe (:meth:`PassPathSelector._rescue_reprobe`,
-    cooldown-throttled) runs first — a rolling 5h window frees capacity before its recorded
+    reads exhausted, selection fails loud rather than probing: `refresh_all` is the one
+writer that keeps the stored health current.
     reset, so a recovered account is rescued rather than stranding the loop. Only when the
     rescue also finds nothing usable does it raise :class:`AllTokensExhaustedError` (a
     :class:`CredentialError`) naming the earliest reset, halting agent work loudly.
@@ -71,13 +71,6 @@ if TYPE_CHECKING:
     from teatree.config.agent_enums import AgentHarnessProvider
 
 logger = logging.getLogger(__name__)
-
-#: A cached-exhausted verdict is trusted until its recorded window reset, but a rolling
-#: 5h window frees capacity continuously — well before that reset. When every account
-#: reads exhausted, :meth:`PassPathSelector._rescue_reprobe` re-probes live before
-#: declaring a hard stall; this cooldown skips any account probed more recently than
-#: this, so a spinning all-exhausted dispatch loop cannot storm the rate-limit API.
-_RESCUE_REPROBE_COOLDOWN = dt.timedelta(seconds=60)
 
 
 class TokenKind(StrEnum):
@@ -140,11 +133,9 @@ class PassPathSelector:
         union — a bare eval shell (no active overlay → :data:`GLOBAL_SCOPE`) still routes
         to an overlay-scoped account without a manual env export. An empty union (nothing
         configured anywhere) returns ``None`` so the caller fails loud downstream.
-        When every account's CACHED verdict reads exhausted, a last-ditch live
-        :meth:`_rescue_reprobe` runs before the hard fail — a rolling 5h window frees
-        capacity before its recorded reset, so a recovered account is rescued here rather
-        than after its full reset. Raises :class:`AllTokensExhaustedError` only when the
-        rescue re-probe also finds no usable account anywhere.
+        Selection performs no network I/O: a candidate is ruled out only by a FRESH stored
+        exhausted verdict, and :meth:`refresh_all` is what keeps those rows current. Raises
+        :class:`AllTokensExhaustedError` when every account reads freshly exhausted.
         """
         configured = self._configured_paths(kind, scope)
         fell_back_across_scopes = False
@@ -159,12 +150,10 @@ class PassPathSelector:
         if sticky is not None and self._sticky_is_usable(sticky, now):
             return sticky
 
-        chosen = self._first_usable(kind, configured, now)
+        chosen = self._first_usable(configured, now)
         if chosen is None:
             others = [path for path in self._all_configured_paths(kind) if path not in configured]
-            chosen = self._first_usable(kind, others, now)
-        if chosen is None:
-            chosen = self._rescue_reprobe(kind, configured, now)
+            chosen = self._first_usable(others, now)
         if chosen is None:
             raise self._all_exhausted_error(kind)
 
@@ -181,47 +170,49 @@ class PassPathSelector:
             )
         return chosen
 
+    def refresh_all(self, *, now: dt.datetime | None = None) -> int:
+        """Probe every configured account and upsert its health row — the ONE writer.
+
+        Selection reads what this leaves behind and never opens a socket itself, so this is
+        the only place a slow, throttled or unreachable rate-limit API can cost anything —
+        and it costs a stale row, not the dispatch that was about to start work. Run it on a
+        cadence; a probe that fails leaves the previous row standing.
+
+        Returns how many rows were written.
+        """
+        moment = now or timezone.now()
+        written = 0
+        for kind in TokenKind:
+            for pass_path in self._all_configured_paths(kind):
+                if self._probe(kind, pass_path, moment) is not None:
+                    written += 1
+        return written
+
     @staticmethod
     def _sticky_is_usable(pass_path: str, now: dt.datetime) -> bool:
         row = AnthropicTokenUsage.objects.filter(pass_path=pass_path).first()
         return row is not None and row.is_fresh(now) and not row.is_exhausted
 
-    def _first_usable(self, kind: TokenKind, candidates: list[str], now: dt.datetime) -> str | None:
-        """The first candidate whose cached-or-freshly-probed health is not exhausted."""
-        for pass_path in candidates:
-            row = AnthropicTokenUsage.objects.filter(pass_path=pass_path).first()
-            if row is not None and row.is_fresh(now):
-                if not row.is_exhausted:
-                    return pass_path
-                continue
-            probed = self._probe(kind, pass_path, now)
-            if probed is not None and not probed.is_exhausted:
-                return pass_path
-        return None
+    @staticmethod
+    def _first_usable(candidates: list[str], now: dt.datetime) -> str | None:
+        """The first candidate the STORED health does not rule out — no network here.
 
-    def _rescue_reprobe(self, kind: TokenKind, configured: list[str], now: dt.datetime) -> str | None:
-        """Last-ditch live re-probe before declaring every account exhausted (#3406).
+        Selection reads :class:`AnthropicTokenUsage` and nothing else, so picking an account
+        costs one query and cannot be stalled by a slow, throttled or unreachable rate-limit
+        API. :func:`refresh_account_health` is the single writer; it probes on a cadence.
 
-        The normal path trusts a FRESH cached-exhausted verdict without re-probing, and an
-        exhausted row is cached until its recorded window reset. But a subscription 5h
-        window is ROLLING — capacity returns continuously, well before that reset — so a
-        cached-exhausted verdict can outlive the real exhaustion and strand the loop on
-        "all accounts exhausted" while an account has in fact recovered. When every
-        candidate reads exhausted, this re-probes each account LIVE (ignoring cache
-        freshness) and returns the first that recovered, bounding the stall to
-        :data:`_RESCUE_REPROBE_COOLDOWN` past real recovery rather than the full reset. The
-        cooldown skips any account probed within that window, so a spinning all-exhausted
-        dispatch loop cannot storm the rate-limit API — one live re-probe per account per
-        cooldown is enough to catch a rolling-window recovery.
+        An account with no row, or one whose row has gone stale, is OFFERED rather than
+        skipped: a cold or lagging table must never be able to halt dispatch, which is the
+        outage this replaces — capacity existed and nothing ran. A genuinely spent account
+        costs one refused call and then records itself through
+        :func:`record_reactive_exhaustion_and_reselect`, so the mistake is self-correcting
+        and bounded. Only a FRESH exhausted verdict rules a candidate out.
         """
-        candidates = configured + [path for path in self._all_configured_paths(kind) if path not in configured]
         for pass_path in candidates:
             row = AnthropicTokenUsage.objects.filter(pass_path=pass_path).first()
-            if row is not None and (now - row.checked_at) < _RESCUE_REPROBE_COOLDOWN:
+            if row is not None and row.is_fresh(now) and row.is_exhausted:
                 continue
-            probed = self._probe(kind, pass_path, now)
-            if probed is not None and not probed.is_exhausted:
-                return pass_path
+            return pass_path
         return None
 
     def _probe(self, kind: TokenKind, pass_path: str, now: dt.datetime) -> AnthropicTokenUsage | None:
@@ -235,12 +226,34 @@ class PassPathSelector:
         try:
             token = credential.resolve()
         except CredentialError:
-            return None
+            return self._record_unusable(pass_path, now)
         try:
             reading = self._health_reading(kind, token)
         except RateLimitProbeError:
-            return None
+            return self._record_unusable(pass_path, now)
         return AnthropicTokenUsage.objects.record(pass_path, reading, now=now)
+
+    @staticmethod
+    def _record_unusable(pass_path: str, now: dt.datetime) -> AnthropicTokenUsage:
+        """Store an account the probe could not use at all as REJECTED.
+
+        An unresolvable credential and a dead probe transport are both "this account cannot
+        serve a request", and selection no longer probes, so the only way it can skip such an
+        account is to find that verdict already written. Recording it as rejected — the status
+        the exhaustion rule already treats as spent — keeps the skip without giving selection
+        back a network call. The verdict expires like any other, so a repaired account
+        recovers on the next refresh rather than being blacklisted.
+        """
+        rejected = TokenHealthReading(
+            organization_id="",
+            utilization_5h=0.0,
+            utilization_7d=0.0,
+            status_5h=REJECTED_STATUS,
+            status_7d=REJECTED_STATUS,
+            reset_5h=None,
+            reset_7d=None,
+        )
+        return AnthropicTokenUsage.objects.record(pass_path, rejected, now=now)
 
     def _health_reading(self, kind: TokenKind, token: str) -> TokenHealthReading:
         """Probe *token* the way its *kind* authenticates and fold it into a cache reading.

--- a/tests/test_credential_config.py
+++ b/tests/test_credential_config.py
@@ -129,7 +129,29 @@ class TestSelectorDefaultPath(TestCase):
         reader = _FakeReader({})
         with _pass_echoes_path():
             assert PassPathSelector(reader=reader).select(TokenKind.OAUTH) is None
-        assert reader.calls == [], "an unconfigured kind must not probe"
+        assert reader.calls == [], "selection reads the store, never the network"
+
+
+def _seed_from_reader(reader: "_FakeReader") -> None:
+    """Store the reader's canned health as the verdicts selection will actually read.
+
+    These tests were written when selection probed, so the reader stub WAS the health.
+    Selection now reads the store, so the same fixture data has to land there — this keeps
+    each test's intent (which account is spent) while moving where that fact lives.
+    """
+    for pass_path, snapshot in reader._health.items():
+        AnthropicTokenUsage.objects.record(pass_path, reading_from(snapshot), now=timezone.now())
+
+
+def _seed_health(pass_path: str, *, exhausted: bool, hours_to_reset: float = 4.0) -> None:
+    """Store a FRESH verdict for *pass_path* — what selection now reads instead of probing.
+
+    Selection consults `AnthropicTokenUsage` and never the network, so a test that wants an
+    account ruled out must say so in the store; a reader stub no longer reaches the decision.
+    """
+    reset = timezone.now() + dt.timedelta(hours=hours_to_reset)
+    snapshot = _snapshot(u5=0.99, reset=reset) if exhausted else _snapshot(reset=reset)
+    AnthropicTokenUsage.objects.record(pass_path, reading_from(snapshot), now=timezone.now())
 
 
 class TestSelectorRouting(TestCase):
@@ -139,7 +161,7 @@ class TestSelectorRouting(TestCase):
         with _pass_echoes_path():
             chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
         assert chosen == "anthropic/a/oauth"
-        assert reader.calls == ["anthropic/a/oauth"], "the first healthy account short-circuits the rest"
+        assert reader.calls == [], "selection reads the store, never the network"
         assert AnthropicActivePick.objects.pick_for("oauth", "") == "anthropic/a/oauth"
 
     def test_overlay_list_falls_back_to_global_when_overlay_has_none(self) -> None:
@@ -157,6 +179,7 @@ class TestSelectorRouting(TestCase):
                 "anthropic/b/oauth": _snapshot(),
             }
         )
+        _seed_from_reader(reader)
         with _pass_echoes_path():
             chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
         assert chosen == "anthropic/b/oauth"
@@ -170,6 +193,7 @@ class TestSelectorRouting(TestCase):
                 "anthropic/other/oauth": _snapshot(),
             }
         )
+        _seed_from_reader(reader)
         with _pass_echoes_path():
             chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH, scope="overlay-x")
         assert chosen == "anthropic/other/oauth", "own account exhausted → borrow another overlay's healthy account"
@@ -181,9 +205,13 @@ class TestSelectorRouting(TestCase):
         with (
             _pass_echoes_path(),
             patch("teatree.credential_config.read_api_key_status", return_value=_metered(out_of_credits=True)),
-            pytest.raises(AllTokensExhaustedError),
         ):
-            PassPathSelector().select(TokenKind.API_KEY)
+            selector = PassPathSelector()
+            # The refresh is what writes the out-of-credits verdict down; the refusal below
+            # is selection reading it, not re-probing the key.
+            selector.refresh_all()
+            with pytest.raises(AllTokensExhaustedError):
+                selector.select(TokenKind.API_KEY)
 
     def test_funded_api_key_is_routed(self) -> None:
         ConfigSetting.objects.set_value(_API_KEY_SETTING, ["anthropic/a/api", "anthropic/b/api"])
@@ -203,6 +231,7 @@ class TestSelectorRouting(TestCase):
                 "anthropic/b/oauth": _snapshot(u5=0.98, reset=soon),
             }
         )
+        _seed_from_reader(reader)
         with _pass_echoes_path(), pytest.raises(AllTokensExhaustedError) as caught:
             PassPathSelector(reader=reader).select(TokenKind.OAUTH)
         message = str(caught.value)
@@ -249,6 +278,7 @@ class TestSelectorRouting(TestCase):
             }
         )
 
+        _seed_from_reader(reader)
         with _pass_echoes_path(), pytest.raises(AllTokensExhaustedError) as caught:
             PassPathSelector(reader=reader).select(TokenKind.OAUTH)
 
@@ -256,41 +286,70 @@ class TestSelectorRouting(TestCase):
         assert caught.value.earliest_reset > now, "a park keyed on this must never be already elapsed"
 
 
-class TestSelectorRescueReprobe(TestCase):
-    """#3406: a cached-exhausted verdict outlives a rolling window's real recovery.
+class TestSelectionNeverProbes(TestCase):
+    """Selection reads the stored health and opens no socket (the #3406 stall, inverted).
 
-    An exhausted health row is trusted until its recorded reset, but a 5h window frees
-    capacity continuously — so when every account reads exhausted the selector re-probes
-    LIVE before declaring a hard stall, rescuing an account that has since recovered
-    rather than stranding the loop until the full recorded reset.
+    The old selector probed LIVE whenever a row was missing or stale, so the decision
+    "can work start" depended on the rate-limit API being reachable and quick. When it
+    was not, selection returned nothing and the factory idled with capacity to spare.
+    `refresh_all` now owns every probe; these pin that the selection path performs none.
     """
 
-    def test_rescue_reprobes_a_cached_exhausted_account_that_recovered(self) -> None:
+    def test_absent_rows_are_offered_without_a_probe(self) -> None:
+        # Fail-open: a cold health table must never be able to halt dispatch. A spent
+        # account costs one refused call and records itself through the reactive path.
         ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth", "anthropic/b/oauth"])
-        stale = timezone.now() - dt.timedelta(minutes=5)
-        reset = timezone.now() + dt.timedelta(hours=4)
-        # Both cached EXHAUSTED (fresh until their far reset), so the cache-respecting
-        # path would hard-fail — but account b has since recovered.
-        for path in ("anthropic/a/oauth", "anthropic/b/oauth"):
-            AnthropicTokenUsage.objects.record(path, reading_from(_snapshot(u5=0.99, reset=reset)), now=stale)
-        reader = _FakeReader({"anthropic/a/oauth": _snapshot(u5=0.99, reset=reset), "anthropic/b/oauth": _snapshot()})
+        reader = _FakeReader({"anthropic/a/oauth": _snapshot(), "anthropic/b/oauth": _snapshot()})
         with _pass_echoes_path():
             chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
-        assert chosen == "anthropic/b/oauth", "the rescue re-probe routes to the recovered account"
-        assert reader.calls == ["anthropic/a/oauth", "anthropic/b/oauth"], "only the rescue path re-probes"
+        assert chosen == "anthropic/a/oauth", "an account with no stored verdict is offered, not skipped"
+        assert reader.calls == [], "selection reads the store, never the network"
 
-    def test_rescue_cooldown_skips_a_just_probed_account(self) -> None:
-        # A just-probed exhausted account is NOT re-probed within the cooldown, so a
-        # spinning all-exhausted dispatch loop cannot storm the rate-limit API.
+    def test_a_stale_exhausted_row_is_offered_without_a_probe(self) -> None:
+        # A rolling window frees capacity before its recorded reset, so a verdict that has
+        # aged out is not evidence of exhaustion — and re-probing to find out is what used
+        # to stall the lane. Offering it costs at most one refused call.
+        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth"])
+        # An exhausted verdict is trusted until its BLOCKING WINDOW re-arms, not for a flat
+        # TTL — so "stale" here means the reset has since passed and the account may well
+        # have capacity again. Offering it is the point: the alternative is stranding a
+        # recovered account until something probes it.
+        aged = timezone.now() - dt.timedelta(hours=6)
+        elapsed_reset = timezone.now() - dt.timedelta(minutes=1)
+        AnthropicTokenUsage.objects.record(
+            "anthropic/a/oauth", reading_from(_snapshot(u5=0.99, reset=elapsed_reset)), now=aged
+        )
+        reader = _FakeReader({"anthropic/a/oauth": _snapshot()})
+        with _pass_echoes_path():
+            chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
+        assert chosen == "anthropic/a/oauth", "a stale verdict does not rule an account out"
+        assert reader.calls == [], "selection reads the store, never the network"
+
+    def test_a_fresh_exhausted_row_still_hard_fails_without_a_probe(self) -> None:
+        # Anti-vacuous: if selection ignored stored health entirely both tests above would
+        # pass while the selector routed to a known-spent account every time.
         ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth"])
         reset = timezone.now() + dt.timedelta(hours=4)
         AnthropicTokenUsage.objects.record(
             "anthropic/a/oauth", reading_from(_snapshot(u5=0.99, reset=reset)), now=timezone.now()
         )
-        reader = _FakeReader({"anthropic/a/oauth": _snapshot()})  # would read healthy IF re-probed
+        reader = _FakeReader({"anthropic/a/oauth": _snapshot()})  # would read healthy IF probed
         with _pass_echoes_path(), pytest.raises(AllTokensExhaustedError):
             PassPathSelector(reader=reader).select(TokenKind.OAUTH)
-        assert reader.calls == [], "a just-probed account is not re-probed within the cooldown"
+        assert reader.calls == [], "selection reads the store, never the network"
+
+
+class TestRefreshAllIsTheOneWriter(TestCase):
+    """`refresh_all` is where the probes live, so a slow API costs a stale row."""
+
+    def test_it_probes_every_configured_account_and_stores_the_verdicts(self) -> None:
+        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth", "anthropic/b/oauth"])
+        reader = _FakeReader({"anthropic/a/oauth": _snapshot(), "anthropic/b/oauth": _snapshot()})
+        with _pass_echoes_path():
+            written = PassPathSelector(reader=reader).refresh_all()
+        assert written == 2
+        assert sorted(reader.calls) == ["anthropic/a/oauth", "anthropic/b/oauth"], "every account is probed"
+        assert AnthropicTokenUsage.objects.count() == 2, "each probe leaves a row selection can read"
 
 
 class TestSelectorCrossScopeFallback(TestCase):
@@ -324,6 +383,7 @@ class TestSelectorCrossScopeFallback(TestCase):
                 "anthropic/healthy/oauth": _snapshot(),
             }
         )
+        _seed_from_reader(reader)
         with _pass_echoes_path():
             chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH, scope=GLOBAL_SCOPE)
         assert chosen == "anthropic/healthy/oauth", "an exhausted union member is skipped for the next healthy account"
@@ -333,7 +393,7 @@ class TestSelectorCrossScopeFallback(TestCase):
         reader = _FakeReader({})
         with _pass_echoes_path():
             assert PassPathSelector(reader=reader).select(TokenKind.OAUTH, scope=GLOBAL_SCOPE) is None
-        assert reader.calls == [], "an all-empty union must not probe"
+        assert reader.calls == [], "selection reads the store, never the network"
 
     def test_all_exhausted_union_raises_all_tokens_exhausted(self) -> None:
         soon = timezone.now() + dt.timedelta(hours=1)
@@ -345,6 +405,7 @@ class TestSelectorCrossScopeFallback(TestCase):
                 "anthropic/b/oauth": _snapshot(u5=0.98, reset=soon + dt.timedelta(hours=1)),
             }
         )
+        _seed_from_reader(reader)
         with _pass_echoes_path(), pytest.raises(AllTokensExhaustedError):
             PassPathSelector(reader=reader).select(TokenKind.OAUTH, scope=GLOBAL_SCOPE)
 
@@ -366,7 +427,7 @@ class TestSelectorSkipsUnusableCandidates(TestCase):
         with _pass_echoes_path():
             chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
         assert chosen == "anthropic/b/oauth"
-        assert reader.calls == ["anthropic/b/oauth"], "the cached exhausted account is skipped, not re-probed"
+        assert reader.calls == [], "selection reads the store, never the network"
 
     def test_candidate_whose_credential_cannot_resolve_is_skipped(self) -> None:
         ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth", "anthropic/b/oauth"])
@@ -378,9 +439,17 @@ class TestSelectorSkipsUnusableCandidates(TestCase):
                 side_effect=lambda path: "" if path == "anthropic/a/oauth" else path,
             ),
         ):
-            chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
+            selector = PassPathSelector(reader=reader)
+            # The writer is what learns an account is unusable; selection only reads what it
+            # left. Refreshing first is the whole contract, so this exercises both halves
+            # rather than asserting a skip selection could not make on its own.
+            selector.refresh_all()
+            after_refresh = list(reader.calls)
+            chosen = selector.select(TokenKind.OAUTH)
         assert chosen == "anthropic/b/oauth", "an unresolvable credential is skipped for the next candidate"
-        assert reader.calls == ["anthropic/b/oauth"], "the unresolvable account is never probed"
+        # The refresh probes — that is its job. What must hold is that SELECTION adds
+        # nothing to that list: it decided purely from what the refresh wrote down.
+        assert reader.calls == after_refresh, "selection reads the store, never the network"
 
     def test_cached_fresh_healthy_candidate_is_returned_without_a_probe(self) -> None:
         ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth"])
@@ -389,7 +458,7 @@ class TestSelectorSkipsUnusableCandidates(TestCase):
         with _pass_echoes_path():
             chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
         assert chosen == "anthropic/a/oauth"
-        assert reader.calls == [], "a fresh healthy cached candidate is returned from the cache, never re-probed"
+        assert reader.calls == [], "selection reads the store, never the network"
 
     def test_candidate_whose_probe_transport_fails_is_skipped(self) -> None:
         ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth", "anthropic/b/oauth"])
@@ -407,9 +476,14 @@ class TestSelectorSkipsUnusableCandidates(TestCase):
 
         reader = _RaisingReader()
         with _pass_echoes_path():
-            chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
+            selector = PassPathSelector(reader=reader)
+            selector.refresh_all()
+            after_refresh = list(reader.calls)
+            chosen = selector.select(TokenKind.OAUTH)
         assert chosen == "anthropic/b/oauth", "a probe transport failure makes the candidate unusable, not fatal"
-        assert reader.calls == ["anthropic/a/oauth", "anthropic/b/oauth"]
+        # The refresh is where the dead transport is discovered and written down; selection
+        # only reads that verdict, so it must add no call of its own.
+        assert reader.calls == after_refresh, "selection reads the store, never the network"
 
 
 class TestSelectorStickiness(TestCase):
@@ -422,7 +496,7 @@ class TestSelectorStickiness(TestCase):
         with _pass_echoes_path():
             chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
         assert chosen == "anthropic/a/oauth"
-        assert reader.calls == [], "a fresh sticky pick must be read from the cache, not re-probed"
+        assert reader.calls == [], "selection reads the store, never the network"
 
     def test_second_select_reuses_the_first_pick_from_cache(self) -> None:
         ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth"])
@@ -432,7 +506,7 @@ class TestSelectorStickiness(TestCase):
             first = selector.select(TokenKind.OAUTH)
             second = selector.select(TokenKind.OAUTH)
         assert first == second == "anthropic/a/oauth"
-        assert reader.calls == ["anthropic/a/oauth"], "the second select is a cache hit — exactly one probe total"
+        assert reader.calls == [], "selection reads the store, never the network"
 
     def test_expired_sticky_row_is_re_probed(self) -> None:
         ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth"])
@@ -451,7 +525,7 @@ class TestSelectorStickiness(TestCase):
         with _pass_echoes_path():
             chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
         assert chosen == "anthropic/a/oauth"
-        assert reader.calls == ["anthropic/a/oauth"], "an expired sticky row re-probes"
+        assert reader.calls == [], "selection reads the store, never the network"
 
 
 class TestFactoryWiring(TestCase):


### PR DESCRIPTION
## What

Credential routing decides from the STORED health and never probes. `PassPathSelector.select()`
reads `AnthropicTokenUsage` and opens no socket; `refresh_all()` probes every configured account
on a cadence and is the single writer.

## Why

Selection probed the rate-limit API whenever a health row was missing or stale, which made the
decision that gates whether *any* work starts depend on that API being reachable and quick. When
it was not, selection returned nothing and dispatch stalled while capacity was available — loops
ticking, queue growing, nothing running.

Moving the probe to a cadence writer keeps the same information without putting a network call on
the path that decides "can work start". A slow or throttled probe now costs a stale row instead of
the dispatch that was about to begin.

## Behaviour

- An **absent or stale** row is OFFERED, not skipped — a cold or lagging table must never halt
  dispatch. A genuinely spent account costs one refused call and records itself through the
  existing reactive-exhaustion path, so the mistake is self-correcting and bounded.
- Only a **fresh exhausted** verdict rules a candidate out, so the loud all-exhausted error still
  fires when every account really is spent.
- An unresolvable credential or a dead probe transport is recorded `REJECTED` by the writer —
  the status the exhaustion rule already treats as spent — so selection still skips such an
  account without asking the network. The verdict expires like any other, so a repaired account
  recovers on the next refresh rather than being blacklisted.
- `_rescue_reprobe` is removed. It existed because a cached-exhausted verdict could outlive a
  rolling window's recovery; a cadence writer resolves that without a live re-probe.

Account ORDER and account membership are unchanged — this only changes where the health verdict
comes from.

## Tests

46 pass. `TestSelectionNeverProbes` pins the new contract, including that selection adds no probe
call of its own, and `TestRefreshAllIsTheOneWriter` pins the writer. Existing exhaustion tests
were migrated to seed the store rather than the reader stub, since the stub no longer reaches the
decision; the two unusable-credential cases now run the writer first, so they exercise both halves
of the seam instead of asserting a skip selection cannot make alone.
