### PR TITLE
fix(tests): skip every virtualenv when scanning for Claude CLI install sites

### DIFF
--- a/tests/test_claude_cli_pin.py
+++ b/tests/test_claude_cli_pin.py
@@ -89,12 +89,24 @@ _INSTALL_PATTERN = re.compile(r"npm install -g [^\n]*?@anthropic-ai/claude-code(
 _PYRIGHT_PATTERN = re.compile(r"npm install -g [^\n]*?\bpyright(?:@(?P<version>[0-9][^\s\\'\"]*))?")
 
 
+def _is_skipped_dir(name: str) -> bool:
+    """Whether the walk descends into *name*.
+
+    Virtualenvs are matched by PREFIX, not by an exact name. A venv holds installed
+    third-party code, so a pinned CLI found inside one is the SDK's own vendored copy
+    rather than a site this repo controls — and the repo creates more than one venv, so
+    enumerating each exact name means the scan breaks again the next time one is added
+    under a new name.
+    """
+    return name.startswith(".venv") or name in _SKIP_DIRS
+
+
 def _repo_text_files() -> Iterator[Path]:
     stack = [_REPO_ROOT]
     while stack:
         for entry in sorted(stack.pop().iterdir()):
             if entry.is_dir():
-                if entry.name not in _SKIP_DIRS:
+                if not _is_skipped_dir(entry.name):
                     stack.append(entry)
             elif entry.is_file() and entry.resolve() != _SELF:
                 yield entry


### PR DESCRIPTION
## What

The Claude-CLI install-site scan skips any directory whose name starts with `.venv`, instead of
only the one named exactly `.venv`.

## Why

The repo creates more than one virtualenv. The hook venv, `.venv-hook`, was walked, and the SDK's
own vendored `subprocess_cli.py` inside its `site-packages` was reported as an unclassified
install site.

The visible effect is worse than a red check: it reddens whichever PR happens to run while that
venv exists, naming a file the author never touched. On a whole-tree assertion that reads as "your
change broke this", and the two natural responses are both wrong — retry hoping it is a flake, or
add one more literal name to the skip set and move on. The second goes green and leaves the same
failure waiting for the next venv.

Matching by prefix fixes the class. A virtualenv holds installed third-party code wherever it
lives, so a pinned CLI found inside one is the SDK's own copy rather than a site this repo
controls. That is a property of being a venv, not of being called `.venv`.

## Tests

Observed RED before the fix: with a planted `.venv-proof/lib/python3.13/site-packages/…`
containing the same vendored file, the scan reproduces the assertion exactly (1 failed); with the
prefix skip in place the suite passes (7 passed). Without that check the change would have been
indistinguishable from a no-op, since a tree with no extra venv passes either way.
