### PR TITLE
fix(tests): give the doctor-aggregate case the same scoped timeout as its siblings

### DIFF
--- a/tests/teatree_core/test_schema_guard.py
+++ b/tests/teatree_core/test_schema_guard.py
@@ -194,6 +194,12 @@ class TestSchemaGuardOnPrivateAlias:
         assert MergeClear.objects.using(alias).count() == 0  # healed: the table is now usable
 
 
+# `setUp` unapplies an initial migration and the cleanup reapplies it, so this class
+# pays the same real-migration cost as its self-healing sibling below and needs the same
+# headroom: measured 20s single-core, which the 12-way shard matrix stretches past the
+# global 60s ceiling. Scoped like the sibling (#1189) so the 60s hang-detector keeps its
+# meaning everywhere else — a global raise would hide the next test drifting to the edge.
+@pytest.mark.timeout(240)
 class BehindSelfDbReportingTest(TransactionTestCase):
     """The one surface that cannot move off ``default`` (#2915).
 


### PR DESCRIPTION
## What

`BehindSelfDbReportingTest` gets the scoped `@pytest.mark.timeout(240)` its two sibling classes in
the same file already carry.

## Why

All three classes drive real migrations — this one unapplies an initial migration in `setUp` and
reapplies it on cleanup. The other two were given a scoped ceiling for exactly that reason
(#1189), with a comment explaining that the work exceeds the global 60s under parallel contention.
This class was the one left out, which put it one contention spike away from red.

Measured 20s single-core; the 12-way shard matrix stretches that past 60s. It failed three
consecutive runs of an unrelated PR, naming a test that PR never touched.

That failure shape is the reason this is worth fixing rather than re-running: "this isn't my
change" and "re-run until it passes" produce the same action, so neither the author nor an
automated loop learns anything, and the next PR pays the same tax. Tracked as #4035.

## Why scoped rather than global

Raising the global ceiling would clear this and hide every other test drifting toward the same
edge. The 60s hang-detector is doing real work everywhere else; this is one class that genuinely
needs more, matching the precedent already set beside it.
