### PR TITLE
fix(config): derive choices for the two closed-value str settings (#4054)

### DIFF
--- a/src/teatree/config/schema.py
+++ b/src/teatree/config/schema.py
@@ -113,6 +113,14 @@ _SECRET_OVERLAY = SettingMeta(Category.SECRET, Registry.OVERLAY)
 _SECRET_COLD = SettingMeta(Category.SECRET, Registry.COLD)
 
 
+# Two closed value sets that have no enum of their own to point at. Declaring them
+# here — rather than as bare ``str`` — is what makes ``setting_choices`` derive them,
+# so the dashboard offers a select instead of a box an invalid value can be typed into.
+# The empty member is a real state in both (auto-detect / unset), never a placeholder.
+_RepoMode = Literal["", "solo", "collaborative"]
+_Privacy = Literal["", "strict", "relaxed"]
+
+
 def _provider_or_none(value: str | None) -> AgentHarnessProvider | None:
     # agent_harness_provider's None default means "inherit the ambient credential";
     # AgentHarnessProvider.parse rejects None, so the None sentinel passes through
@@ -277,7 +285,7 @@ class TeatreeSettingsSchema(BaseSettings):
     outer_loop_measure_days: Annotated[int, BeforeValidator(_parse_strict_int), _DEFAULT_OVERLAY]
     outer_loop_stop_after_consecutive_failures: Annotated[int, BeforeValidator(_parse_strict_int), _DEFAULT_OVERLAY]
     park_attempt_retention_days: Annotated[int, BeforeValidator(_parse_strict_int), _DEFAULT_OVERLAY]
-    privacy: Annotated[str, BeforeValidator(_parse_strict_str), _DEFAULT_OVERLAY]
+    privacy: Annotated[_Privacy, BeforeValidator(_parse_strict_str), _DEFAULT_OVERLAY]
     pr_review_backend: Annotated[PrReviewBackend, BeforeValidator(PrReviewBackend.parse), _DEFAULT_OVERLAY]
     provision_fast_step_timeout_seconds: Annotated[int, BeforeValidator(_parse_strict_int), _DEFAULT_OVERLAY]
     provision_max_concurrency: Annotated[int, BeforeValidator(_parse_strict_int), _DEFAULT_OVERLAY]
@@ -292,7 +300,7 @@ class TeatreeSettingsSchema(BaseSettings):
     ram_kill_allowlist: Annotated[list[str], BeforeValidator(_parse_str_list), _DEFAULT_OVERLAY]
     ram_warn_avail_gb: Annotated[float, BeforeValidator(_parse_strict_float), _DEFAULT_OVERLAY]
     regulated_path_model_allowlist: Annotated[list[str], BeforeValidator(_parse_str_list), _DEFAULT_OVERLAY]
-    repo_mode: Annotated[str, BeforeValidator(_parse_strict_str), _DEFAULT_OVERLAY]
+    repo_mode: Annotated[_RepoMode, BeforeValidator(_parse_strict_str), _DEFAULT_OVERLAY]
     require_anti_vacuity_attestation: Annotated[bool, BeforeValidator(_parse_strict_bool), _DEFAULT_OVERLAY]
     require_debt_delta: Annotated[bool, BeforeValidator(_parse_strict_bool), _DEFAULT_OVERLAY]
     require_executed_repro: Annotated[bool, BeforeValidator(_parse_strict_bool), _DEFAULT_OVERLAY]

--- a/tests/config/test_defaults_file.py
+++ b/tests/config/test_defaults_file.py
@@ -7,6 +7,11 @@ at canonical values, the taxonomy must classify every credential/secret key corr
 and — the key risk — the model-derived per-field validator must behave IDENTICALLY to
 the pre-change registry coercer (the parity matrix). A drift in any of these turns the
 suite red before the 237-key mapping can silently rot.
+
+The one sanctioned divergence is a key whose schema declares a CLOSED value set over a
+tolerant ``str`` coercer: the two tiers then differ on an off-set string, by design and in
+one direction only. That class is derived rather than listed, and both directions of the
+divergence are asserted — see :class:`TestClosedValueSetsNarrowTheSchemaOnly`.
 """
 
 import tomllib
@@ -24,6 +29,7 @@ from teatree.config.schema import (
     TeatreeSettingsSchema,
     _parse_strict_str,
     _provider_or_none,
+    setting_choices,
     setting_meta,
     shipped_defaults,
 )
@@ -260,12 +266,30 @@ _KIND_BY_QUALNAME = {
 }
 
 
+def _choice_narrowed_str_keys() -> tuple[str, ...]:
+    """The ``str``-coerced keys whose SCHEMA declares a closed set the coercer does not enforce.
+
+    Derived, so a future closed set joins this class by declaring its members and nothing
+    else. The divergence is deliberate and one-directional — see
+    :class:`TestClosedValueSetsNarrowTheSchemaOnly` for what pins the direction.
+    """
+    return tuple(
+        key
+        for key in _KEYS
+        if getattr(ALL_KNOWN_CONFIG_SETTINGS[key], "__qualname__", "") == "_parse_strict_str" and setting_choices(key)
+    )
+
+
 def _fixture_and_valid(key: str) -> tuple[str, list[Any], list[Any]]:
     """The (kind, accepted, rejected) fixture triple for *key*'s storage coercer."""
     if key == "handover_mirror_path":
         return ("str", *_FIXTURES["str"])
     if key == "agent_harness_provider":
         return ("provider", *_FIXTURES["provider"])
+    if key in _choice_narrowed_str_keys():
+        # Both tiers accept every declared member and reject every non-string; they differ
+        # only on an off-set STRING, which is the narrowing the paired class asserts.
+        return ("closed_str", [str(value) for value in setting_choices(key)], _FIXTURES["str"][1])
     coercer = ALL_KNOWN_CONFIG_SETTINGS[key]
     qual = getattr(coercer, "__qualname__", "")
     if qual.endswith("_parse_overridable_positive_int.<locals>.parse"):
@@ -287,6 +311,31 @@ def _outcome(fn: Any, value: Any) -> tuple[bool, Any]:
         return (False, fn(value))
     except Exception:  # noqa: BLE001 — parity compares raise-vs-accept, not the exception class
         return (True, None)
+
+
+class TestClosedValueSetsNarrowTheSchemaOnly:
+    """A closed set declared on the schema constrains the UI, never what already loads.
+
+    The schema declares a key's admissible values so ``setting_choices`` can derive a
+    select; the storage coercer stays the tolerant ``str`` one so a value stored before the
+    set was declared still resolves rather than bricking ``get_effective_settings``. Both
+    halves are asserted, because either one alone is a different design: widen the schema
+    back to bare ``str`` and the select disappears, tighten the coercer and a box carrying
+    an off-set value stops loading its config at all.
+    """
+
+    @pytest.mark.parametrize("key", _choice_narrowed_str_keys())
+    def test_the_schema_refuses_an_off_set_value(self, key: str) -> None:
+        raised, _ = _outcome(_field_adapter(key).validate_python, "__not_a_declared_member__")
+        assert raised
+
+    @pytest.mark.parametrize("key", _choice_narrowed_str_keys())
+    def test_the_storage_coercer_still_accepts_it(self, key: str) -> None:
+        assert _STORAGE_COERCER[key]("__not_a_declared_member__") == "__not_a_declared_member__"
+
+    def test_the_class_is_not_empty(self) -> None:
+        # The control: an empty derivation would make both assertions above vacuous.
+        assert set(_choice_narrowed_str_keys()) == {"privacy", "repo_mode"}
 
 
 class TestParityMatrix:

--- a/tests/teatree_config/test_schema.py
+++ b/tests/teatree_config/test_schema.py
@@ -1,0 +1,41 @@
+"""Choice derivation over the settings schema (:func:`setting_choices`).
+
+A key whose admissible values are a CLOSED set must derive them, so the dashboard
+renders a select and an invalid value is impossible to PICK rather than merely
+rejected after the fact. A key whose value is a registry NAME resolved elsewhere
+must derive nothing. Both directions are pinned because only the second is silent:
+a wrongly closed set reads as a tidier UI right up until an overlay's registered
+name is no longer selectable.
+"""
+
+import pytest
+
+from teatree.config.schema import setting_choices
+
+#: Settings naming a SKILL — resolved through the skill registry, so any name the
+#: operator has installed is admissible and no member list can be complete.
+SKILL_NAME_SETTINGS = (
+    "architectural_review_skill",
+    "backlog_sweep_skill",
+    "dogfood_smoke_skill",
+    "eval_local_skill",
+    "review_skill",
+    "scanning_news_skill",
+)
+
+
+class TestClosedValueSetsDeriveTheirMembers:
+    def test_repo_mode_offers_auto_detect_beside_both_pinned_verdicts(self) -> None:
+        assert setting_choices("repo_mode") == ("", "solo", "collaborative")
+
+    def test_privacy_offers_unset_beside_both_strictness_levels(self) -> None:
+        assert setting_choices("privacy") == ("", "strict", "relaxed")
+
+
+class TestRegistryNamesStayOpen:
+    def test_agent_harness_derives_nothing_so_a_registered_transport_stays_selectable(self) -> None:
+        assert setting_choices("agent_harness") == ()
+
+    @pytest.mark.parametrize("key", SKILL_NAME_SETTINGS)
+    def test_a_skill_name_derives_nothing(self, key: str) -> None:
+        assert setting_choices(key) == ()

--- a/tests/teatree_dash/views/test_settings.py
+++ b/tests/teatree_dash/views/test_settings.py
@@ -813,6 +813,13 @@ class TestConstrainedTypesRenderAsSelects(TestCase):
         assert "<select" not in row
         assert 'type="text"' in row
 
+    def test_a_closed_str_setting_renders_a_select_of_every_member_including_the_empty_one(self) -> None:
+        row = _row_html(self.client, "repo_mode")
+        assert "<select" in row
+        assert 'type="text"' not in row
+        for member in ("", "solo", "collaborative"):
+            assert f'value="&quot;{member}&quot;"' in row
+
     def test_the_options_come_from_the_schema_rather_than_a_list_kept_beside_it(self) -> None:
         with patch("teatree.dash.settings_editor.setting_choices", return_value=("only-this",)):
             row = build_setting_row("autonomy")


### PR DESCRIPTION
## What

`repo_mode` and `privacy` were declared as bare `str` in `TeatreeSettingsSchema`, so `setting_choices()` returned `()`, the dashboard rendered a free-text box, and an invalid value could be **typed** rather than being impossible to pick. Each now declares its member set as a `Literal`, keeping the empty member — a real state in both (auto-detect / unset), not a placeholder.

- `repo_mode` = `"" | solo | collaborative` — its own declaration comment states the contract.
- `privacy` = `"" | strict | relaxed` — `docs/blueprint/configuration.md`, `skills/retro/SKILL.md`.

## Why the storage coercer stays tolerant

The coercer stays `_parse_strict_str`, so the change constrains the UI, never what already loads. A stricter coercer would make `get_effective_settings()` **raise** on any box already storing an off-set value (`resolution._coerce_setting_rows` is loud-on-corruption) — bricking config resolution is worse than a free-text box, which is the issue's own guard.

The parity matrix (`tests/config/test_defaults_file.py`) caught this divergence rather than being excused past it. The choice-narrowed class is **derived** (a `_parse_strict_str` key with non-empty `setting_choices`), and both directions are asserted: the schema refuses an off-set value, the coercer still accepts it. Widening the schema back to bare `str`, or tightening the coercer, turns it red.

## Extension points pinned OPEN

`agent_harness` (an overlay registers a third transport under the `teatree.harnesses` entry-point group, #3157 E1) and the six `*_skill` settings still derive `()` — pinned so a future tidy-up cannot close them.

## Classification of all 33 `str`-typed settings

Read each declaration comment, per the issue's method.

| Class | Count | Keys |
|---|---|---|
| Closed — converted | 2 | `repo_mode`, `privacy` |
| Registry NAME resolved elsewhere | 11 | `agent_harness`, the six `*_skill`, `dogfood_smoke_overlay`, `active_loop_schedule`, `low_power_preset_name`, `openai_compatible_credential_entry` |
| Genuinely open | 18 | paths (`workspace_dir`, `handover_mirror_path`, `private_tests`), URL (`openai_compatible_base_url`), regexes (`mr_title_regex`, `colleague_repo_url_pattern`, `solo_repo_url_pattern`), `target_branch`, `issue_implementer_label`, identities (`slack_user_id`, `slack_user_channel`, `substrate_auto_merge_authorized_by`), `approved_recipe_sha`, `dashboard_instance_label`, `timezone`, model ids (`agent_session_model`, `agent_honesty_model`, `openai_compatible_model`) |
| Borderline — left open, noted | 2 | `agent_session_effort`, `openai_compatible_lane` |

## Architecture pre-check — [#4054](https://github.com/souliane/teatree/issues/4054)

1. **BLUEPRINT §** — configuration (`docs/blueprint/configuration.md`). The schema is the one declaration of a key's admissible values; `setting_choices` is the single derivation behind every constrained control. No BLUEPRINT change: the documented values are unchanged.
2. **FSM phase boundaries** — n/a, no `Ticket`/`Worktree` transition.
3. **Extension-point contracts** — `agent_harness` + the six `*_skill` registry names must keep deriving `()`; now pinned in `tests/teatree_config/test_schema.py`.
4. **Component boundaries** — `src/teatree/config/schema.py` only (the taxonomy layer). No consumer changed; the dashboard already derives options through `setting_choices`.
5. **Dependency direction** — no new import (`Literal` was already imported). No new cross-module edge, so the tach DAG is untouched.
6. **Test surface** — `tests/teatree_config/test_schema.py` (derivation, both directions); `tests/teatree_dash/views/test_settings.py` (`repo_mode` renders a `<select>` of all three members — the user-visible outcome); `tests/config/test_defaults_file.py::TestClosedValueSetsNarrowTheSchemaOnly` (the schema/coercer divergence, with a non-empty control so it cannot go vacuous). All three observed RED on the pre-fix schema.
7. **Resilience invariants** — n/a, no external write.
8. **Identity and key normalization** — n/a, no bare/qualified form introduced; no strip/split added.
9. **Behavior preservation** — type-narrowing only. The registry coercer, `derive_*` registry parity, the cold path and every write path are unchanged; `defaults.toml` ships `""` for both keys, which stays admissible. No gate narrowed, no must-block test inverted.
10. **Removability / harness-vs-data** — the closed set lives in the schema declaration, where every other closed set already lives and where the derivation reads it; reverting is a one-line annotation change per key. Harness side is correct: the member set is a type-level contract the validator enforces, not per-item policy a table should hold.

## Open questions & assumptions

- **(assumed)** `privacy`'s admissible set is `"" | strict | relaxed`. It carries no declaration comment; the members come from `docs/blueprint/configuration.md` and `skills/retro/SKILL.md`. It has no live production reader, so nothing reads a value outside that set today.
- **(assumed)** `repo_mode`'s empty member stays admissible — `resolve_repo_mode` treats empty as "auto-detect", so dropping it would remove the default state.
- **(assumed)** the `UserSettings` dataclass keeps `str` for both. It holds the RESOLVED value, which the tolerant coercer does not constrain, so a `Literal` there would claim a guarantee the write path does not make.
- **(decided)** write-time validation is out of scope — see "Why the storage coercer stays tolerant".
- **(open)** `agent_session_effort` — the scale IS closed (`low|medium|high|xhigh|max`, `parse_effort` is fail-loud), but the schema's code default is `""` and `parse_effort("")` raises. A `Literal` without `""` breaks the model default; one with `""` offers a value the resolver rejects. Needs the unset-vs-default question answered first.
- **(open)** `openai_compatible_lane` — its comment enumerates `factory|eval|bulk`, but the value is an `x-lane` HTTP header consumed by the external endpoint's own analytics/routing rules. Nothing in teatree validates it, so a fourth lane configured at that endpoint is valid today.

## Verification

- `t3 tool verify-gates` — **exit 0**, all gate stages green (commit + manual + push).
- `uv run pytest tests/config/test_defaults_file.py tests/teatree_config/test_schema.py` — 856 passed.
- Wider scoped run (`tests/config tests/teatree_config tests/teatree_dash tests/teatree_core/test_config_* tests/conformance` + doctest on the changed module) — 3090 passed. The two parity failures it surfaced are fixed by the derived narrowing class above.
- Anti-vacuity: with the schema reverted to bare `str`, all three new pins go RED; restored, green.

One unrelated failure is **pre-existing and environment-dependent**, not from this diff: `tests/teatree_config/test_host_projection.py::TestColdReadersFallThroughToTheProjection::test_loop_status_resolves_from_the_projection` points its "unreachable source" fixture at `/var/lib/teatree/control-db/db.sqlite3`, which IS mounted inside the teatree container, so the cold reader reads the real control DB instead of the test projection. It imports nothing this PR touches and fails identically on a clean tree.
