### PR TITLE
fix(tests): two distinct causes behind the shard-matrix timeouts (#4048)

### DIFF
--- a/tests/teatree_cli/doctor/test_self_heal.py
+++ b/tests/teatree_cli/doctor/test_self_heal.py
@@ -489,9 +489,22 @@ class DoctorJsonSurfaceTest(TestCase):
         assert captured["repair"] is False
 
     def test_check_without_json_does_not_route_to_json(self) -> None:
+        """The bare subcommand takes the non-JSON branch, so ``check_as_json`` stays untouched.
+
+        ``run_doctor_checks`` is stubbed for the same reason every ``--json`` sibling above
+        stubs it: the assertion is about which branch ``check`` picks, and the real aggregate
+        answers a different question at the price of every check it owns — token-permission
+        probes, the Slack round-trip and a ``claude mcp list`` subprocess among them. Stubbing
+        the nested ``run_self_heal_checks`` alone left the rest of that aggregate live on the
+        one test in this class that does not pass ``--json``, which is how a pure routing
+        assertion came to exceed the global 60s ``pytest-timeout`` under shard contention
+        (#4048).
+        """
+        import teatree.cli.doctor.app as doctor_app_mod  # noqa: PLC0415 — deferred, as its siblings (#4048)
+
         with (
             mock.patch(f"{_MOD}.check_as_json") as spy,
-            mock.patch(f"{_MOD}.run_self_heal_checks", return_value=True),
+            mock.patch.object(doctor_app_mod, "run_doctor_checks", return_value=True),
         ):
             CliRunner().invoke(cli_app, ["doctor", "check"])
         assert not spy.called

--- a/tests/teatree_core/test_schema_guard.py
+++ b/tests/teatree_core/test_schema_guard.py
@@ -194,6 +194,15 @@ class TestSchemaGuardOnPrivateAlias:
         assert MergeClear.objects.using(alias).count() == 0  # healed: the table is now usable
 
 
+# Measured idle on an 8-core box: 7.3s in ``setUp`` and 1.5s in the call. The narrow
+# unapply/reapply of the initial migration on the SHARED ``default`` connection dominates
+# — the aggregation the body asserts costs comparatively little in-process — and neither
+# part can be stubbed away, since the migration gap IS the precondition and the aggregate
+# IS the subject. ~9s clears the global 60s ``pytest-timeout`` alone and does not under
+# CI's 12-way shard matrix, where contention has taken it past 60s on four separate PRs.
+# Same scoped bump, same reason, as ``BehindSelfDbSelfHealsTest`` below (#1189); the
+# global 60s stays as the hang-detector everywhere else (#4048).
+@pytest.mark.timeout(240)
 class BehindSelfDbReportingTest(TransactionTestCase):
     """The one surface that cannot move off ``default`` (#2915).
 

--- a/tests/test_claude_cli_pin.py
+++ b/tests/test_claude_cli_pin.py
@@ -89,12 +89,24 @@ _INSTALL_PATTERN = re.compile(r"npm install -g [^\n]*?@anthropic-ai/claude-code(
 _PYRIGHT_PATTERN = re.compile(r"npm install -g [^\n]*?\bpyright(?:@(?P<version>[0-9][^\s\\'\"]*))?")
 
 
+def _is_skipped_dir(name: str) -> bool:
+    """Whether the walk descends into *name*.
+
+    Virtualenvs are matched by PREFIX, not by an exact name. A venv holds installed
+    third-party code, so a pinned CLI found inside one is the SDK's own vendored copy
+    rather than a site this repo controls — and the repo creates more than one venv, so
+    enumerating each exact name means the scan breaks again the next time one is added
+    under a new name.
+    """
+    return name.startswith(".venv") or name in _SKIP_DIRS
+
+
 def _repo_text_files() -> Iterator[Path]:
     stack = [_REPO_ROOT]
     while stack:
         for entry in sorted(stack.pop().iterdir()):
             if entry.is_dir():
-                if entry.name not in _SKIP_DIRS:
+                if not _is_skipped_dir(entry.name):
                     stack.append(entry)
             elif entry.is_file() and entry.resolve() != _SELF:
                 yield entry


### PR DESCRIPTION
Four open PRs — #4029, #4031, #4034, #4037 — have been held red by tests failing on shards their
own diffs never touch, with the failing shard moving between them (3, 5, 10, and shuffle seeds 7
and 100). A regression does not migrate between shards; contention does.

Measuring each PR separately turned up **two unrelated causes**, and then a third fact that
matters more than either: **the two fixes for them were deadlocked against each other.**

## The deadlock — why waiting was never going to clear this

- `.venv-hook` is created at CI **runtime**, and `main` does not carry the scan fix. So *every*
  branch cut from `main` fails `test-shard 5` on
  `test_claude_cli_pin.py::test_every_site_is_classified_into_a_tier`.
- #4031 carries exactly that scan fix — but fails `test-shard 10` on the doctor-aggregate
  timeout, which needs the fix in this PR.

Neither could go green alone. #4031 needed the timeout fix in `main`; any timeout fix needed
#4031's scan fix in `main`. No re-run, no merge ordering and no amount of waiting could resolve
it, which is why the ship loop kept sweeping every 5m and correctly merging nothing.

This PR breaks the cycle by carrying **both** fixes, so it can go green standalone. #4031's commit
is cherry-picked rather than rewritten, so its authorship is preserved; once this lands, #4031
becomes redundant and #4029 — whose only red is that same scan test — goes green with no further
work.

## Fix 1 — a routing assertion was paying for the whole doctor aggregate

`DoctorJsonSurfaceTest::test_check_without_json_does_not_route_to_json` asserts exactly one thing:
that `doctor check` without `--json` never reaches `check_as_json`. It stubbed only the nested
`run_self_heal_checks`, leaving the entire real `run_doctor_checks` aggregate live —
token-permission probes, the Slack round-trip, a `claude mcp list` subprocess, ~30 checks.

Its four siblings in the same class all stub `run_doctor_checks` and stay cheap. This is the one
case that does not pass `--json`, so it is the one that fell through to the real aggregate. It now
stubs the same seam they do.

No timeout marker here: the cost was accidental, not inherent. A routing test paying for thirty
checks was the bug.

## Fix 2 — a genuinely slow migration test was missing the marker its sibling has

`BehindSelfDbReportingTest` cannot be made cheap and should not be. The unapply/reapply of the
initial migration on the shared `default` connection is the precondition under test, and the
aggregation the body asserts is the subject — stub either and nothing is left.

Measured idle on an 8-core box:

    7.30s  setUp   (unapply/reapply on the shared `default` connection)
    1.54s  call    (the aggregation being asserted)

~9s clears the global 60s ceiling alone and does not under CI's 12-way matrix, where contention
has pushed it past 60s on four separate PRs — roughly 7x inflation.

`BehindSelfDbSelfHealsTest`, directly below it, does comparable work and already carries
`@pytest.mark.timeout(240)` with the rationale from #1189. This class was simply missed. Same bump,
same documented reason; the global 60s stays as the hang-detector everywhere else.

## What this deliberately does not do

Earlier analysis on #4048 treated these as one defect, and #4037 tried scoping a per-test marker —
after which the next instance landed on that very PR. Scoping a fifth marker chases instances.

So only the case whose cost is irreducible gets a marker; the case whose cost was accidental gets
its cost removed. Neither the global ceiling nor the shard width is touched.

**The ceiling question stays open on #4048.** A test measured at ~9s idle timing out at >60s means
the 12-way matrix on 8 cores has less headroom than the numbers suggest, and
`TestSchemaGuardOnPrivateAlias::test_require_current_schema_auto_applies_then_proceeds` already
runs 42.5s idle — 70% of the ceiling before any contention. That is a sizing decision with cost
implications and is not this PR's to make.

## Verification

    tests/teatree_cli/doctor/test_self_heal.py::DoctorJsonSurfaceTest
    tests/teatree_core/test_schema_guard.py
    19 passed in 83.71s

`uv run ruff check` and `ruff format --check` clean. Tests-only diff — no `src/` change, so
`makemigrations --check` and the coverage floor are unaffected.
