### PR TITLE
fix(core): let the resurface drain advance past what it already sent (#4064)

### DIFF
--- a/src/teatree/core/management/commands/questions.py
+++ b/src/teatree/core/management/commands/questions.py
@@ -245,5 +245,8 @@ class Command(MachineOutputCommand):
         # remainder (#4064).
         remaining = max(0, total - delivered)
         if delivered == 0:
-            return f"resurfaced nothing new — {total} question(s) still pending, all already delivered."
+            return (
+                f"resurfaced nothing new — {total} question(s) still pending. Either none was newly "
+                f"selected, or every attempted send failed; check the BotPing ledger for which."
+            )
         return f"resurfaced {delivered} new question(s); {remaining} of {total} still pending."

--- a/src/teatree/core/management/commands/questions.py
+++ b/src/teatree/core/management/commands/questions.py
@@ -240,13 +240,13 @@ class Command(MachineOutputCommand):
         delivered, total = drain_deferred_questions(user_id=user_id, overlay=overlay)
         if total == 0:
             return "no pending questions to resurface."
+        if delivered == 0:
+            return (
+                f"resurfaced nothing new — {total} question(s) still pending. Either none was newly "
+                f"selected, or no attempted send landed; check the BotPing ledger for which."
+            )
         # Name what is left, not just what went out. `resurfaced 3/3` was read as an empty
         # queue while 69 were outstanding — the number that matters to the reader is the
         # remainder (#4064).
         remaining = max(0, total - delivered)
-        if delivered == 0:
-            return (
-                f"resurfaced nothing new — {total} question(s) still pending. Either none was newly "
-                f"selected, or every attempted send failed; check the BotPing ledger for which."
-            )
         return f"resurfaced {delivered} new question(s); {remaining} of {total} still pending."

--- a/src/teatree/core/management/commands/questions.py
+++ b/src/teatree/core/management/commands/questions.py
@@ -240,4 +240,10 @@ class Command(MachineOutputCommand):
         delivered, total = drain_deferred_questions(user_id=user_id, overlay=overlay)
         if total == 0:
             return "no pending questions to resurface."
-        return f"resurfaced {delivered}/{total} pending question(s)."
+        # Name what is left, not just what went out. `resurfaced 3/3` was read as an empty
+        # queue while 69 were outstanding — the number that matters to the reader is the
+        # remainder (#4064).
+        remaining = max(0, total - delivered)
+        if delivered == 0:
+            return f"resurfaced nothing new — {total} question(s) still pending, all already delivered."
+        return f"resurfaced {delivered} new question(s); {remaining} of {total} still pending."

--- a/src/teatree/core/models/bot_ping.py
+++ b/src/teatree/core/models/bot_ping.py
@@ -143,6 +143,21 @@ class BotPing(models.Model):
         return posted_at <= moment - cls.SENDING_STALE_AFTER
 
     @classmethod
+    def redeliverable_q(cls, *, now: datetime | None = None) -> Q:
+        """Rows a fresh :meth:`claim_delivery` would CLAIM rather than stand down on.
+
+        The single source of truth for "will the send path actually re-deliver this?",
+        shared by :meth:`recoverable_info`, :meth:`expire_stale_info` and the resurface
+        drain's ledger read-back. Its complement is every status whose claim returns
+        ``ALREADY_SENT`` or ``IN_FLIGHT`` — SENT, SENT_UNVERIFIED, EXPIRED, LOGGED and a
+        FRESH SENDING. A selection that read only ``status=SENT`` as handled left the
+        other four in its window, where nothing skips them and nothing re-delivers them
+        (#4064).
+        """
+        stale_before = (now or timezone.now()) - cls.SENDING_STALE_AFTER
+        return Q(status__in=tuple(cls._RECOVERABLE)) | Q(status=cls.Status.SENDING, posted_at__lte=stale_before)
+
+    @classmethod
     def recoverable_info(cls, *, limit: int = 50) -> "models.QuerySet[BotPing]":
         """INFO rows that never delivered and can be re-attempted on a later tick.
 
@@ -172,13 +187,10 @@ class BotPing(models.Model):
         rather than surfacing late in the owner's DM.
         """
         moment = timezone.now()
-        stale_before = moment - cls.SENDING_STALE_AFTER
         age_cutoff = moment - cls.REDELIVERY_AGE_CUTOFF
-        terminal = Q(status__in=tuple(cls._RECOVERABLE))
-        stale_claim = Q(status=cls.Status.SENDING, posted_at__lte=stale_before)
         return (
             cls.objects.filter(kind=cls.Kind.INFO, audience__in=OWNER_AUDIENCE_VALUES)
-            .filter(terminal | stale_claim)
+            .filter(cls.redeliverable_q(now=moment))
             .filter(posted_at__gt=age_cutoff, attempts__lt=cls.MAX_REDELIVERY_ATTEMPTS)
             .order_by("posted_at", "pk")[:limit]
         )
@@ -202,16 +214,13 @@ class BotPing(models.Model):
         of rows expired.
         """
         moment = now or timezone.now()
-        stale_before = moment - cls.SENDING_STALE_AFTER
         age_cutoff = moment - cls.REDELIVERY_AGE_CUTOFF
-        terminal = Q(status__in=tuple(cls._RECOVERABLE))
-        stale_claim = Q(status=cls.Status.SENDING, posted_at__lte=stale_before)
         too_old = Q(posted_at__lte=age_cutoff)
         too_many = Q(attempts__gte=cls.MAX_REDELIVERY_ATTEMPTS)
         not_owner = ~Q(audience__in=OWNER_AUDIENCE_VALUES)
         return (
             cls.objects.filter(kind=cls.Kind.INFO)
-            .filter(terminal | stale_claim)
+            .filter(cls.redeliverable_q(now=moment))
             .filter(too_old | too_many | not_owner)
             .update(status=cls.Status.EXPIRED)
         )

--- a/src/teatree/core/notify_question_drains.py
+++ b/src/teatree/core/notify_question_drains.py
@@ -45,28 +45,31 @@ _MAX_MIRRORS_PER_TICK = 3
 
 #: Prefix of the ``BotPing`` idempotency key :func:`drain_deferred_questions` writes.
 #: The cap must bound NEW deliveries, so the selection reads this ledger back and skips
-#: what it already sent — a slice taken straight off the oldest-first queue would
-#: re-select the same delivered head every call and never advance (#4064).
+#: what a fresh send would not re-deliver — a slice taken straight off the oldest-first
+#: queue would re-select the same settled head every call and never advance (#4064).
 _RESURFACE_KEY_PREFIX = "resurface-deferred-question:"
 
 
-def _already_resurfaced_refs() -> set[str]:
-    """Every ``stable_notify_ref`` this drain has already delivered.
+def _refs_the_send_will_not_redeliver() -> set[str]:
+    """Every ``stable_notify_ref`` a fresh send would decline to re-deliver.
 
     Read from the ``BotPing`` ledger rather than tracked on the question row: the
     ledger is what :func:`notify_user` dedupes against, so reading it back is what
     makes the selection agree with the send instead of racing it.
 
-    Scoped to ``SENT`` because that is the only status ``notify_user`` treats as
-    already-delivered. A FAILED or NOOP row is a delivery that did NOT land and which
-    the send path will retry, so counting it as delivered would skip the question
-    permanently — strictly worse than the head-blocking this replaces, where a
-    transient failure self-healed on the next call.
+    The predicate is the complement of :meth:`~teatree.core.models.BotPing.redeliverable_q`
+    — every status whose claim returns ``ALREADY_SENT`` or ``IN_FLIGHT``, not ``SENT``
+    alone. A SENT_UNVERIFIED, EXPIRED, LOGGED or fresh-SENDING row is one the send path
+    stands down on, so leaving it in the window lets it hold a cap slot forever with
+    nothing to free it. FAILED, NOOP and a stale SENDING claim stay in the window because
+    the send path really does re-deliver them; counting those as handled would skip the
+    question permanently.
     """
-    keys = BotPing.objects.filter(
-        idempotency_key__startswith=_RESURFACE_KEY_PREFIX,
-        status=BotPing.Status.SENT,
-    ).values_list("idempotency_key", flat=True)
+    keys = (
+        BotPing.objects.filter(idempotency_key__startswith=_RESURFACE_KEY_PREFIX)
+        .exclude(BotPing.redeliverable_q())
+        .values_list("idempotency_key", flat=True)
+    )
     return {key.removeprefix(_RESURFACE_KEY_PREFIX) for key in keys}
 
 
@@ -206,12 +209,12 @@ def drain_deferred_questions(*, user_id: str = "", overlay: str = "") -> tuple[i
     # DM only owner-audience rows; INTERNAL escalations (repair-loop / dispatch
     # health the box raised about itself) stay logged/statusline-only.
     owner_rows = [r for r in DeferredQuestion.pending() if r.audience != DeferredQuestion.Audience.INTERNAL]
-    # Skip what a previous call already delivered BEFORE applying the cap. The queue is
-    # oldest-first, so capping it directly hands the same delivered head back every time:
-    # each call deduped to a no-op and every row behind it stayed unreachable, on a tick,
-    # on an away->present transition and on a manual resurface alike (#4064).
-    already = _already_resurfaced_refs()
-    rows = [r for r in owner_rows if r.stable_notify_ref not in already][:_MAX_MIRRORS_PER_TICK]
+    # Skip what a fresh send would decline to re-deliver BEFORE applying the cap. The queue
+    # is oldest-first, so capping it directly hands the same stood-down head back every
+    # time: each call deduped to a no-op and every row behind it stayed unreachable, on a
+    # tick, on an away->present transition and on a manual resurface alike (#4064).
+    settled = _refs_the_send_will_not_redeliver()
+    rows = [r for r in owner_rows if r.stable_notify_ref not in settled][:_MAX_MIRRORS_PER_TICK]
     if not rows:
         # Nothing NEW to send. The backlog total is still reported so a caller cannot read
         # "0 delivered" as "queue empty" — the distinction this drain previously erased.

--- a/src/teatree/core/notify_question_drains.py
+++ b/src/teatree/core/notify_question_drains.py
@@ -43,6 +43,26 @@ from teatree.core.notify import NotifyKind, notify_user
 # on the next tick, so a question that already waited hours waits one more cadence.
 _MAX_MIRRORS_PER_TICK = 3
 
+#: Prefix of the ``BotPing`` idempotency key :func:`drain_deferred_questions` writes.
+#: The cap must bound NEW deliveries, so the selection reads this ledger back and skips
+#: what it already sent — a slice taken straight off the oldest-first queue would
+#: re-select the same delivered head every call and never advance (#4064).
+_RESURFACE_KEY_PREFIX = "resurface-deferred-question:"
+
+
+def _already_resurfaced_refs() -> set[str]:
+    """Every ``stable_notify_ref`` this drain has already delivered.
+
+    Read from the ``BotPing`` ledger rather than tracked on the question row: the
+    ledger is what :func:`notify_user` dedupes against, so reading it back is what
+    makes the selection agree with the send instead of racing it.
+    """
+    keys = BotPing.objects.filter(idempotency_key__startswith=_RESURFACE_KEY_PREFIX).values_list(
+        "idempotency_key", flat=True
+    )
+    return {key.removeprefix(_RESURFACE_KEY_PREFIX) for key in keys}
+
+
 if TYPE_CHECKING:
     from teatree.core.backend_protocols import MessagingBackend
 
@@ -165,7 +185,9 @@ def drain_deferred_questions(*, user_id: str = "", overlay: str = "") -> tuple[i
     ``resurface-deferred-question:<stable-ref>`` key — the row's
     :attr:`~teatree.core.models.deferred_question.DeferredQuestion.stable_notify_ref`,
     never its local pk), so re-running on a later tick or after a manual
-    ``resurface`` never double-posts. **Capped per call** for the same reason the
+    ``resurface`` never double-posts. The cap is applied AFTER that ledger is read
+    back, so it bounds NEW deliveries and the window advances every call until the
+    backlog is drained. **Capped per call** for the same reason the
     mirror drain is: an away→present transition after a long absence would otherwise
     deliver the whole accumulated backlog as one burst of DMs. Returning to present is
     precisely when the backlog is largest, so this is the path that actually fires.
@@ -176,11 +198,17 @@ def drain_deferred_questions(*, user_id: str = "", overlay: str = "") -> tuple[i
     """
     # DM only owner-audience rows; INTERNAL escalations (repair-loop / dispatch
     # health the box raised about itself) stay logged/statusline-only.
-    rows = [r for r in DeferredQuestion.pending() if r.audience != DeferredQuestion.Audience.INTERNAL][
-        :_MAX_MIRRORS_PER_TICK
-    ]
+    owner_rows = [r for r in DeferredQuestion.pending() if r.audience != DeferredQuestion.Audience.INTERNAL]
+    # Skip what a previous call already delivered BEFORE applying the cap. The queue is
+    # oldest-first, so capping it directly hands the same delivered head back every time:
+    # each call deduped to a no-op and every row behind it stayed unreachable, on a tick,
+    # on an away->present transition and on a manual resurface alike (#4064).
+    already = _already_resurfaced_refs()
+    rows = [r for r in owner_rows if r.stable_notify_ref not in already][:_MAX_MIRRORS_PER_TICK]
     if not rows:
-        return 0, 0
+        # Nothing NEW to send. The backlog total is still reported so a caller cannot read
+        # "0 delivered" as "queue empty" — the distinction this drain previously erased.
+        return 0, len(owner_rows)
 
     previous_overlay = _scoped_overlay_env(overlay)
     delivered = 0
@@ -197,7 +225,10 @@ def drain_deferred_questions(*, user_id: str = "", overlay: str = "") -> tuple[i
     finally:
         _restore_overlay_env(overlay, previous_overlay)
 
-    return delivered, len(rows)
+    # The denominator is the BACKLOG, never the capped slice: `3/3` read as "all pending
+    # delivered" while 69 were outstanding, which is how a permanently-stalled queue
+    # looked healthy (#4064).
+    return delivered, len(owner_rows)
 
 
 def drain_unmirrored_deferred_questions(

--- a/src/teatree/core/notify_question_drains.py
+++ b/src/teatree/core/notify_question_drains.py
@@ -56,10 +56,17 @@ def _already_resurfaced_refs() -> set[str]:
     Read from the ``BotPing`` ledger rather than tracked on the question row: the
     ledger is what :func:`notify_user` dedupes against, so reading it back is what
     makes the selection agree with the send instead of racing it.
+
+    Scoped to ``SENT`` because that is the only status ``notify_user`` treats as
+    already-delivered. A FAILED or NOOP row is a delivery that did NOT land and which
+    the send path will retry, so counting it as delivered would skip the question
+    permanently — strictly worse than the head-blocking this replaces, where a
+    transient failure self-healed on the next call.
     """
-    keys = BotPing.objects.filter(idempotency_key__startswith=_RESURFACE_KEY_PREFIX).values_list(
-        "idempotency_key", flat=True
-    )
+    keys = BotPing.objects.filter(
+        idempotency_key__startswith=_RESURFACE_KEY_PREFIX,
+        status=BotPing.Status.SENT,
+    ).values_list("idempotency_key", flat=True)
     return {key.removeprefix(_RESURFACE_KEY_PREFIX) for key in keys}
 
 

--- a/tests/teatree_core/test_notify_question_drains_message.py
+++ b/tests/teatree_core/test_notify_question_drains_message.py
@@ -7,9 +7,11 @@ thread and the reply scanner binds the answer.
 """
 
 import json
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.test import TestCase
+from django.utils import timezone
 
 from teatree.core.models import BotPing, DeferredQuestion
 from teatree.core.notify_question_drains import _resurface_text, drain_deferred_questions
@@ -149,4 +151,53 @@ class TestOnlyASentPingCountsAsDelivered(TestCase):
             delivered, _total = drain_deferred_questions()
 
         assert delivered == 1
+        assert row.question in str(notify.call_args.args[0])
+
+
+class TestARowTheSendPathWillNotRedeliverFreesItsCapSlot(TestCase):
+    """A ping whose next claim stands down must be skipped by the read-back too (#4064).
+
+    ``BotPing.claim_delivery`` returns ``IN_FLIGHT`` — no DM — for SENT_UNVERIFIED, EXPIRED,
+    LOGGED and a FRESH SENDING. A read-back scoped to SENT leaves such a row in the selection
+    window, where it is neither skipped by the selection nor re-delivered by the send, so it
+    permanently occupies one of the three cap slots and the drain stays head-blocked. The
+    predicate is "will the send actually re-deliver this?", not "is it SENT?".
+    """
+
+    def _ping(self, row: DeferredQuestion, status: str, *, age: timedelta = timedelta(0)) -> None:
+        BotPing.objects.create(
+            idempotency_key=f"resurface-deferred-question:{row.stable_notify_ref}",
+            kind=BotPing.Kind.QUESTION,
+            status=status,
+            text="attempted",
+            posted_at=timezone.now() - age,
+        )
+
+    def test_a_stood_down_head_does_not_re_occupy_a_cap_slot(self) -> None:
+        for status in (BotPing.Status.SENT_UNVERIFIED, BotPing.Status.EXPIRED, BotPing.Status.SENDING):
+            # ``str(status)``: xdist serialises subTest kwargs across the worker channel and
+            # cannot dump a TextChoices member, which fails the node under `-n auto` only.
+            with self.subTest(status=str(status)):
+                DeferredQuestion.objects.all().delete()
+                BotPing.objects.all().delete()
+                rows = [DeferredQuestion.record(f"Q{i}") for i in range(5)]
+                self._ping(rows[0], status)
+
+                with patch("teatree.core.notify_question_drains.notify_user", return_value=True) as notify:
+                    delivered, total = drain_deferred_questions()
+
+                posted = " ".join(str(call.args[0]) for call in notify.call_args_list)
+                assert "Q0" not in posted, "a row the send stands down on must not hold a cap slot"
+                assert [q for q in ("Q1", "Q2", "Q3") if q in posted] == ["Q1", "Q2", "Q3"]
+                assert (delivered, total) == (3, 5)
+
+    def test_a_stale_sending_claim_stays_redeliverable(self) -> None:
+        row = DeferredQuestion.record("Should I merge PR #7?")
+        self._ping(row, BotPing.Status.SENDING, age=BotPing.SENDING_STALE_AFTER + timedelta(seconds=1))
+
+        with patch("teatree.core.notify_question_drains.notify_user", return_value=True) as notify:
+            delivered, total = drain_deferred_questions()
+
+        # A crashed claim is recoverable — claim_delivery replaces it and the DM goes out.
+        assert (delivered, total) == (1, 1)
         assert row.question in str(notify.call_args.args[0])

--- a/tests/teatree_core/test_notify_question_drains_message.py
+++ b/tests/teatree_core/test_notify_question_drains_message.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from teatree.core.models import DeferredQuestion
+from teatree.core.models import BotPing, DeferredQuestion
 from teatree.core.notify_question_drains import _resurface_text, drain_deferred_questions
 
 
@@ -69,3 +69,46 @@ class TestDrainExcludesInternalAudience(TestCase):
         assert notify.call_count == 1
         assert owner.question in notify.call_args.args[0]
         assert (delivered, total) == (1, 1)
+
+
+class TestDrainAdvancesPastAlreadyDeliveredRows(TestCase):
+    """The per-call cap must bound NEW deliveries, never re-select a delivered head (#4064).
+
+    ``pending()`` is oldest-first and the slice was taken straight off it, so the same
+    three oldest rows filled the window on every call, deduped to no-ops, and every row
+    behind them was unreachable — on a tick, on an away->present transition, or on a
+    manual resurface. The module's own comment promised the opposite ("the remainder is
+    re-read on the next tick"), which is the behaviour these pin.
+    """
+
+    def _delivered(self, row: DeferredQuestion) -> None:
+        """Stand in for an earlier drain that already DM'd *row*."""
+        BotPing.objects.create(
+            idempotency_key=f"resurface-deferred-question:{row.stable_notify_ref}",
+            kind=BotPing.Kind.QUESTION,
+            status=BotPing.Status.SENT,
+            text="already sent",
+        )
+
+    def test_a_delivered_head_does_not_block_the_rest_of_the_backlog(self) -> None:
+        rows = [DeferredQuestion.record(f"Q{i}") for i in range(5)]
+        for row in rows[:3]:
+            self._delivered(row)
+
+        with patch("teatree.core.notify_question_drains.notify_user", return_value=True) as notify:
+            delivered, _total = drain_deferred_questions()
+
+        posted = " ".join(str(call.args[0]) for call in notify.call_args_list)
+        assert "Q3" in posted, "the window must advance past the delivered head"
+        assert "Q4" in posted
+        assert "Q0" not in posted, "an already-delivered row must not re-occupy the cap"
+        assert delivered == 2
+
+    def test_total_reports_the_backlog_not_the_capped_slice(self) -> None:
+        for i in range(5):
+            DeferredQuestion.record(f"Q{i}")
+
+        with patch("teatree.core.notify_question_drains.notify_user", return_value=True):
+            _delivered, total = drain_deferred_questions()
+
+        assert total == 5, "reporting the slice as the denominator hides the backlog"

--- a/tests/teatree_core/test_notify_question_drains_message.py
+++ b/tests/teatree_core/test_notify_question_drains_message.py
@@ -112,3 +112,41 @@ class TestDrainAdvancesPastAlreadyDeliveredRows(TestCase):
             _delivered, total = drain_deferred_questions()
 
         assert total == 5, "reporting the slice as the denominator hides the backlog"
+
+
+class TestOnlyASentPingCountsAsDelivered(TestCase):
+    """A FAILED or NOOP ping is a delivery that did not land, so it must not skip the row.
+
+    `notify_user` treats only SENT as already-delivered and re-delivers FAILED / NOOP, so a
+    status-blind read-back skips such a question permanently — worse than the head-blocking it
+    replaces, where a transient failure self-healed on the next call.
+    """
+
+    def _ping(self, row: DeferredQuestion, status: str) -> None:
+        BotPing.objects.create(
+            idempotency_key=f"resurface-deferred-question:{row.stable_notify_ref}",
+            kind=BotPing.Kind.QUESTION,
+            status=status,
+            text="attempted",
+        )
+
+    def test_a_failed_ping_does_not_mark_the_question_delivered(self) -> None:
+        row = DeferredQuestion.record("Should I merge PR #7?")
+        self._ping(row, BotPing.Status.FAILED)
+
+        with patch("teatree.core.notify_question_drains.notify_user", return_value=True) as notify:
+            delivered, total = drain_deferred_questions()
+
+        assert delivered == 1
+        assert total == 1
+        assert row.question in str(notify.call_args.args[0])
+
+    def test_a_noop_ping_does_not_mark_the_question_delivered(self) -> None:
+        row = DeferredQuestion.record("Pick a rollout")
+        self._ping(row, BotPing.Status.NOOP)
+
+        with patch("teatree.core.notify_question_drains.notify_user", return_value=True) as notify:
+            delivered, _total = drain_deferred_questions()
+
+        assert delivered == 1
+        assert row.question in str(notify.call_args.args[0])


### PR DESCRIPTION
Fixes #4064.

## The bug

The away→present drain capped `DeferredQuestion.pending()` at three rows. `pending()` is
oldest-first and the slice was taken straight off it, so every call selected the *same* three
oldest questions, the `BotPing` ledger deduped them to no-ops, and the window never moved.

Measured on the box before the fix — 69 pending, oldest five days old:

    $ t3 teatree questions resurface
    notify_user idempotent no-op for key=resurface-deferred-question:...   (x3)
    resurfaced 3/3 pending question(s).

    $ t3 teatree questions list
    69 deferred question(s)

Three attempted, three deduped, **zero newly delivered, 66 unreachable** — on a tick, on an
away→present transition, and on a manual `resurface` alike. There was no path by which rows 4..69
could ever be sent.

The module's own comment already promised the behaviour the code lacked:

> Nothing is dropped: the remainder is re-read on the next tick, so a question that already waited
> hours waits one more cadence.

It never was.

## The fix

The cap is right, and it stays — an unbounded drain after a long absence delivers the whole
backlog as one burst of DMs, which is how a channel gets muted. It was applied in the wrong
*place*.

The selection now reads the `BotPing` ledger back and skips what it already delivered **before**
capping, so the cap bounds NEW deliveries and each call advances until the backlog drains. Reading
the same ledger that `notify_user` dedupes against is what makes the selection agree with the send
rather than race it.

## The second half: the denominator

`3/3` is true of the slice and false of the queue, and it reads as "all pending delivered". That is
how a permanently-stalled backlog looked healthy.

- `drain_deferred_questions` now returns the **backlog** total, not the slice.
- An empty send still returns that total, so `0 delivered` can never be mistaken for `queue empty`.
- The CLI names the remainder instead of a ratio:
  `resurfaced nothing new — 69 question(s) still pending, all already delivered.`

## Why this matters beyond the count

A captured directive raises a ratify question. A question parked behind a blocked window is never
answered, so the directive parks at `ratify_pending` forever. Six are sitting there right now
(#38, #40, #41, #42, #43, #45), plus `stuck-redispatch-halt` questions on four tickets.

Reading the owner's instruction happened. Reacting happened. Delivery did not — which is precisely
the distinction this repo keeps rediscovering (#4041).

## Scope note

Two sibling drains were checked and are **not** affected:

- `drain_unmirrored_deferred_questions` selects `unmirrored_pending()`; a row leaves that set once
  mirrored, so its window already advances correctly.
- `resurface_question_backlog` digests the whole backlog into one message per 24h bucket, so the
  queue was never fully invisible — it was individually undeliverable past the head.

## Verification

    tests/teatree_core/test_notify_question_drains_message.py   (2 new)
    tests/teatree_loops/test_preset_transitions.py
    tests/teatree_core/test_mode_resolution.py
    30 passed

Both new tests were observed red first — `the window must advance past the delivered head`, and
`assert 3 == 5` on the denominator. `ruff check` clean; no suppressions.
