### PR TITLE
fix(loop): stop CI-verdict flapping from re-arming merge-sweep skip DMs

### DIFF
--- a/src/teatree/core/models/sweep_skip_streak.py
+++ b/src/teatree/core/models/sweep_skip_streak.py
@@ -8,10 +8,20 @@ and each is log-only, so a PR that is skipped every tick forever produces no sig
 at all — the shape where a finished branch quietly never merges.
 
 One row per ``(slug, pr_id)`` counts how many CONSECUTIVE sweep passes produced the
-SAME reason. Persistence is what surfaces, not any individual skip: a reason that
-changes restarts the count (a different problem), a non-skip outcome deletes the row
-(the PR moved), and ``surfaced_at`` makes the surfacing single-shot so a PR held for
-days is announced once rather than every tick.
+SAME reason GROUP. Persistence is what surfaces, not any individual skip: a reason
+that changes to a genuinely different GROUP restarts the count (a different
+problem), a non-skip outcome deletes the row (the PR moved), and ``surfaced_at``
+makes the surfacing single-shot so a PR held for days is announced once rather than
+every tick.
+
+``ci_pending``, ``ci_red``, ``required_checks_indeterminate`` and
+``uv_audit_red_but_clean_on_main`` are all transient phases of the SAME CI-verdict
+emitted by ``classify_sweep_ci`` — a PR's checks legitimately flap between pending
+(still running) and red (a check failed, or reran) while it remains the SAME stuck
+PR. Treating each flip as "a different problem" re-armed a fresh announcement every
+time, producing back-to-back near-duplicate DMs for one stuck PR (#4080). These four
+are grouped for the streak-continuity comparison only — the stored ``reason`` still
+reflects the exact latest observation, so the surfaced text stays specific.
 """
 
 import datetime as dt
@@ -23,6 +33,21 @@ from django.utils import timezone
 
 _SECONDS_PER_HOUR = 3600
 _STREAK_FIELDS = ("reason", "url", "overlay", "first_seen_at", "last_seen_at", "tick_count", "surfaced_at")
+
+#: Sub-reasons of ``classify_sweep_ci``'s CI-verdict — transient phases of one
+#: "CI is not clean yet" condition, not distinct problems. See module docstring.
+_CI_VERDICT_REASONS = frozenset(
+    {"ci_pending", "ci_red", "required_checks_indeterminate", "uv_audit_red_but_clean_on_main"},
+)
+
+
+def _reason_group(reason: str) -> str:
+    """The identity used to decide whether a streak continues or restarts.
+
+    Collapses the CI-verdict sub-reasons to one group; every other reason (draft,
+    changes_requested, fork holds, no_clear_for_head, …) is its own group.
+    """
+    return "ci_verdict" if reason in _CI_VERDICT_REASONS else reason
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,12 +81,13 @@ class SweepSkipStreakManager(models.Manager["SweepSkipStreak"]):
         )
         if created:
             return row
-        if row.reason != observation.reason:
+        if _reason_group(row.reason) != _reason_group(observation.reason):
             row.reason = observation.reason
             row.first_seen_at = moment
             row.tick_count = 1
             row.surfaced_at = None
         else:
+            row.reason = observation.reason
             row.tick_count += 1
         row.url = observation.url or row.url
         row.overlay = observation.overlay or row.overlay

--- a/tests/teatree_core/models/test_sweep_skip_streak.py
+++ b/tests/teatree_core/models/test_sweep_skip_streak.py
@@ -112,3 +112,46 @@ class TestRendering(django.test.TestCase):
         row = _observe()
 
         assert str(row) == "sweep-skip<o/r#7 ci_pending x1>"
+
+
+class TestCiVerdictContinuity(django.test.TestCase):
+    """A PR's CI verdict flaps between pending/red/indeterminate while it stays blocked.
+
+    Those are transient phases of the SAME "CI is not clean" problem, not a
+    different problem — treating them as different reasons re-armed a fresh
+    announcement on every flip, producing back-to-back near-duplicate DMs for
+    the same stuck PR (souliane/teatree#4080).
+    """
+
+    def test_ci_pending_to_ci_red_continues_the_streak(self) -> None:
+        _observe(reason="ci_pending")
+        _observe(reason="ci_pending")
+        row = _observe(reason="ci_red")
+
+        assert row.tick_count == 3
+        assert row.reason == "ci_red"
+
+    def test_ci_red_to_ci_pending_does_not_re_arm_after_surfacing(self) -> None:
+        for _ in range(3):
+            _observe(reason="ci_red")
+        SweepSkipStreak.objects.mark_surfaced([SweepSkipStreak.objects.get(slug="o/r", pr_id=7).pk])
+
+        row = _observe(reason="ci_pending")
+
+        assert row.surfaced_at is not None
+        assert row.reason == "ci_pending"
+
+    def test_required_checks_indeterminate_and_uv_audit_fallback_share_the_group(self) -> None:
+        _observe(reason="ci_pending")
+        _observe(reason="required_checks_indeterminate")
+        row = _observe(reason="uv_audit_red_but_clean_on_main")
+
+        assert row.tick_count == 3
+
+    def test_a_genuinely_different_reason_still_restarts_the_streak(self) -> None:
+        _observe(reason="ci_red")
+        _observe(reason="ci_red")
+        row = _observe(reason="draft")
+
+        assert row.tick_count == 1
+        assert row.surfaced_at is None

--- a/tests/teatree_loop/test_pr_sweep_skip_surface.py
+++ b/tests/teatree_loop/test_pr_sweep_skip_surface.py
@@ -97,6 +97,16 @@ class TestSurfacesOnPersistence(django.test.TestCase):
 
         assert notifier.sent[0][1] == "pr_sweep_aged_skip:o/r#7:ci_pending"
 
+    def test_ci_verdict_flapping_surfaces_at_most_once(self) -> None:
+        """A PR whose CI toggles ci_pending <-> ci_red must not re-DM (souliane/teatree#4080)."""
+        notifier = _Recorder()
+        flapping = ["ci_pending", "ci_red", "ci_pending", "ci_red", "ci_red", "ci_pending"]
+
+        for reason in flapping:
+            record_sweep_outcomes([_skip(reason=reason)], notify=notifier)
+
+        assert len(notifier.sent) == 1
+
 
 class TestNonSkipOutcomesClear(django.test.TestCase):
     def test_a_merge_clears_the_streak(self) -> None:


### PR DESCRIPTION
fix(loop): stop CI-verdict flapping from re-arming merge-sweep skip DMs

Direct DB query of teatree_bot_ping / teatree_sweep_skip_streak showed the
aged-skip notify path already sends at most one DM per (pr, reason) — no
duplicate `sent` rows exist. The actual source of the reported spam is
SweepSkipStreak.observe() treating any raw reason-string change as "a
different problem" and resetting the streak. ci_pending, ci_red,
required_checks_indeterminate and uv_audit_red_but_clean_on_main are all
transient phases of the same classify_sweep_ci() CI-verdict, so a PR whose
CI naturally flaps between pending/red gets re-armed and DMed again minutes
to hours later for what is really the same stuck PR (confirmed in the DB
across #4003, #3949, #3926, #3925, #3913, #3911, #3895, #3887, #4071).

Group those four sub-reasons for the streak-continuity comparison only;
the stored/displayed reason still reflects the exact latest observation.
A genuinely different reason (draft, changes_requested, fork holds,
no_clear_for_head, ...) still restarts the streak as before.

Open questions & assumptions:
- Assumed (not explicit in the report): required_checks_indeterminate and
  uv_audit_red_but_clean_on_main belong in the same CI-verdict group as
  ci_pending/ci_red since they share the same classify_sweep_ci() origin.
- Out of scope, reported back separately: triaging/clearing the 11 stuck
  PRs named in the original request (ci_red: #3929, #4003, #4031, #4032,
  #4037, #4071; ci_pending: #3948, #3963, #3985, #4055, #4072) — that is
  PR-by-PR investigation work, not a single code fix.
- The full local affected-tests/verify-gates lane did not complete within
  this turn's time budget (whole-suite collection cost plus a concurrent
  sibling session contending for host resources); targeted tests for the
  changed files (33/33) plus ruff check/format are green. CI's sharded
  lane is the merge authority.

Fixes #4080

## What

## Why