### PR TITLE
fix(loop): back off the pr_sweep aged-skip DM instead of re-arming on every reason wobble (#4077)

### DIFF
--- a/skills/interactive/SKILL.md
+++ b/skills/interactive/SKILL.md
@@ -44,7 +44,7 @@ The invariant is not kept by remembering it. Four mechanisms enforce it, each ve
 
 **Session-end check.** Every session end sweeps all five states and names each item with the exact command that advances it. It runs unconditionally — which skills a session loaded says nothing about whether it stranded work — and it fails open, so a probe that cannot answer contributes nothing rather than breaking the session. It lives in `hooks/scripts/session_end_work_check.py`.
 
-**Aged-skip surfacing.** The merge sweep declines to merge on about ten reasons, all of them sound per tick and all of them silent. A reason that repeats for the same PR across consecutive passes is announced once, naming the PR, the reason and how long it has been held; `t3 doctor check` reports every aged hold standing.
+**Aged-skip surfacing.** The merge sweep declines to merge on about ten reasons, all of them sound per tick and all of them silent. A reason that repeats for the same PR across consecutive passes is announced once, naming the PR, the reason and how long it has been held, then re-announced only after a 24h backoff — the backoff is per PR, not per reason, so a stuck PR whose reason wobbles between `ci_red` and `ci_pending` gets a daily reminder rather than a DM per flap; `t3 doctor check` reports every aged hold standing.
 
 ### Using it
 

--- a/src/teatree/core/models/sweep_skip_streak.py
+++ b/src/teatree/core/models/sweep_skip_streak.py
@@ -9,9 +9,13 @@ at all — the shape where a finished branch quietly never merges.
 
 One row per ``(slug, pr_id)`` counts how many CONSECUTIVE sweep passes produced the
 SAME reason. Persistence is what surfaces, not any individual skip: a reason that
-changes restarts the count (a different problem), a non-skip outcome deletes the row
-(the PR moved), and ``surfaced_at`` makes the surfacing single-shot so a PR held for
-days is announced once rather than every tick.
+changes restarts the per-reason count (useful for "how long has THIS reason held"),
+a non-skip outcome deletes the row (the PR moved), and ``surfaced_at`` — the last
+time this PR was announced, independent of which reason triggered it — gates a
+cooldown so a PR held for days is announced once, then again only after backing
+off, rather than every tick or every time the granular reason wobbles (e.g.
+``ci_red`` flapping to ``ci_pending`` and back on every rerun of the same stuck PR
+is not a new problem).
 """
 
 import datetime as dt
@@ -60,7 +64,6 @@ class SweepSkipStreakManager(models.Manager["SweepSkipStreak"]):
             row.reason = observation.reason
             row.first_seen_at = moment
             row.tick_count = 1
-            row.surfaced_at = None
         else:
             row.tick_count += 1
         row.url = observation.url or row.url
@@ -74,9 +77,24 @@ class SweepSkipStreakManager(models.Manager["SweepSkipStreak"]):
         deleted, _ = self.filter(slug=slug, pr_id=pr_id).delete()
         return deleted
 
-    def due_to_surface(self, *, threshold: int) -> models.QuerySet["SweepSkipStreak"]:
-        """Streaks that have reached *threshold* and have not been announced yet."""
-        return self.filter(tick_count__gte=threshold, surfaced_at__isnull=True).order_by("first_seen_at")
+    def due_to_surface(
+        self,
+        *,
+        threshold: int,
+        cooldown: dt.timedelta,
+        now: dt.datetime | None = None,
+    ) -> models.QuerySet["SweepSkipStreak"]:
+        """Streaks at/over *threshold* that have never surfaced, or last surfaced ≥ *cooldown* ago.
+
+        Reason-independent: a PR that has already been announced does not become due
+        again just because its granular skip reason changed — only the backoff window
+        re-arms it, so a flapping ``ci_red``/``ci_pending`` on the same stuck PR is one
+        notification and a later reminder, not one notification per wobble.
+        """
+        moment = now or timezone.now()
+        never_surfaced = models.Q(surfaced_at__isnull=True)
+        cooled_down = models.Q(surfaced_at__lte=moment - cooldown)
+        return self.filter(tick_count__gte=threshold).filter(never_surfaced | cooled_down).order_by("first_seen_at")
 
     def aged(self, *, threshold: int) -> models.QuerySet["SweepSkipStreak"]:
         """Every streak at/over *threshold*, announced or not — the standing doctor view."""

--- a/src/teatree/loop/pr_sweep_skip_surface.py
+++ b/src/teatree/loop/pr_sweep_skip_surface.py
@@ -6,19 +6,24 @@ merges and nobody is told why. Silence is the defect, not the skip.
 
 This reads the sweep's own emitted signals rather than reaching into the scanner, so
 ``pr_sweep`` needs no hook: a ``pr_sweep.skip`` extends that PR's streak, any other
-``pr_sweep.*`` outcome resolves it, and a streak reaching
-:data:`SURFACE_AFTER_TICKS` is announced EXACTLY once (``surfaced_at``). A reason
-that changes re-arms one further announcement, because a different reason is a
-different problem. ``t3 doctor check`` reports every aged streak standing, announced
-or not.
+``pr_sweep.*`` outcome resolves it, and a streak reaching :data:`SURFACE_AFTER_TICKS`
+is announced — then again only after backing off for :data:`REANNOUNCE_COOLDOWN`.
+The backoff is reason-independent on BOTH halves, the DB gate and the idempotency key
+(see :func:`_announcement_key`): a granular reason wobble (``ci_red`` flapping to
+``ci_pending`` and back on the same stuck PR) does not re-arm an immediate second DM,
+because it is not a new problem — only the cooldown window does. ``t3 doctor check``
+reports every aged streak standing, announced or not.
 
 Every failure is swallowed: a missing table, an unreachable DM transport, or a
 malformed payload must degrade to a quiet tick, never abort one.
 """
 
+import datetime as dt
 import logging
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
+
+from django.utils import timezone
 
 from teatree.loop.scanners.base import ScanSignal
 
@@ -30,6 +35,12 @@ logger = logging.getLogger(__name__)
 #: Consecutive identical skips before a PR is announced. Below this a skip is
 #: ordinary sweep bookkeeping; at it, the PR is stuck and nobody has been told.
 SURFACE_AFTER_TICKS = 3
+
+#: Minimum time between announcements for the SAME PR, regardless of how many times
+#: (or how often) its skip reason changes in between. Stops a flapping reason from
+#: re-arming a fresh DM every few ticks while still reminding the owner daily that a
+#: PR is genuinely still stuck.
+REANNOUNCE_COOLDOWN = dt.timedelta(hours=24)
 
 _SKIP_KIND = "pr_sweep.skip"
 _SWEEP_PREFIX = "pr_sweep."
@@ -57,7 +68,7 @@ def _surface_text(row: "SweepSkipStreak") -> str:
     )
 
 
-def _observe(signal: ScanSignal) -> None:
+def _observe(signal: ScanSignal, moment: dt.datetime) -> None:
     from teatree.core.models import SkipObservation, SweepSkipStreak  # noqa: PLC0415 — deferred: ORM app registry
 
     payload = signal.payload
@@ -76,23 +87,45 @@ def _observe(signal: ScanSignal) -> None:
             url=str(payload.get("url") or ""),
             overlay=str(payload.get("overlay") or ""),
         ),
+        now=moment,
     )
 
 
-def _announce_due(notify: SkipNotifier, threshold: int) -> list[str]:
+def _announcement_key(row: "SweepSkipStreak", *, moment: dt.datetime, cooldown: dt.timedelta) -> str:
+    """One key per PR per cooldown window — deliberately NOT per reason.
+
+    The notify ledger no-ops a key it has already delivered, forever. Keying on the
+    reason therefore swallowed the backed-off reminder in the case that matters most
+    (a PR stuck on ONE unchanged reason for days) while a reason wobble sailed
+    through — the exact inversion of the backoff. A window index is stable for a
+    re-run inside the window and provably distinct once ``cooldown`` has elapsed.
+
+    A non-positive ``cooldown`` degrades to a one-second window rather than raising:
+    this module's contract is that no failure aborts a tick.
+    """
+    window = int(moment.timestamp() // max(cooldown.total_seconds(), 1.0))
+    return f"pr_sweep_aged_skip:{row.ref}:{window}"
+
+
+def _announce_due(
+    notify: SkipNotifier,
+    threshold: int,
+    cooldown: dt.timedelta,
+    moment: dt.datetime,
+) -> list[str]:
     from teatree.core.models import SweepSkipStreak  # noqa: PLC0415 — deferred: ORM import needs the app registry
 
     announced: list[str] = []
-    due = list(SweepSkipStreak.objects.due_to_surface(threshold=threshold))
+    due = list(SweepSkipStreak.objects.due_to_surface(threshold=threshold, cooldown=cooldown, now=moment))
     for row in due:
         try:
-            notify(text=_surface_text(row), idempotency_key=f"pr_sweep_aged_skip:{row.ref}:{row.reason}")
+            notify(text=_surface_text(row), idempotency_key=_announcement_key(row, moment=moment, cooldown=cooldown))
         except Exception:
             logger.exception("pr_sweep aged-skip surfacing failed to notify for %s", row.ref)
         announced.append(row.ref)
     # Stamped regardless of delivery: an undeliverable DM must not re-fire the same
     # announcement every tick — the doctor view keeps reporting it standing.
-    SweepSkipStreak.objects.mark_surfaced([row.pk for row in due])
+    SweepSkipStreak.objects.mark_surfaced([row.pk for row in due], now=moment)
     return announced
 
 
@@ -101,6 +134,8 @@ def record_sweep_outcomes(
     *,
     notify: SkipNotifier | None = None,
     threshold: int = SURFACE_AFTER_TICKS,
+    cooldown: dt.timedelta = REANNOUNCE_COOLDOWN,
+    now: dt.datetime | None = None,
 ) -> list[str]:
     """Fold this tick's sweep signals into the streak ledger; announce the newly aged.
 
@@ -110,9 +145,10 @@ def record_sweep_outcomes(
     if not sweep_signals:
         return []
     try:
+        moment = now or timezone.now()
         for signal in sweep_signals:
-            _observe(signal)
-        return _announce_due(notify or _default_notify, threshold)
+            _observe(signal, moment)
+        return _announce_due(notify or _default_notify, threshold, cooldown, moment)
     except Exception:
         logger.exception("pr_sweep aged-skip surfacing failed")
         return []

--- a/tests/teatree_core/models/test_sweep_skip_streak.py
+++ b/tests/teatree_core/models/test_sweep_skip_streak.py
@@ -42,13 +42,16 @@ class TestObserve(django.test.TestCase):
         assert row.reason == "draft"
         assert row.tick_count == 1
 
-    def test_a_resurfaced_reason_after_surfacing_re_arms(self) -> None:
+    def test_a_new_reason_shortly_after_surfacing_does_not_clear_the_cooldown(self) -> None:
         for _ in range(3):
             _observe()
         SweepSkipStreak.objects.mark_surfaced([SweepSkipStreak.objects.get(slug="o/r", pr_id=7).pk])
         _observe(reason="draft")
 
-        assert SweepSkipStreak.objects.get(slug="o/r", pr_id=7).surfaced_at is None
+        row = SweepSkipStreak.objects.get(slug="o/r", pr_id=7)
+        assert row.reason == "draft"
+        assert row.tick_count == 1
+        assert row.surfaced_at is not None
 
     def test_distinct_prs_keep_distinct_streaks(self) -> None:
         _observe(pr_id=7)
@@ -68,17 +71,21 @@ class TestResolve(django.test.TestCase):
         assert SweepSkipStreak.objects.resolve(slug="o/r", pr_id=99) == 0
 
 
+_COOLDOWN = dt.timedelta(hours=24)
+
+
 class TestDueToSurface(django.test.TestCase):
     def test_below_the_threshold_nothing_is_due(self) -> None:
         _observe()
 
-        assert list(SweepSkipStreak.objects.due_to_surface(threshold=3)) == []
+        assert list(SweepSkipStreak.objects.due_to_surface(threshold=3, cooldown=_COOLDOWN)) == []
 
     def test_at_the_threshold_the_streak_is_due(self) -> None:
         for _ in range(3):
             _observe()
 
-        assert [row.pr_id for row in SweepSkipStreak.objects.due_to_surface(threshold=3)] == [7]
+        due = SweepSkipStreak.objects.due_to_surface(threshold=3, cooldown=_COOLDOWN)
+        assert [row.pr_id for row in due] == [7]
 
     def test_an_already_surfaced_streak_is_not_due_again(self) -> None:
         for _ in range(4):
@@ -86,7 +93,35 @@ class TestDueToSurface(django.test.TestCase):
         SweepSkipStreak.objects.mark_surfaced([SweepSkipStreak.objects.get(slug="o/r", pr_id=7).pk])
         _observe()
 
-        assert list(SweepSkipStreak.objects.due_to_surface(threshold=3)) == []
+        assert list(SweepSkipStreak.objects.due_to_surface(threshold=3, cooldown=_COOLDOWN)) == []
+
+    def test_a_reason_change_within_the_cooldown_does_not_re_arm(self) -> None:
+        for _ in range(3):
+            _observe()
+        SweepSkipStreak.objects.mark_surfaced([SweepSkipStreak.objects.get(slug="o/r", pr_id=7).pk])
+        for _ in range(3):
+            _observe(reason="draft")
+
+        assert list(SweepSkipStreak.objects.due_to_surface(threshold=3, cooldown=_COOLDOWN)) == []
+
+    def test_a_streak_is_due_again_once_the_cooldown_has_elapsed(self) -> None:
+        for _ in range(3):
+            _observe()
+        row = SweepSkipStreak.objects.get(slug="o/r", pr_id=7)
+        stale_surface = timezone.now() - _COOLDOWN - dt.timedelta(minutes=1)
+        SweepSkipStreak.objects.filter(pk=row.pk).update(surfaced_at=stale_surface)
+
+        due = SweepSkipStreak.objects.due_to_surface(threshold=3, cooldown=_COOLDOWN)
+        assert [r.pr_id for r in due] == [7]
+
+    def test_a_streak_surfaced_just_within_the_cooldown_boundary_is_not_due(self) -> None:
+        for _ in range(3):
+            _observe()
+        row = SweepSkipStreak.objects.get(slug="o/r", pr_id=7)
+        recent_surface = timezone.now() - _COOLDOWN + dt.timedelta(minutes=1)
+        SweepSkipStreak.objects.filter(pk=row.pk).update(surfaced_at=recent_surface)
+
+        assert list(SweepSkipStreak.objects.due_to_surface(threshold=3, cooldown=_COOLDOWN)) == []
 
 
 class TestAged(django.test.TestCase):

--- a/tests/teatree_loop/test_pr_sweep_skip_surface.py
+++ b/tests/teatree_loop/test_pr_sweep_skip_surface.py
@@ -15,9 +15,10 @@ import django.test
 from django.utils import timezone
 
 from teatree.cli.doctor.app import _check_aged_sweep_skips
-from teatree.core.models import SweepSkipStreak
+from teatree.core.models import BotPing, SweepSkipStreak
+from teatree.core.notify_ledger import already_sent_noop
 from teatree.loop import pr_sweep_skip_surface
-from teatree.loop.pr_sweep_skip_surface import SURFACE_AFTER_TICKS, record_sweep_outcomes
+from teatree.loop.pr_sweep_skip_surface import REANNOUNCE_COOLDOWN, SURFACE_AFTER_TICKS, record_sweep_outcomes
 from teatree.loop.scanners.base import ScanSignal
 
 
@@ -80,22 +81,69 @@ class TestSurfacesOnPersistence(django.test.TestCase):
 
         assert len(notifier.sent) == 1
 
-    def test_a_new_reason_re_arms_one_more_surface(self) -> None:
+    def test_a_new_reason_within_the_cooldown_does_not_re_arm(self) -> None:
         notifier = _Recorder()
         for _ in range(SURFACE_AFTER_TICKS):
             record_sweep_outcomes([_skip(reason="ci_pending")], notify=notifier)
         for _ in range(SURFACE_AFTER_TICKS):
             record_sweep_outcomes([_skip(reason="changes_requested")], notify=notifier)
 
+        assert len(notifier.sent) == 1
+
+    def test_a_still_stuck_pr_re_arms_once_the_cooldown_has_elapsed(self) -> None:
+        notifier = _Recorder()
+        start = dt.datetime(2026, 1, 2, 3, 4, 5, tzinfo=dt.UTC)
+        for _ in range(SURFACE_AFTER_TICKS):
+            record_sweep_outcomes([_skip(reason="ci_pending")], notify=notifier, now=start)
+        later = start + REANNOUNCE_COOLDOWN + dt.timedelta(minutes=1)
+        for _ in range(SURFACE_AFTER_TICKS):
+            record_sweep_outcomes([_skip(reason="changes_requested")], notify=notifier, now=later)
+
         assert len(notifier.sent) == 2
         assert "changes_requested" in notifier.sent[1][0]
 
-    def test_the_idempotency_key_pins_the_pr_and_reason(self) -> None:
+    def test_the_idempotency_key_pins_the_pr_and_the_cooldown_window(self) -> None:
         notifier = _Recorder()
+        moment = dt.datetime(2026, 1, 2, 3, 4, 5, tzinfo=dt.UTC)
         for _ in range(SURFACE_AFTER_TICKS):
-            record_sweep_outcomes([_skip()], notify=notifier)
+            record_sweep_outcomes([_skip()], notify=notifier, now=moment)
 
-        assert notifier.sent[0][1] == "pr_sweep_aged_skip:o/r#7:ci_pending"
+        assert notifier.sent[0][1] == "pr_sweep_aged_skip:o/r#7:20455"
+
+
+class TestReminderSurvivesTheNotifyLedger(django.test.TestCase):
+    """A reminder the notify ledger has already sent under that key is no reminder at all.
+
+    ``already_sent_noop`` no-ops a delivered key forever, so keying the announcement on
+    the skip REASON swallowed the backed-off reminder for the dominant case — a PR stuck
+    on one unchanged reason for days — while a reason wobble sailed through. That is the
+    exact inversion of the intended backoff.
+    """
+
+    def _stuck_on(self, reason: str, notifier: _Recorder, moment: dt.datetime) -> None:
+        for _ in range(SURFACE_AFTER_TICKS):
+            record_sweep_outcomes([_skip(reason=reason)], notify=notifier, now=moment)
+
+    def test_a_same_reason_reminder_uses_a_key_the_ledger_has_not_already_sent(self) -> None:
+        notifier = _Recorder()
+        start = dt.datetime(2026, 1, 2, 3, 4, 5, tzinfo=dt.UTC)
+        self._stuck_on("ci_red", notifier, start)
+        text, key = notifier.sent[0]
+        BotPing.objects.create(idempotency_key=key, kind=BotPing.Kind.INFO, status=BotPing.Status.SENT, text=text)
+        self._stuck_on("ci_red", notifier, start + REANNOUNCE_COOLDOWN + dt.timedelta(minutes=1))
+
+        assert len(notifier.sent) == 2
+        assert already_sent_noop(notifier.sent[1][1]) is None
+
+    def test_two_announcements_inside_one_window_share_a_key_whatever_the_reason(self) -> None:
+        notifier = _Recorder()
+        moment = dt.datetime(2026, 1, 2, 3, 4, 5, tzinfo=dt.UTC)
+        self._stuck_on("ci_red", notifier, moment)
+        SweepSkipStreak.objects.filter(slug="o/r", pr_id=7).update(surfaced_at=None)
+        self._stuck_on("draft", notifier, moment)
+
+        assert len(notifier.sent) == 2
+        assert notifier.sent[0][1] == notifier.sent[1][1]
 
 
 class TestNonSkipOutcomesClear(django.test.TestCase):
@@ -170,12 +218,13 @@ class TestDoctorSurface(django.test.TestCase):
 
 class TestProductionNotifyPath(django.test.TestCase):
     def test_the_default_notifier_routes_through_the_notify_egress(self) -> None:
+        moment = dt.datetime(2026, 1, 2, 3, 4, 5, tzinfo=dt.UTC)
         with mock.patch("teatree.messaging.notify_with_fallback") as sent:
             for _ in range(SURFACE_AFTER_TICKS):
-                pr_sweep_skip_surface.record_sweep_outcomes([_skip()])
+                pr_sweep_skip_surface.record_sweep_outcomes([_skip()], now=moment)
 
         assert sent.call_count == 1
-        assert sent.call_args.kwargs["idempotency_key"] == "pr_sweep_aged_skip:o/r#7:ci_pending"
+        assert sent.call_args.kwargs["idempotency_key"] == "pr_sweep_aged_skip:o/r#7:20455"
 
     def test_an_erroring_ledger_write_never_aborts_the_tick(self) -> None:
         with mock.patch.object(pr_sweep_skip_surface, "_observe", side_effect=RuntimeError("db down")):


### PR DESCRIPTION
Closes [#4077](https://github.com/souliane/teatree/issues/4077)

## Why

The merge sweep declines to merge on ~10 reasons, each sound per tick and each silent, so `SweepSkipStreak` + `pr_sweep_skip_surface` exist to announce a PR that has been stuck for N consecutive passes. That announcement re-armed on **any** reason change (`SweepSkipStreak.observe`'s `row.surfaced_at = None` reset). A PR stuck for days has a skip reason that legitimately wobbles between closely-related CI states — `ci_red` ↔ `ci_pending` ↔ `required_checks_indeterminate`, on every rerun and every push — so the owner got a fresh near-identical DM per flap instead of one notification followed by a backed-off reminder.

This is observable on the current box: `t3 doctor check`'s aged-skip view shows PRs at 139× / 45h (`ci_red`) and 57× / 5h (`ci_pending`) while the owner reports repeated DMs about the same stuck PRs.

## What

- `SweepSkipStreak.observe()` no longer clears `surfaced_at` on a reason change. The per-reason `tick_count` / `first_seen_at` bookkeeping still resets — that is what powers the doctor's "how long has THIS reason held" view — but the notify gate no longer resets with it.
- `SweepSkipStreak.objects.due_to_surface()` takes an explicit `cooldown: timedelta` alongside `threshold`: a streak is due when it has never surfaced, **or** surfaced at least `cooldown` ago, regardless of intervening reason changes.
- `record_sweep_outcomes` defines `REANNOUNCE_COOLDOWN = timedelta(hours=24)` and threads it through, so a still-stuck PR gets a backed-off daily reminder instead of either silence-forever or a DM per flap.

### The DB gate alone was not sufficient

`already_sent_noop` no-ops a delivered idempotency key **forever**, and the announcement key carried the skip reason (`pr_sweep_aged_skip:{ref}:{reason}`). So with only the DB-gate half, the reminder would land **only when the reason changed** and never for a PR stuck on one unchanged reason — the exact inversion of the intended backoff, and precisely the dominant real-world case (`#4003`: 139 skips, 45h, reason `ci_red` throughout).

The key is now one per PR per cooldown window (`_announcement_key`): reason-independent, stable for a re-run inside the window (so a genuine repeat is still correctly deduped), and provably distinct once the cooldown has elapsed (`t2 ≥ t1 + W ⟹ ⌊t2/W⌋ > ⌊t1/W⌋`).

The tick's clock is threaded end to end (`now=`), so one tick stamps `observe` / `due_to_surface` / `mark_surfaced` and derives its window from a single instant.

## Test plan / evidence

Both halves were observed **RED against the pre-fix code before the fix** (per `/t3:code` § TDD Discipline — a test that passes on the buggy code guards nothing):

- Re-introducing `row.surfaced_at = None` in `observe()` → **3 RED**: `test_a_new_reason_shortly_after_surfacing_does_not_clear_the_cooldown`, `TestDueToSurface::test_a_reason_change_within_the_cooldown_does_not_re_arm`, `TestSurfacesOnPersistence::test_a_new_reason_within_the_cooldown_does_not_re_arm`.
- Restoring the reason-keyed idempotency key → **4 RED**, including `TestReminderSurvivesTheNotifyLedger::test_a_same_reason_reminder_uses_a_key_the_ledger_has_not_already_sent`, which fails with `AssertionError: assert NotifyOutcome(sent=True, reason=<NotifyReason.ALREADY_SENT…` — the swallowed reminder itself, asserted through the real `already_sent_noop` against a real seeded `BotPing`.

Green proof:

- `t3 tool verify-gates` → **exit 0**, "all gate stages green (commit + push)" (commit-stage prek + the push-stage gates: public-repo leak gate, comment-density, README/BLUEPRINT, ensure-pr, ci-critical parity).
- `uv run tach check` → `All modules validated!`
- `bash dev/test-affected.sh` (escalated to full) → **28738 passed, 62 skipped, 5 xfailed, 27 failed**. None of the 27 are in the touched modules; all are pre-existing environmental failures that reproduce in isolation on this box and are unreachable from this diff — a `check_editable_sanity` `ConfigSetting` read without `django_db` (`RuntimeError: Database access not allowed`), an ambient `TEATREE_GH_TOKEN` leaking into `test_code_host_from_overlay_returns_none_when_no_token`, the control-DB venue in `cli_doctor`, an absent `pass` store in `test_banned_terms_scanner`, and low-RAM xdist worker crashes (`budget:low_ram (used=91%)`) while the box sat at load 55 on 8 cores.

## Architecture pre-check — [#4077](https://github.com/souliane/teatree/issues/4077)

**1. BLUEPRINT § alignment.** §4 Domain Models (`SweepSkipStreak`) + §5.6 Loop Topology. BLUEPRINT describes the row as "one row per PR the sweep keeps skipping — the streak ages into a doctor WARN"; that statement is unchanged (the doctor view still reads `aged()`). Only the notifier's dedup/backoff moves, so no BLUEPRINT edit is needed. `skills/interactive/SKILL.md` § "Aged-skip surfacing" said "announced once" and **is** updated in this PR.

**2. FSM phase boundaries.** n/a — no `Ticket.State` / `Worktree.State` transition touched.

**3. Extension-point contracts.** n/a — no `OverlayBase` hook, scanner registration, or `*Backend` Protocol changed. `record_sweep_outcomes` has one production call site (`loop/phases/act.py`); `cli/doctor/checks_loop.py` consumes `aged()`, which is untouched.

**4. Component boundaries.** Preserved: persistence + the "is this streak due?" predicate stay on the manager in `core/models/sweep_skip_streak.py`; tick orchestration, the cadence constant, and key construction stay in `loop/pr_sweep_skip_surface.py`.

**5. Dependency direction.** One new module-level import — `django.utils.timezone` in `teatree.loop`, the house pattern for that package (`loop/rendering.py`, `loop/queue_drain.py`, `loop/preset_resolution.py`). No backwards edge; `uv run tach check` → `All modules validated!`

**6. Test surface.**

| Behaviour | Test |
|---|---|
| A reason change no longer clears the notify gate | `test_sweep_skip_streak.py::TestObserve::test_a_new_reason_shortly_after_surfacing_does_not_clear_the_cooldown` |
| `due_to_surface` gates on the cooldown, not the reason | `TestDueToSurface::{test_a_reason_change_within_the_cooldown_does_not_re_arm, test_a_streak_is_due_again_once_the_cooldown_has_elapsed, test_a_streak_surfaced_just_within_the_cooldown_boundary_is_not_due}` |
| A wobble inside the cooldown sends no second DM | `test_pr_sweep_skip_surface.py::TestSurfacesOnPersistence::test_a_new_reason_within_the_cooldown_does_not_re_arm` |
| A still-stuck PR is reminded once the cooldown elapses | `…::test_a_still_stuck_pr_re_arms_once_the_cooldown_has_elapsed` |
| The reminder is not swallowed by the notify ledger | `TestReminderSurvivesTheNotifyLedger::test_a_same_reason_reminder_uses_a_key_the_ledger_has_not_already_sent` |
| The key is per PR per window, never per reason | `TestReminderSurvivesTheNotifyLedger::test_two_announcements_inside_one_window_share_a_key_whatever_the_reason` |

**7. Resilience invariants.** *idempotency* is the crux of this diff and is pinned on both properties (stable in-window, distinct across windows). *fallback-transport* unchanged (`notify_with_fallback`, `OWNER_ESCALATION`). *verify-by-re-read* / *heartbeat* / *sub-agent return contract* n/a — no external write beyond the DM, no long-running work, no sub-agent. The module's never-abort-a-tick contract is preserved: the outer swallow is intact and the new arithmetic cannot raise (`max(cooldown.total_seconds(), 1.0)` guards a zero cooldown).

**8. Identity and key normalization.** The announcement identity is `pr_sweep_aged_skip:<slug>#<pr_id>:<window>`, built by the single function `_announcement_key` and used at its single call site. No stripping or under-qualification: `row.ref` is already the fully-qualified `<slug>#<pr_id>`. The reason is deliberately *not* part of the identity — see check 9.

**9. Behavior preservation / capability deletion.** Enumerated against `git show afef24b4b:…`:

| Old behaviour | Disposition |
|---|---|
| A skip extends the `(slug, pr_id)` streak | preserved |
| A reason change restarts `tick_count` / `first_seen_at` | preserved (the doctor's per-reason age view) |
| A non-skip outcome deletes the row | preserved |
| A streak at threshold announces once, then `surfaced_at` silences it | preserved |
| `surfaced_at` stamped regardless of delivery | preserved |
| `t3 doctor check` reports every aged streak standing | preserved (`aged()` untouched) |
| Every failure swallowed; a tick is never aborted | preserved |
| **A reason change re-armed a further announcement** | **dropped — the defect this issue names.** Replaced by a 24h per-PR backoff. |
| **The idempotency key carried the reason** | **dropped** — the second half of the same defect (see "The DB gate alone was not sufficient"). |

No privacy / leak / security matcher is touched, and no must-block test was inverted to must-not-block. `test_a_resurfaced_reason_after_surfacing_re_arms` was **rewritten** to assert the opposite contract this issue specifies, and was observed RED against the old code first.

**10. Removability / harness-vs-data.** *Removability:* self-contained — deleting `_announcement_key` and the `cooldown` parameter reverts to announce-once with no other call site touched; blast radius is this module plus its manager method. *Harness vs data:* `REANNOUNCE_COOLDOWN` is a module constant (harness), matching its sibling `SURFACE_AFTER_TICKS` and the issue's stated fix. It is threaded as a parameter rather than read at the use site, so promoting it to a per-overlay `ConfigSetting` later is a one-line change at the `act.py` call site. No per-PR policy variance exists today that a table would express.

## Out of scope

Triaging the specific PRs the sweep is currently skipping (`ci_red` / `ci_pending` on several open PRs) — several already have dedicated in-flight worktrees. This PR is scoped to the notifier's dedup/backoff behaviour only, per the issue.

## Open questions & assumptions

- **assumed** — the reason is dropped from the idempotency key rather than kept alongside the window. The window alone re-arms correctly; keeping the reason would let a wobble mint a distinct key, which is the defect's own shape. The message text and `t3 doctor check` still name the current reason, so no operator-visible information is lost.
- **assumed** — `REANNOUNCE_COOLDOWN` stays a module constant (as the issue specifies) rather than a per-overlay `ConfigSetting`. It is threaded as a parameter, so promoting it later is a one-line change.
- **assumed** — a non-positive `cooldown` degrades to a one-second window rather than raising, keeping the module's never-abort-a-tick contract.
- **assumed** — the tick clock is threaded via a `now=` parameter rather than mocking `timezone.now`, because this repo ships no time-freezing library (`time_machine` / `freezegun` are not dependencies) and the manager methods already take `now`.
- **decided-by-issue** — 24h is the backoff, and the reason-change reset is removed rather than lengthened.
- **open** — none blocking.
