### PR TITLE
refactor(credentials): drop the proactive credential-health writer (#4056)

### DIFF
--- a/src/teatree/credential_config.py
+++ b/src/teatree/credential_config.py
@@ -24,14 +24,15 @@ exhausted:
     ``CLAUDE_CODE_OAUTH_TOKEN`` is set in the env) — it never lands on a dead entry.
 *   A sticky pick whose health-cache row is fresh and non-exhausted is reused with NO
     probe — the hot path reads the CACHED table only, never the network.
-*   On a cache miss / expiry each candidate is probed once (the reader), its health
-    row upserted, and the first non-exhausted one is pinned as the new sticky pick.
+*   A candidate with no row, or one whose verdict has aged out, is OFFERED rather than
+    skipped and pinned as the new sticky pick — a cold or lagging table must never halt
+    dispatch, and a genuinely spent account costs one refused call before
+    :func:`record_reactive_exhaustion_and_reselect` writes that verdict down. That
+    reactive write is the ONLY thing that keeps the stored health current; nothing
+    probes on a cadence.
 *   When the overlay's own accounts are all exhausted the selector falls back to ANY
     other configured account (across overlays); when every account's CACHED verdict still
-    reads exhausted, selection fails loud rather than probing: `refresh_all` is the one
-writer that keeps the stored health current.
-    reset, so a recovered account is rescued rather than stranding the loop. Only when the
-    rescue also finds nothing usable does it raise :class:`AllTokensExhaustedError` (a
+    reads FRESHLY exhausted it raises :class:`AllTokensExhaustedError` (a
     :class:`CredentialError`) naming the earliest reset, halting agent work loudly.
 
 The token that signs a probe is never logged or returned; only its ``pass_path`` and
@@ -59,7 +60,6 @@ from teatree.llm.credentials import (
 from teatree.llm.rate_limits import (
     MeteredKeyReader,
     MeteredKeySnapshot,
-    RateLimitProbeError,
     RateLimitReader,
     RateLimitSnapshot,
     read_api_key_status,
@@ -134,7 +134,7 @@ class PassPathSelector:
         to an overlay-scoped account without a manual env export. An empty union (nothing
         configured anywhere) returns ``None`` so the caller fails loud downstream.
         Selection performs no network I/O: a candidate is ruled out only by a FRESH stored
-        exhausted verdict, and :meth:`refresh_all` is what keeps those rows current. Raises
+        exhausted verdict, and the reactive writer is what keeps those rows current. Raises
         :class:`AllTokensExhaustedError` when every account reads freshly exhausted.
         """
         configured = self._configured_paths(kind, scope)
@@ -170,24 +170,6 @@ class PassPathSelector:
             )
         return chosen
 
-    def refresh_all(self, *, now: dt.datetime | None = None) -> int:
-        """Probe every configured account and upsert its health row — the ONE writer.
-
-        Selection reads what this leaves behind and never opens a socket itself, so this is
-        the only place a slow, throttled or unreachable rate-limit API can cost anything —
-        and it costs a stale row, not the dispatch that was about to start work. Run it on a
-        cadence; a probe that fails leaves the previous row standing.
-
-        Returns how many rows were written.
-        """
-        moment = now or timezone.now()
-        written = 0
-        for kind in TokenKind:
-            for pass_path in self._all_configured_paths(kind):
-                if self._probe(kind, pass_path, moment) is not None:
-                    written += 1
-        return written
-
     @staticmethod
     def _sticky_is_usable(pass_path: str, now: dt.datetime) -> bool:
         row = AnthropicTokenUsage.objects.filter(pass_path=pass_path).first()
@@ -199,12 +181,11 @@ class PassPathSelector:
 
         Selection reads :class:`AnthropicTokenUsage` and nothing else, so picking an account
         costs one query and cannot be stalled by a slow, throttled or unreachable rate-limit
-        API. :func:`refresh_account_health` is the single writer; it probes on a cadence.
+        API.
 
         An account with no row, or one whose row has gone stale, is OFFERED rather than
-        skipped: a cold or lagging table must never be able to halt dispatch, which is the
-        outage this replaces — capacity existed and nothing ran. A genuinely spent account
-        costs one refused call and then records itself through
+        skipped: a cold or lagging table must never be able to halt dispatch. A genuinely
+        spent account costs one refused call and then records itself through
         :func:`record_reactive_exhaustion_and_reselect`, so the mistake is self-correcting
         and bounded. Only a FRESH exhausted verdict rules a candidate out.
         """
@@ -214,46 +195,6 @@ class PassPathSelector:
                 continue
             return pass_path
         return None
-
-    def _probe(self, kind: TokenKind, pass_path: str, now: dt.datetime) -> AnthropicTokenUsage | None:
-        """Resolve *pass_path*'s token, read its live health, and upsert the cache row.
-
-        Returns the upserted row, or ``None`` when the token cannot be resolved
-        (no credential stored) or the probe transport fails — either makes the
-        candidate unusable, so the selector moves on. The token never leaves this scope.
-        """
-        credential = _CREDENTIAL_CLASS[kind](pass_path_override=pass_path)
-        try:
-            token = credential.resolve()
-        except CredentialError:
-            return self._record_unusable(pass_path, now)
-        try:
-            reading = self._health_reading(kind, token)
-        except RateLimitProbeError:
-            return self._record_unusable(pass_path, now)
-        return AnthropicTokenUsage.objects.record(pass_path, reading, now=now)
-
-    @staticmethod
-    def _record_unusable(pass_path: str, now: dt.datetime) -> AnthropicTokenUsage:
-        """Store an account the probe could not use at all as REJECTED.
-
-        An unresolvable credential and a dead probe transport are both "this account cannot
-        serve a request", and selection no longer probes, so the only way it can skip such an
-        account is to find that verdict already written. Recording it as rejected — the status
-        the exhaustion rule already treats as spent — keeps the skip without giving selection
-        back a network call. The verdict expires like any other, so a repaired account
-        recovers on the next refresh rather than being blacklisted.
-        """
-        rejected = TokenHealthReading(
-            organization_id="",
-            utilization_5h=0.0,
-            utilization_7d=0.0,
-            status_5h=REJECTED_STATUS,
-            status_7d=REJECTED_STATUS,
-            reset_5h=None,
-            reset_7d=None,
-        )
-        return AnthropicTokenUsage.objects.record(pass_path, rejected, now=now)
 
     def _health_reading(self, kind: TokenKind, token: str) -> TokenHealthReading:
         """Probe *token* the way its *kind* authenticates and fold it into a cache reading.

--- a/tests/test_credential_config.py
+++ b/tests/test_credential_config.py
@@ -34,7 +34,7 @@ from teatree.credential_config import (
     resolve_subscription_credential,
 )
 from teatree.llm.credentials import AnthropicApiKeyCredential, AnthropicSubscriptionCredential, CredentialError
-from teatree.llm.rate_limits import MeteredKeySnapshot, RateLimitProbeError, RateLimitSnapshot
+from teatree.llm.rate_limits import MeteredKeySnapshot, RateLimitSnapshot
 from teatree.utils.eval_container import IN_CONTAINER_ENV_VAR
 
 _OAUTH_SETTING = "anthropic_oauth_pass_paths"
@@ -202,16 +202,13 @@ class TestSelectorRouting(TestCase):
         # An out-of-credits metered key must not be routed to — routing collapses the
         # credit signal onto the same exhaustion refusal the selector already enforces.
         ConfigSetting.objects.set_value(_API_KEY_SETTING, ["anthropic/metered/api"])
-        with (
-            _pass_echoes_path(),
-            patch("teatree.credential_config.read_api_key_status", return_value=_metered(out_of_credits=True)),
-        ):
-            selector = PassPathSelector()
-            # The refresh is what writes the out-of-credits verdict down; the refusal below
-            # is selection reading it, not re-probing the key.
-            selector.refresh_all()
-            with pytest.raises(AllTokensExhaustedError):
-                selector.select(TokenKind.API_KEY)
+        AnthropicTokenUsage.objects.record(
+            "anthropic/metered/api", reading_from_metered(_metered(out_of_credits=True)), now=timezone.now()
+        )
+        reader = _FakeReader({})
+        with _pass_echoes_path(), pytest.raises(AllTokensExhaustedError):
+            PassPathSelector(reader=reader).select(TokenKind.API_KEY)
+        assert reader.calls == [], "selection reads the store, never the network"
 
     def test_funded_api_key_is_routed(self) -> None:
         ConfigSetting.objects.set_value(_API_KEY_SETTING, ["anthropic/a/api", "anthropic/b/api"])
@@ -292,7 +289,8 @@ class TestSelectionNeverProbes(TestCase):
     The old selector probed LIVE whenever a row was missing or stale, so the decision
     "can work start" depended on the rate-limit API being reachable and quick. When it
     was not, selection returned nothing and the factory idled with capacity to spare.
-    `refresh_all` now owns every probe; these pin that the selection path performs none.
+    Nothing probes on the selection path at all; a spent account records itself reactively
+    after one refused call, and these pin that selection adds no probe of its own.
     """
 
     def test_absent_rows_are_offered_without_a_probe(self) -> None:
@@ -337,19 +335,6 @@ class TestSelectionNeverProbes(TestCase):
         with _pass_echoes_path(), pytest.raises(AllTokensExhaustedError):
             PassPathSelector(reader=reader).select(TokenKind.OAUTH)
         assert reader.calls == [], "selection reads the store, never the network"
-
-
-class TestRefreshAllIsTheOneWriter(TestCase):
-    """`refresh_all` is where the probes live, so a slow API costs a stale row."""
-
-    def test_it_probes_every_configured_account_and_stores_the_verdicts(self) -> None:
-        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth", "anthropic/b/oauth"])
-        reader = _FakeReader({"anthropic/a/oauth": _snapshot(), "anthropic/b/oauth": _snapshot()})
-        with _pass_echoes_path():
-            written = PassPathSelector(reader=reader).refresh_all()
-        assert written == 2
-        assert sorted(reader.calls) == ["anthropic/a/oauth", "anthropic/b/oauth"], "every account is probed"
-        assert AnthropicTokenUsage.objects.count() == 2, "each probe leaves a row selection can read"
 
 
 class TestSelectorCrossScopeFallback(TestCase):
@@ -429,28 +414,6 @@ class TestSelectorSkipsUnusableCandidates(TestCase):
         assert chosen == "anthropic/b/oauth"
         assert reader.calls == [], "selection reads the store, never the network"
 
-    def test_candidate_whose_credential_cannot_resolve_is_skipped(self) -> None:
-        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth", "anthropic/b/oauth"])
-        reader = _FakeReader({"anthropic/b/oauth": _snapshot()})
-        with (
-            patch.dict(os.environ, {}, clear=True),
-            patch(
-                "teatree.llm.credentials.read_pass",
-                side_effect=lambda path: "" if path == "anthropic/a/oauth" else path,
-            ),
-        ):
-            selector = PassPathSelector(reader=reader)
-            # The writer is what learns an account is unusable; selection only reads what it
-            # left. Refreshing first is the whole contract, so this exercises both halves
-            # rather than asserting a skip selection could not make on its own.
-            selector.refresh_all()
-            after_refresh = list(reader.calls)
-            chosen = selector.select(TokenKind.OAUTH)
-        assert chosen == "anthropic/b/oauth", "an unresolvable credential is skipped for the next candidate"
-        # The refresh probes — that is its job. What must hold is that SELECTION adds
-        # nothing to that list: it decided purely from what the refresh wrote down.
-        assert reader.calls == after_refresh, "selection reads the store, never the network"
-
     def test_cached_fresh_healthy_candidate_is_returned_without_a_probe(self) -> None:
         ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth"])
         _seed_fresh_healthy_row("anthropic/a/oauth")
@@ -459,31 +422,6 @@ class TestSelectorSkipsUnusableCandidates(TestCase):
             chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
         assert chosen == "anthropic/a/oauth"
         assert reader.calls == [], "selection reads the store, never the network"
-
-    def test_candidate_whose_probe_transport_fails_is_skipped(self) -> None:
-        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth", "anthropic/b/oauth"])
-
-        class _RaisingReader:
-            def __init__(self) -> None:
-                self.calls: list[str] = []
-
-            def __call__(self, token: str, *, is_oauth: bool) -> RateLimitSnapshot:
-                self.calls.append(token)
-                if token == "anthropic/a/oauth":
-                    msg = "probe failed"
-                    raise RateLimitProbeError(msg)
-                return _snapshot()
-
-        reader = _RaisingReader()
-        with _pass_echoes_path():
-            selector = PassPathSelector(reader=reader)
-            selector.refresh_all()
-            after_refresh = list(reader.calls)
-            chosen = selector.select(TokenKind.OAUTH)
-        assert chosen == "anthropic/b/oauth", "a probe transport failure makes the candidate unusable, not fatal"
-        # The refresh is where the dead transport is discovered and written down; selection
-        # only reads that verdict, so it must add no call of its own.
-        assert reader.calls == after_refresh, "selection reads the store, never the network"
 
 
 class TestSelectorStickiness(TestCase):


### PR DESCRIPTION
Closes #4056. Finishes the revert of the proactive credential-health writer shipped in #4027.

## What and why

#4027 added `PassPathSelector.refresh_all` — declared in its own docstring as "the ONE writer" that would keep the stored account health current on a cadence — plus its helpers `_probe` and `_record_unusable`. **No cadence was ever wired.** Nothing in production called `refresh_all`.

The stored health has exactly one real writer, and it is the reactive one: `record_reactive_exhaustion_and_reselect`, called from `src/teatree/agents/usage_window.py` when a mid-run limit is actually observed. That path is untouched here and still wired.

The decision is to remove rather than rewire. A proactive prober is a design choice that has to earn its place on its own merits; inheriting one by accident because a PR declared it does not earn it.

## The judgement call on the surviving behaviour test

Three of the four tests that exercised the removed API are deleted. One is rewritten, deliberately.

**Deleted** — `test_candidate_whose_credential_cannot_resolve_is_skipped` and `test_candidate_whose_probe_transport_fails_is_skipped`. These are the two #4056 identified as passing *only because their own bodies called `refresh_all` first*, supplying wiring production never had. They asserted a skip that selection cannot make on its own. They go with the code they described — that is the point of the ticket.

**Deleted** — `TestRefreshAllIsTheOneWriter::test_it_probes_every_configured_account_and_stores_the_verdicts`. It tested only the removed method.

**Rewritten** — `test_out_of_credits_api_key_is_treated_as_exhausted`. This one asserts *real* behaviour (an out-of-credits metered key must read as exhausted and be refused), and it reached that behaviour through the removed API. I kept the coverage rather than deleting it, because the behaviour is only *partly* guarded elsewhere:

- `test_reading_from_metered_out_of_credits_maps_to_a_rejected_window` covers the translation half (`out_of_credits` → `REJECTED_STATUS` → `is_exhausted`).
- `test_a_fresh_exhausted_row_still_hard_fails_without_a_probe` covers the refusal half, but only for `OAUTH`.

Neither joins them for `API_KEY`, so deleting outright would have left the composition unguarded. It now seeds the verdict through the surviving `reading_from_metered` into `AnthropicTokenUsage` and asserts `select(TokenKind.API_KEY)` raises `AllTokensExhaustedError` — the same behaviour, guarded on the path that actually runs in production.

## Also in this change

**Restored `_sticky_is_usable` and `_first_usable`.** The partial revert had removed these from under `select()`, which still calls both. The branch was red on production code — 24 tests failing with `AttributeError: 'PassPathSelector' object has no attribute '_first_usable'`. They belong to the selection/reactive path, not the proactive writer.

**Corrected the module docstring.** It described a probe-on-cache-miss selection path that no longer exists, and #4027 had left one bullet ungrammatical mid-sentence ("...is the one\nwriter that keeps the stored health current.\n reset, so a recovered account is rescued..."). Also removed the now-unused `RateLimitProbeError` import left behind by the partial revert.

## Verification

- `tests/test_credential_config.py`: **43 passed**.
- All modules importing `credential_config` (token_report, usage_window, headless, eval backends, llm, eval CLI): 1653 passed. The 4 failures in that run are pre-existing and unrelated — they are in `test_api_runner.py` and `test_ephemeral_checkout.py`, which contain zero references to `credential_config`, and this branch touches only the two credential files.
- `ruff check` and `ruff format --check` clean on both files.
- `grep -rc refresh_all src/ tests/` → no matches anywhere.
- Push gate: never-lockout contract 7 passed, conformance lane 301 passed / 3 xfailed, scoped doctest + ast-grep clean.

No `--no-verify`, no `# noqa`, no skip markers, no lowered coverage floor.

## One finding for a follow-up, not fixed here

`PassPathSelector._health_reading` is now **dead** — `_probe` was its only caller. Coverage confirms it: lines 206-210, zero hits from the module's own suite. With it, the injectable reader seam (`__init__`'s `reader` / `api_key_reader`, and the `read_rate_limits` / `read_api_key_status` imports) has no production consumer left either.

I did not remove it in this PR, deliberately. That seam is what ~20 tests use to assert `reader.calls == []` — the guard on the load-bearing invariant of #4027's *good* half, that selection performs no network I/O. Removing it means rewriting those call sites and answering a real design question: how do we keep pinning "selection opens no socket" once there is no reader to inject? That deserves its own change rather than being improvised inside a revert.

Flagging the coverage consequence explicitly so it is a decision, not a surprise: this leaves 5 permanently-uncovered statements against the 93% whole-tree floor.
