### PR TITLE
fix(governor): count stuck PRs over the same key space as open PRs (#4102)

### DIFF
--- a/src/teatree/core/admission_governor.py
+++ b/src/teatree/core/admission_governor.py
@@ -398,6 +398,13 @@ def read_merge_signal(*, overlay: str = "", stuck_after: int = MERGE_STUCK_AFTER
     undercounts and the brake never fires — failing toward MORE claiming, the one direction
     this gate exists to prevent.
 
+    Both sides are then counted over that ONE de-duplicated key space. ``SweepSkipStreak``
+    is unique on ``(slug, pr_id)`` case-SENSITIVELY, so ``Owner/Repo``#800 and
+    ``owner/repo``#800 are two legal rows naming one PR: counting rows against a live set
+    counted by key lets that PR contribute 2 to ``stuck_prs`` and 1 to ``open_prs``, and
+    enough such pairs push ``stuck_prs >= open_prs`` while healthy PRs are still moving —
+    a brake fired on arithmetic, which is the silent stall this gate exists to catch.
+
     A read that raises returns ``fresh=False`` — unknown never brakes, because a probe that
     cannot answer must not be able to halt the factory.
     """
@@ -412,9 +419,8 @@ def read_merge_signal(*, overlay: str = "", stuck_after: int = MERGE_STUCK_AFTER
         live_keys = {
             (str(repo).lower(), int(iid)) for repo, iid in live.values_list("repo", "iid") if str(iid).isdigit()
         }
-        stuck = sum(
-            1 for slug, pr_id in streaks.values_list("slug", "pr_id") if (str(slug).lower(), int(pr_id)) in live_keys
-        )
+        streak_keys = {(str(slug).lower(), int(pr_id)) for slug, pr_id in streaks.values_list("slug", "pr_id")}
+        stuck = len(streak_keys & live_keys)
     except Exception:
         logger.exception("merge-throughput probe failed — reporting unknown, which never brakes")
         return MergeSignal(fresh=False, open_prs=0, stuck_prs=0)

--- a/tests/teatree_loop/test_issue_intake_wiring.py
+++ b/tests/teatree_loop/test_issue_intake_wiring.py
@@ -523,6 +523,29 @@ class TestMergeSignalCountsOnlyLivePrs(TestCase):
         assert isinstance(scanner, IssueIntakeScanner)
         assert scanner.can_claim is True
 
+    def test_two_casings_of_one_pr_count_once_against_the_live_set(self) -> None:
+        """The unique constraint is case-SENSITIVE, so one PR can hold two streak rows.
+
+        Counting streaks by row while the live set is counted by de-duplicated key lets
+        that one PR contribute 2 to ``stuck_prs`` and 1 to ``open_prs`` — a brake fired on
+        arithmetic, with a healthy moving PR still in the pile.
+        """
+        for iid in (800, 801, 802):
+            self._live_pr(overlay="acme", repo="o/r", iid=iid)
+        for slug in ("o/r", "O/R"):
+            SweepSkipStreak.objects.create(slug=slug, pr_id=800, reason="ci red", tick_count=9, overlay="acme")
+        SweepSkipStreak.objects.create(slug="o/r", pr_id=801, reason="ci red", tick_count=9, overlay="acme")
+
+        signal = read_merge_signal(overlay="acme")
+        with patch(_PATCH_TARGET, return_value=_enabled()):
+            scanner = _issue_intake_scanner_for(_backend())
+
+        assert signal.open_prs == 3
+        assert signal.stuck_prs == 2, "two casings of one PR are one stuck PR, not two"
+        assert not signal.stalled, "PR 802 is healthy and moving — the pipeline is not stalled"
+        assert isinstance(scanner, IssueIntakeScanner)
+        assert scanner.can_claim is True
+
     def test_a_stall_in_one_overlay_leaves_another_overlay_claiming(self) -> None:
         for i in range(3):
             self._live_pr(overlay="other", repo="x/y", iid=500 + i)


### PR DESCRIPTION
Closes #4102

`read_merge_signal` counted open PRs by de-duplicated `(lowered slug, iid)` key but counted stuck PRs by `SweepSkipStreak` **row**. The streak table's unique constraint is case-SENSITIVE, so `Owner/Repo`#800 and `owner/repo`#800 are two legal rows naming one PR — and since #4060 lowercases both sides before comparing, both rows match the same live key. That one PR then contributes 2 to `stuck_prs` and 1 to `open_prs`; enough such pairs push `stuck_prs >= open_prs` while healthy PRs are still moving, braking new issue intake on arithmetic rather than on evidence.

The fix intersects the two key sets so both sides are counted over one de-duplicated space. Case-folding stays on both sides — matching exactly instead would drop every differently-cased streak and fail toward MORE claiming, the direction this gate exists to prevent.

## Verification

The regression test seeds three live PRs (`o/r`#800, #801, #802), two differently-cased streak rows for #800, and one for #801.

- Pre-fix (`src/` change reverted): RED — `stuck_prs` reads 3 against `open_prs` 3, the scanner logs `issue intake is claiming nothing new: 3 of 3 open PR(s) refused by the merge sweep`, and `can_claim` goes False. The false brake reproduces.
- Post-fix: GREEN — `stuck_prs` is 2, `stalled` is False, PR #802 keeps the pipeline moving.

```
uv run --no-sync python -m pytest tests/teatree_loop/test_issue_intake_wiring.py -q --no-migrations -p no:cacheprovider
38 passed in 38.47s
```

## Architecture pre-check

**1. BLUEPRINT § alignment** — §5.6 Loop Topology: the admission governor's merge-throughput probe gating issue intake. No contract change, so no BLUEPRINT edit.

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition touched; the probe only feeds the intake scanner's `can_claim`.

**3. Extension-point contracts** — none. `read_merge_signal` is internal to `teatree.core.admission_governor`; its single consumer is `teatree.loop.scanner_factories`, whose behaviour is asserted in the same test class.

**4. Component boundaries** — stays in `src/teatree/core/admission_governor.py`, the existing home of the signal readers.

**5. Dependency direction** — no import added. No new cross-module edge.

**6. Test surface** — `tests/teatree_loop/test_issue_intake_wiring.py::TestMergeSignalCountsOnlyLivePrs::test_two_casings_of_one_pr_count_once_against_the_live_set` asserts `stuck_prs == 2`, `not signal.stalled`, and `scanner.can_claim is True`. Observed RED with the fix reverted, GREEN with it restored.

**7. Resilience invariants** — no external write. The existing unknown-never-brakes contract (`except Exception` → `fresh=False`) is untouched; idempotency is unaffected since the read is pure.

**8. Identity and key normalization** — this IS the fix. The canonical key is the fully-qualified, case-folded `(slug.lower(), int(pr_id))`. Both sides now normalize UP to it before counting, instead of one side counting raw rows. No qualifier is stripped to make a comparison succeed.

**9. Behavior preservation / capability deletion** — the `sum(1 for ...)` row-count is replaced by a set intersection over the same predicate. Every streak row that previously matched a live key still matches; the only change is that duplicates collapse. No matcher narrowed, no test inverted.

**10. Removability / harness-vs-data** — three-line change inside one function, revertible in isolation. It belongs in the harness: it is the counting rule itself, not a per-item policy a table could express.

## Open questions & assumptions

- The issue notes the reachability of the two-casing state is plausible (the DB constraint permits it, `PullRequestQuerySet.for_pr`'s docstring says rows do get recorded as `Owner/Repo`) but not demonstrated against real data. I did not query production rows; the fix is correct whether the state is live or latent, since counting both sides over one key space is the invariant either way.
- The issue also records a separate, explicitly-unrequested finding: `read_merge_signal` absorbs failures in its own `except Exception` while `read_quota_signal` lets the raise propagate to `loop/admission.py`, though the docstring claims both follow "the same rule". Aligning the wording versus aligning the plumbing are two defensible choices, so I left it out of this change rather than pick one unilaterally.
