### PR TITLE
fix(intake): a ticket owns its issue in every state but IGNORED

### DIFF
--- a/src/teatree/core/models/ticket_state_sets.py
+++ b/src/teatree/core/models/ticket_state_sets.py
@@ -135,6 +135,22 @@ class TicketStateSetsModel(TicketFacet):
         return frozenset({cls.State.SHIPPED, cls.State.IN_REVIEW, cls.State.MERGED})
 
     @classmethod
+    def issue_owning_states(cls) -> frozenset[str]:
+        """States in which a ticket OWNS its issue URL, so intake must not re-admit it.
+
+        Derived as the complement of IGNORED rather than enumerated: the hand-written
+        list this replaces silently omitted PLANNED and DELIVERED, and the persistence
+        handler reuses the existing row and returns early for anything past
+        NOT_STARTED — so each re-admission scheduled no work, claimed an
+        ``ImplementedIssueMarker``, held an intake budget slot until the dead grace
+        abandoned it, and re-admitted on the next tick (#4133).
+
+        IGNORED is the one release valve: it is how an abandoned or dead ticket hands
+        its issue back to intake, so no issue can be wedged by a stale row.
+        """
+        return frozenset(cls.State.values) - {cls.State.IGNORED}
+
+    @classmethod
     def merged_states(cls) -> frozenset[str]:
         """States that mean the ticket's PR has landed (merged-or-past).
 

--- a/src/teatree/loop/scanners/issue_intake.py
+++ b/src/teatree/loop/scanners/issue_intake.py
@@ -66,24 +66,6 @@ class _TickContext:
     merged_prs: list[RawAPIDict]
 
 
-#: A ticket in one of these states OWNS its issue URL — rule 2 of the decision
-#: table reads this as "work already exists", so no second ticket is created.
-_ACTIVE_TICKET_STATES: frozenset[str] = frozenset(
-    {
-        "not_started",
-        "scoped",
-        "started",
-        "coded",
-        "tested",
-        "reviewed",
-        "shipped",
-        "in_review",
-        "merged",
-        "retrospected",
-    }
-)
-
-
 def issue_url(issue: RawAPIDict) -> str:
     for name in ("web_url", "html_url"):
         value = issue.get(name)
@@ -334,7 +316,12 @@ class IssueIntakeScanner:
         return config_tier | trusted_handles()
 
     def _tracked_issue_urls(self) -> frozenset[str]:
-        """Issue URLs an ACTIVE ticket already owns — rule 2's local half.
+        """Issue URLs a ticket already owns — rule 2's local half.
+
+        Ownership is :meth:`Ticket.issue_owning_states` (every state but IGNORED), the
+        SSOT rather than a second hand-maintained list — the list this replaced omitted
+        PLANNED and DELIVERED, so a parked ticket's issue was re-admitted every tick
+        (#4133).
 
         Fails SAFE to empty: a DB-blocked harness degrades to "no local work known",
         and the forge read-back plus the TOCTOU-safe marker claim still guard against
@@ -342,7 +329,7 @@ class IssueIntakeScanner:
         """
         try:
             ticket_model = cast("type[Ticket]", apps.get_model("core", "Ticket"))
-            qs = ticket_model.objects.filter(state__in=_ACTIVE_TICKET_STATES)
+            qs = ticket_model.objects.filter(state__in=ticket_model.issue_owning_states())
             if self.overlay_name:
                 qs = qs.filter(overlay=self.overlay_name)
             return frozenset(url for url in qs.values_list("issue_url", flat=True) if url)

--- a/tests/teatree_core/models/test_ticket.py
+++ b/tests/teatree_core/models/test_ticket.py
@@ -719,6 +719,11 @@ class TestTicketStateSets(TestCase):
             {Ticket.State.MERGED, Ticket.State.RETROSPECTED, Ticket.State.DELIVERED},
         )
 
+    def test_issue_owning_states_is_every_state_but_ignored(self) -> None:
+        # Derived, not enumerated: a new State joins the owning set by default, so
+        # intake can never re-admit an issue a live ticket already holds (#4133).
+        assert Ticket.issue_owning_states() == frozenset(Ticket.State.values) - {Ticket.State.IGNORED}
+
     def test_every_set_member_is_a_real_state(self) -> None:
         valid = set(Ticket.State.values)
         for name in (
@@ -726,6 +731,7 @@ class TestTicketStateSets(TestCase):
             "in_flight_excluded_states",
             "completable_states",
             "merged_states",
+            "issue_owning_states",
         ):
             states = getattr(Ticket, name)()
             assert isinstance(states, frozenset), f"{name} must return an immutable frozenset"

--- a/tests/teatree_loop/scanners/test_issue_intake.py
+++ b/tests/teatree_loop/scanners/test_issue_intake.py
@@ -561,22 +561,58 @@ def _assigned(issue: RawAPIDict, assignee: str) -> RawAPIDict:
 
 
 class IssueIntakeExistingWorkTests(_PublicRepoTestCase):
-    """Rule 2: an active ticket already owning the URL blocks a second intake."""
+    """Rule 2: a ticket already owning the URL blocks a second intake (#4133).
+
+    Ownership is every state but IGNORED. ``_handle_orchestrator`` reuses the
+    existing row (``get_or_create(issue_url=...)``) and returns early for anything
+    past NOT_STARTED, so a re-admission cannot schedule work — it only claims an
+    ``ImplementedIssueMarker``, holds an intake budget slot until the dead grace
+    abandons it, and re-admits on the next tick, forever.
+    """
+
+    def _ticket_at(self, state: str) -> None:
+        Ticket.objects.create(issue_url=self.URL_A, overlay=self.OVERLAY, role=Ticket.Role.AUTHOR, state=state)
 
     def test_active_ticket_for_the_url_is_ignored(self) -> None:
-        Ticket.objects.create(issue_url=self.URL_A, overlay=self.OVERLAY, role=Ticket.Role.AUTHOR)
+        self._ticket_at(Ticket.State.NOT_STARTED)
         host = _Host(authored={OWNER: [_issue(self.URL_A, author=OWNER)]})
 
         assert self._scanner(host).scan() == []
         assert not ImplementedIssueMarker.objects.exists()
 
-    def test_a_terminal_ticket_does_not_block_intake(self) -> None:
-        Ticket.objects.create(
-            issue_url=self.URL_A, overlay=self.OVERLAY, role=Ticket.Role.AUTHOR, state=Ticket.State.DELIVERED
-        )
+    def test_a_planned_ticket_blocks_re_admission(self) -> None:
+        self._ticket_at(Ticket.State.PLANNED)
+        host = _Host(authored={OWNER: [_issue(self.URL_A, author=OWNER)]})
+
+        assert self._scanner(host).scan() == []
+        assert not ImplementedIssueMarker.objects.exists()
+
+    def test_a_delivered_ticket_blocks_re_admission(self) -> None:
+        self._ticket_at(Ticket.State.DELIVERED)
+        host = _Host(authored={OWNER: [_issue(self.URL_A, author=OWNER)]})
+
+        assert self._scanner(host).scan() == []
+        assert not ImplementedIssueMarker.objects.exists()
+
+    def test_an_ignored_ticket_leaves_the_issue_re_claimable(self) -> None:
+        # The release valve: IGNORED is how an abandoned or dead ticket hands its
+        # issue back, so the fix above cannot wedge an issue permanently.
+        self._ticket_at(Ticket.State.IGNORED)
         host = _Host(authored={OWNER: [_issue(self.URL_A, author=OWNER)]})
 
         assert len(self._scanner(host).scan()) == 1
+
+    def test_every_state_but_ignored_blocks_re_admission(self) -> None:
+        blocking = []
+        for state in Ticket.State.values:
+            Ticket.objects.all().delete()
+            ImplementedIssueMarker.objects.all().delete()
+            self._ticket_at(state)
+            host = _Host(authored={OWNER: [_issue(self.URL_A, author=OWNER)]})
+            if self._scanner(host).scan() == []:
+                blocking.append(state)
+
+        assert set(blocking) == set(Ticket.State.values) - {Ticket.State.IGNORED}
 
 
 class IssueIntakePayloadReadersTests(_PublicRepoTestCase):


### PR DESCRIPTION
`_ACTIVE_TICKET_STATES` (`src/teatree/loop/scanners/issue_intake.py`) was a hand-written list of ten states that omitted `planned` and `delivered`. A ticket parked at either made `work_exists` false, so `decide_intake` fell through to `ACT_TRUSTED_AUTHOR` and re-admitted the issue.

The re-admission could never produce work: `_handle_orchestrator` reuses the existing row via `get_or_create(issue_url=...)` and returns early for anything past `NOT_STARTED`. Each cycle therefore claimed an `ImplementedIssueMarker`, held one of the 2-4 intake budget slots until the ~2h dead grace abandoned it, and re-admitted on the next tick — indefinitely, for as long as the ticket stayed parked.

## The `delivered` decision

`delivered` **is** in the owning set. The previous behaviour was pinned by `test_a_terminal_ticket_does_not_block_intake`; that test is inverted here, deliberately:

- a delivered ticket's still-open issue hit exactly the same dead loop (row reused, early return, marker churn) — so the re-admission it allowed bought nothing and cost a budget slot every 2h;
- it was also a second path to re-implementing already-shipped work, the stale-open-issue class;
- `merged` and `retrospected` were already in the set, so `delivered` sitting outside it made the post-ship tail inconsistent rather than deliberate.

The inversion strengthens the guard (blocks more) — it does not narrow a privacy/safety matcher.

## Not resurrecting the opposite bug

`ignored` stays **out** as the single release valve, so an abandoned or dead ticket still hands its issue back to intake:

- `board_reconcile` already writes `IGNORED` when the issue closes on the board;
- a stalled `planned` ticket is a `stuck_ticket_redispatch` candidate (`_STATE_PHASE[PLANNED] = "coding"`), so reviving parked work is that sweep's job, not intake's;
- `test_an_ignored_ticket_leaves_the_issue_re_claimable` pins it, and `test_every_state_but_ignored_blocks_re_admission` sweeps every `Ticket.State` value so the boundary can't drift.

The set is now derived (`frozenset(State.values) - {IGNORED}`) and lives with the other canonical state sets on `TicketStateSetsModel`, so a new FSM state cannot silently drop out of it the way `planned` did.

## Verification

Observed RED on pre-fix code — `test_a_planned_ticket_blocks_re_admission` and `test_a_delivered_ticket_blocks_re_admission` both emitted an `issue_intake.admitted` signal instead of `[]`, and the state sweep reported `planned` / `delivered` / `review_posted` missing.

```
uv run --no-sync python -m pytest tests/teatree_loop tests/teatree_core/models tests/teatree_core/intake \
  tests/teatree_core/test_work_lease.py tests/teatree_core/fleet/test_claim_wire.py tests/conformance \
  -q --no-migrations -p no:cacheprovider
→ 4965 passed, 3 xfailed
```

`ruff check` / `ruff format --check` / `ty check` clean on the changed files.

## Architecture pre-check — #4133

**1. BLUEPRINT § alignment** — §5.6 Loop Topology (intake scanner) and §4 Domain Models (the ticket state sets). No contradiction: the change makes the scanner read the documented SSOT instead of a private copy.

**2. FSM phase boundaries** — n/a. No transition is added, removed, or re-guarded; only the read-side classification of existing states.

**3. Extension-point contracts** — none. `TicketStateSetsModel` is a core facet with no overlay surface; the only consumer of the removed constant was `IssueIntakeScanner._tracked_issue_urls` (`grep -rn _ACTIVE_TICKET_STATES` → 0 hits after the change).

**4. Component boundaries** — the state set belongs with the other canonical sets in `core/models/ticket_state_sets.py`; the scanner keeps only the query.

**5. Dependency direction** — no new import. `issue_intake` already reaches `Ticket` through the lazy `apps.get_model("core", "Ticket")` handle and now calls a classmethod on it.

**6. Test surface** — `tests/teatree_loop/scanners/test_issue_intake.py::IssueIntakeExistingWorkTests` (per-state admission behaviour, incl. the all-states sweep) and `tests/teatree_core/models/test_ticket.py::TestTicketStateSets` (membership + real-State pin).

**7. Resilience invariants** — no external write. The existing fail-safe-to-empty degrade in `_tracked_issue_urls` is unchanged, and the TOCTOU-safe marker claim still backstops it.

**8. Identity and key normalization** — n/a; no bare/qualified identity pair. The set is `State` values throughout, never raw strings.

**9. Behavior preservation / capability deletion** — one behaviour is intentionally dropped: "a DELIVERED ticket does not block intake" (see the `delivered` section above). `review_posted` also joins the set; it is inert for issue intake because reviewer tickets key on the PR URL, not the issue URL. Nothing else changes, and no must-block test was inverted to must-not-block.

**10. Removability / harness-vs-data** — no new component; the change deletes a hand-maintained constant and replaces it with a derived classmethod, so the blast radius of reverting is the one call site. The policy stays in the harness because it is FSM semantics, not per-item configuration.

Closes #4133
