### PR TITLE
fix(config): render the retirement record when config_setting refuses a key

### DIFF
--- a/src/teatree/config/retired_settings.py
+++ b/src/teatree/config/retired_settings.py
@@ -176,6 +176,30 @@ def removed_setting(key: str) -> RetiredSetting | None:
     return entry if entry is not None and entry.replacement is None else None
 
 
+def retirement_notice(key: str) -> str | None:
+    """What became of *key*, or ``None`` when no retirement is recorded for it.
+
+    souliane/teatree#4094: ``config_setting get``/``set`` answered a retired key with
+    the unknown-key refusal, which reads exactly like the answer for a typo — so a
+    reader who knows the setting used to exist concludes the mechanism was lost
+    rather than superseded. The two outcomes must not read alike either: a rename
+    still has an answer to give (the replacement), while a removal has none, and
+    saying so is the whole point of recording the reason.
+    """
+    entry = _BY_KEY.get(key)
+    if entry is None:
+        return None
+    if entry.replacement is not None:
+        return (
+            f"{key!r} was renamed to {entry.replacement!r} — {entry.reason}. "
+            f"Read and write {entry.replacement!r} instead."
+        )
+    return (
+        f"{key!r} was removed — {entry.reason}. It has no replacement. "
+        f"Clear any stale row with `{CLEAR_REMEDY.format(key=key)}`."
+    )
+
+
 def warn_removed_setting(entry: RetiredSetting) -> None:
     """Report a stored row under a removed key on stderr — the anti-silent-revert line.
 

--- a/src/teatree/core/management/commands/config_setting.py
+++ b/src/teatree/core/management/commands/config_setting.py
@@ -27,7 +27,7 @@ import json
 import sys
 import tomllib
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, NoReturn
 
 import typer
 from django.core.exceptions import ValidationError
@@ -41,6 +41,7 @@ from teatree.config import (
     get_effective_settings,
 )
 from teatree.config.feature_flags import flag_trailer, render_flags_audit
+from teatree.config.retired_settings import retirement_notice
 from teatree.config.setting_groups import group_outline
 from teatree.config.stored_row_health import stored_row_note
 from teatree.config.write_validation import ConfigWriteError, validate_config_write
@@ -82,6 +83,17 @@ def _stored_row_suffix(key: str) -> str:
 
 
 class Command(TyperCommand):
+    def _refuse_unknown_key(self, key: str) -> NoReturn:
+        """Refuse *key*, rendering its retirement record when one is on file (#4094).
+
+        The registry is the single source, so this surface, the resolver's loud
+        warning and the ``list`` marker cannot come to describe a retirement
+        differently. A retired key stays unwritable — the record is the answer, not
+        an admission that would resolve nowhere.
+        """
+        self.stderr.write(f"  refusing: {retirement_notice(key) or f'{key!r} is not a known config setting'}")
+        raise SystemExit(2)
+
     @command()
     def set(
         self,
@@ -107,8 +119,7 @@ class Command(TyperCommand):
         on write is what keeps a bad row from bricking all reads.
         """
         if key not in _ALLOWED_SETTINGS:
-            self.stderr.write(f"  refusing: {key!r} is not a known config setting")
-            raise SystemExit(2)
+            self._refuse_unknown_key(key)
         try:
             parsed = json.loads(value)
         except json.JSONDecodeError as exc:
@@ -161,8 +172,7 @@ class Command(TyperCommand):
         from an operator's deliberate pin. Same key/JSON validation as ``set``.
         """
         if key not in _ALLOWED_SETTINGS:
-            self.stderr.write(f"  refusing: {key!r} is not a known config setting")
-            raise SystemExit(2)
+            self._refuse_unknown_key(key)
         try:
             parsed = json.loads(value)
         except json.JSONDecodeError as exc:
@@ -255,8 +265,7 @@ class Command(TyperCommand):
         accepts every key ``list`` can display (the unified known-key set).
         """
         if key not in _ALLOWED_SETTINGS:
-            self.stderr.write(f"  refusing: {key!r} is not a known config setting")
-            raise SystemExit(2)
+            self._refuse_unknown_key(key)
         stored = ConfigSetting.objects.get_effective(key, scope=overlay)
         if stored is not None:
             self.stdout.write(f"  {key} = {stored!r}  [source: db, {scope_label(overlay)}]{_flag_suffix(key)}")

--- a/tests/teatree_config/test_retired_settings.py
+++ b/tests/teatree_config/test_retired_settings.py
@@ -1,0 +1,39 @@
+"""The retirement registry's operator-facing rendering (souliane/teatree#4094).
+
+The registry is the single source every surface renders from, so the notice is
+asserted against the registry itself rather than a pinned sentence.
+"""
+
+from teatree.config.retired_settings import (
+    CLEAR_REMEDY,
+    REMOVED_SETTING_KEYS,
+    RENAMED_SETTING_KEYS,
+    removed_setting,
+    retirement_notice,
+)
+
+
+class TestRetirementNotice:
+    def test_a_renamed_key_is_told_where_its_value_now_lives(self) -> None:
+        notice = retirement_notice("speed")
+        assert RENAMED_SETTING_KEYS["speed"] in notice
+        assert "renamed" in notice
+
+    def test_a_removed_key_carries_its_reason_and_the_shared_remedy(self) -> None:
+        key = "issue_implementer_require_label"
+        notice = retirement_notice(key)
+        assert removed_setting(key).reason in notice
+        assert CLEAR_REMEDY.format(key=key) in notice
+
+    def test_the_two_outcomes_do_not_read_alike(self) -> None:
+        # A removal has no answer to give and must say so; a rename has one. Reading
+        # "no successor" as "use X" is the hour the reporting issue paid for.
+        removed = retirement_notice(next(iter(REMOVED_SETTING_KEYS)))
+        assert "no replacement" in removed
+        assert "no replacement" not in retirement_notice("speed")
+
+    def test_a_live_key_has_no_retirement_to_report(self) -> None:
+        assert retirement_notice("issue_implementer_label") is None
+
+    def test_an_unrecorded_key_has_no_retirement_to_report(self) -> None:
+        assert retirement_notice("not_a_real_setting") is None

--- a/tests/teatree_core/management/test_config_setting_command.py
+++ b/tests/teatree_core/management/test_config_setting_command.py
@@ -18,6 +18,7 @@ from django.test import TestCase
 from teatree.config import get_effective_settings
 from teatree.config.cold_defaults import flatten_settings_table
 from teatree.config.enums import Mode
+from teatree.config.retired_settings import CLEAR_REMEDY, RENAMED_SETTING_KEYS, removed_setting
 from teatree.config.setting_groups import UNGROUPED_PATH
 from teatree.core.models import ConfigSetting
 
@@ -284,6 +285,50 @@ class TestConfigSettingGet(TestCase):
     def test_get_rejects_non_overridable_key(self) -> None:
         with pytest.raises(SystemExit):
             call_command("config_setting", "get", "not_a_real_setting", stderr=StringIO())
+
+
+class TestRetiredKeyRefusalRendersTheRecord(TestCase):
+    """A retired key is answered with its retirement record (souliane/teatree#4094).
+
+    The bare unknown-key refusal is indistinguishable from a typo, so a reader who
+    knows the setting used to exist concludes the mechanism is lost rather than
+    superseded — twice, in one session, from ``issue_implementer_require_label``.
+    """
+
+    def _refusal(self, subcommand: str, key: str) -> str:
+        err = StringIO()
+        args = ["config_setting", subcommand, key] + ([] if subcommand == "get" else ["true"])
+        with pytest.raises(SystemExit):
+            call_command(*args, stderr=err, stdout=StringIO())
+        return err.getvalue()
+
+    def test_get_of_a_removed_key_renders_its_reason_and_remedy(self) -> None:
+        entry = removed_setting("issue_implementer_require_label")
+        rendered = self._refusal("get", "issue_implementer_require_label")
+        assert entry.reason in rendered
+        assert CLEAR_REMEDY.format(key="issue_implementer_require_label") in rendered
+        assert "is not a known config setting" not in rendered
+
+    def test_get_of_a_renamed_key_names_its_replacement(self) -> None:
+        rendered = self._refusal("get", "speed")
+        assert RENAMED_SETTING_KEYS["speed"] in rendered
+        assert "is not a known config setting" not in rendered
+
+    def test_get_of_a_genuinely_unknown_key_is_unchanged(self) -> None:
+        assert "is not a known config setting" in self._refusal("get", "not_a_real_setting")
+
+    def test_set_of_a_removed_key_renders_the_record_and_still_refuses(self) -> None:
+        entry = removed_setting("issue_implementer_require_label")
+        assert entry.reason in self._refusal("set", "issue_implementer_require_label")
+        assert ConfigSetting.objects.filter(key="issue_implementer_require_label").exists() is False
+
+    def test_set_of_a_renamed_key_points_at_the_replacement(self) -> None:
+        assert RENAMED_SETTING_KEYS["speed"] in self._refusal("set", "speed")
+        assert ConfigSetting.objects.filter(key="speed").exists() is False
+
+    def test_seed_of_a_removed_key_renders_the_record(self) -> None:
+        entry = removed_setting("issue_implementer_require_label")
+        assert entry.reason in self._refusal("seed", "issue_implementer_require_label")
 
 
 class TestConfigSettingColdHookGateKey(TestCase):


### PR DESCRIPTION
`config_setting get/set/seed` answered a RETIRED key with the bare unknown-key refusal — the same sentence a typo gets. A reader who knows the setting used to exist therefore concludes the mechanism is broken or lost, rather than deliberately superseded. `issue_implementer_require_label` did exactly that to a prior session, twice, while `retired_settings.py` held the correct answer both times.

`retired_settings.py`'s own contract is that a retirement is visible, never silent. The resolver honours it (a loud line naming key, reason and remedy) and `config_setting list` marks stale rows — but `get`/`set` is how anyone actually asks about a setting, and that path never consulted the registry.

## What changed

- `teatree.config.retired_settings.retirement_notice(key)` renders the record from the single registry source, so this surface cannot drift from the resolver warning and the `list` marker.
- The three refusal sites in `config_setting` (`get:258`, `set:110`, `seed:164`) route through one `_refuse_unknown_key` helper that prefers the notice.

The two retirement shapes read differently, which is the part that cost the hour:

- **renamed** (`replacement` set) — `'speed' was renamed to 'wip' — …. Read and write 'wip' instead.`
- **removed** (`replacement is None`) — `'issue_implementer_require_label' was removed — <recorded reason>. It has no replacement. Clear any stale row with \`t3 <overlay> config_setting clear …\`.`

A key in neither registry keeps today's message unchanged. A retired key stays unwritable (`set`/`seed` still exit 2); `get` exits 2 too — there is no value to report — but the record is printed either way.

## Test

`TestRetiredKeyRefusalRendersTheRecord` in `tests/teatree_core/management/test_config_setting_command.py` — both shapes across `get`/`set`/`seed`, plus the positive control that a genuinely unknown key is unchanged and that a refused write leaves no row. Assertions read the registry (`removed_setting(...).reason`, `RENAMED_SETTING_KEYS[...]`, `CLEAR_REMEDY`), so the test cannot drift from the single source.

Observed RED on pre-fix code: 5 failed / 1 passed (the unknown-key control), each failure showing the bare `refusing: '<key>' is not a known config setting`. GREEN after the fix.

## Architecture pre-check

1. **BLUEPRINT § alignment** — no section changes; this restores the stated visibility contract of `config/retired_settings.py` on a surface that did not honour it.
2. **FSM phase boundaries** — n/a, no state transition.
3. **Extension-point contracts** — none touched; no overlay hook, scanner, or Protocol.
4. **Component boundaries** — the rendering lives in `teatree.config` beside the registry it reads (the other two surfaces already do the same); the command keeps only the refusal wiring.
5. **Dependency direction** — `core.management.commands` → `teatree.config` is an existing downward edge (the module already imports five config names). No new edge.
6. **Test surface** — the class above; each assertion fails if the refusal drops the record or the unknown-key path changes.
7. **Resilience invariants** — n/a, no external write.
8. **Identity/key normalization** — the retired key is used verbatim; no stripping or requalification.
9. **Behavior preservation** — purely additive on the refusal path. The unknown-key message, both exit codes, and the "a retired key is not settable" refusal are all preserved; no test was inverted.
10. **Removability / harness-vs-data** — the notice is one pure function with a single caller; deleting it reverts to the old message with no cascade. The varying part (which keys, why, what replaced them) stays in the `RETIRED_SETTINGS` data table, the harness only renders it.

Closes #4094
