### PR TITLE
fix(lease): report the reclaim reason the pid probe supports (#4141)

### DIFF
--- a/src/teatree/core/loop_lease_liveness.py
+++ b/src/teatree/core/loop_lease_liveness.py
@@ -146,6 +146,25 @@ def lease_is_live(claim: LeaseClaim, now: datetime, *, trust_pid_past_ttl: bool)
     return within_ttl and claim.within_unverifiable_grace(now)
 
 
+def reclaim_reason(owner_pid: int | None) -> str:
+    """Why a reclaimed lease was not live, branched on the ACTUAL pid probe (#4141).
+
+    :func:`lease_is_live` collapses disjoint not-live reasons into one boolean and
+    only ONE of them is proof of death. A ``loop:<name>`` slot whose cadence is at
+    least the lease TTL lapses between its own consecutive ticks, so its owner is
+    routinely ALIVE when the sweep reclaims it; reporting proof there sends an
+    operator diagnosing a real outage after a session that never died.
+    """
+    if owner_pid is None:
+        return "the TTL lapsed without a re-claim and no owner pid was recorded"
+    probe = pid_alive_probe()
+    if probe is None:
+        return f"the TTL lapsed without a re-claim; owner pid {owner_pid} could not be probed"
+    if probe(owner_pid):
+        return f"the TTL lapsed without a re-claim; owner pid {owner_pid} is still alive"
+    return f"owner pid {owner_pid} is provably dead"
+
+
 def live_foreign_owner_session(claim: LeaseClaim, session_id: str, now: datetime, *, trust_pid_past_ttl: bool) -> str:
     """The non-empty session of a live owner *other than* ``session_id``, or ``""``.
 

--- a/src/teatree/core/loop_lease_manager.py
+++ b/src/teatree/core/loop_lease_manager.py
@@ -40,6 +40,7 @@ from teatree.core.loop_lease_liveness import (
     live_foreign_owner_session,
     pid_alive_probe,
     pid_is_foreign,
+    reclaim_reason,
 )
 
 logger = logging.getLogger(__name__)
@@ -421,7 +422,7 @@ class LoopLeaseQuerySet(models.QuerySet):
         return 0
 
     def reclaim_dead_owner_leases(self, *, current_pid: int | None = None) -> list[str]:
-        """Orphan every owner-slot lease whose owning SESSION is provably dead (#3571).
+        """Orphan every owner-slot lease whose owner no longer holds it (#3571).
 
         The background reclaim the worker supervisor, ``run_boot_sweeps`` (``t3
         recover``) and the self-heal watchdog run on a cadence so a dead session's
@@ -431,7 +432,8 @@ class LoopLeaseQuerySet(models.QuerySet):
         fires), which routes through the shared discriminator — a busy ``t3-master``
         owner is KEPT (#1604), a per-loop lease past its TTL is reclaimed regardless of
         a reused pid, a fresh-heartbeat owner is never touched. Idempotent and
-        conservative. Returns the reclaimed slot names; every eviction is logged loudly.
+        conservative. Returns the reclaimed slot names; every eviction is logged loudly,
+        under the :func:`reclaim_reason` the pid probe actually supports (#4141).
         """
         reclaimed: list[str] = []
         owned = self.exclude(session_id="").values("name", "session_id", "owner_pid", "lease_expires_at")
@@ -441,12 +443,13 @@ class LoopLeaseQuerySet(models.QuerySet):
                 continue
             reclaimed.append(name)
             logger.warning(
-                "Reclaimed dead-owner loop lease %r (session %r, owner_pid %s, expired at %s): the owning "
-                "session is provably dead past TTL, returning the lease to the pool (#3571).",
+                "Reclaimed stale loop lease %r (session %r, owner_pid %s, expired at %s): %s — returning "
+                "the lease to the pool (#3571).",
                 name,
                 row["session_id"],
                 row["owner_pid"],
                 row["lease_expires_at"],
+                reclaim_reason(row["owner_pid"]),
             )
         return reclaimed
 

--- a/src/teatree/core/worktree/recovery_sweeps.py
+++ b/src/teatree/core/worktree/recovery_sweeps.py
@@ -6,7 +6,7 @@ transition a mid-transition crash dropped; ``reclaim_orphaned_claims`` (#652)
 returns an expired-lease CLAIMED task to PENDING so another open session resumes
 it; ``reap_stale_claims`` fails any residual stale CLAIMED row; and
 ``reclaim_dead_owner_leases`` (#3571) orphans a ``loop:<name>``/``t3-master`` lease
-whose owning session is provably dead so the live worker stops SKIPping the loop.
+whose owner stopped holding it so the live worker stops SKIPping the loop.
 
 Lives in ``teatree.core`` (not ``teatree.loop``) so ``t3 recover`` (#1764) can
 compose it without ``core`` depending on ``loop`` — the dependency direction the

--- a/tests/teatree_core/test_loop_lease_reclaim_message.py
+++ b/tests/teatree_core/test_loop_lease_reclaim_message.py
@@ -1,0 +1,109 @@
+"""The reclaim warning must branch on the pid probe it already ran (#4141).
+
+``lease_is_live`` returns not-live for two disjoint reasons — a pid the probe
+answered DEAD, and (on a ``loop:<name>`` slot) a lapsed TTL under a still-ALIVE
+pid — and the sweep's warning asserted the first unconditionally. Every loop
+whose cadence is at least the lease TTL lapses between its own consecutive
+ticks, so the false "provably dead" was permanent noise on exactly the loops an
+operator investigating an outage reads first.
+"""
+
+import datetime as dt
+import logging
+
+import pytest
+from django.utils import timezone
+
+import teatree.utils.singleton as singleton_mod
+from teatree.core.loop_lease_liveness import reclaim_reason
+from teatree.core.models import LoopLease
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+_PER_LOOP_SLOT = "loop:issue_implementer"
+_MASTER_SLOT = "t3-master"
+_OWNER_SESSION = "loop-runner"
+_OWNER_PID = 7
+
+
+def _seed(slot: str, *, owner_pid: int | None) -> None:
+    now = timezone.now()
+    LoopLease.objects.create(
+        name=slot,
+        session_id=_OWNER_SESSION,
+        owner_pid=owner_pid,
+        acquired_at=now - dt.timedelta(seconds=3600),
+        lease_expires_at=now - dt.timedelta(seconds=60),
+    )
+
+
+def _sweep_warning(caplog: pytest.LogCaptureFixture) -> str:
+    with caplog.at_level(logging.WARNING, logger="teatree.core.loop_lease_manager"):
+        reclaimed = LoopLease.objects.reclaim_dead_owner_leases()
+    assert reclaimed, "the lease must have been reclaimed for a warning to exist"
+    return "\n".join(rec.getMessage() for rec in caplog.records)
+
+
+class TestReclaimWarningBranchesOnTheProbe:
+    """The sweep's warning says what the probe actually answered."""
+
+    def test_a_lapsed_ttl_under_a_live_pid_is_not_called_provably_dead(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(singleton_mod, "pid_alive", lambda _p: True)
+        _seed(_PER_LOOP_SLOT, owner_pid=_OWNER_PID)
+
+        message = _sweep_warning(caplog)
+
+        assert "provably dead" not in message
+        assert f"owner pid {_OWNER_PID} is still alive" in message
+
+    def test_a_dead_pid_is_still_reported_as_proof(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(singleton_mod, "pid_alive", lambda _p: False)
+        _seed(_MASTER_SLOT, owner_pid=_OWNER_PID)
+
+        assert f"owner pid {_OWNER_PID} is provably dead" in _sweep_warning(caplog)
+
+    def test_a_null_pid_is_not_called_provably_dead(self, caplog: pytest.LogCaptureFixture) -> None:
+        _seed(_PER_LOOP_SLOT, owner_pid=None)
+
+        message = _sweep_warning(caplog)
+
+        assert "provably dead" not in message
+        assert "no owner pid was recorded" in message
+
+    def test_the_slot_and_session_stay_in_the_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        _seed(_PER_LOOP_SLOT, owner_pid=None)
+
+        message = _sweep_warning(caplog)
+
+        assert _PER_LOOP_SLOT in message
+        assert _OWNER_SESSION in message
+
+
+class TestReclaimReason:
+    """The ORM-free note itself, over the three probe outcomes."""
+
+    def test_an_alive_pid_names_the_lapsed_ttl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(singleton_mod, "pid_alive", lambda _p: True)
+
+        assert reclaim_reason(_OWNER_PID) == f"the TTL lapsed without a re-claim; owner pid {_OWNER_PID} is still alive"
+
+    def test_a_dead_pid_is_the_only_proof(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(singleton_mod, "pid_alive", lambda _p: False)
+
+        assert reclaim_reason(_OWNER_PID) == f"owner pid {_OWNER_PID} is provably dead"
+
+    def test_an_unprobeable_pid_claims_no_proof(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delattr(singleton_mod, "pid_alive")
+
+        reason = reclaim_reason(_OWNER_PID)
+
+        assert "provably dead" not in reason
+        assert f"owner pid {_OWNER_PID} could not be probed" in reason
+
+    def test_a_null_pid_claims_no_proof(self) -> None:
+        assert reclaim_reason(None) == "the TTL lapsed without a re-claim and no owner pid was recorded"


### PR DESCRIPTION
Closes #4141

## What was wrong

`lease_is_live` returns not-live for two disjoint reasons: a pid the probe answered DEAD, and — on a `loop:<name>` slot, where `trust_pid_past_ttl` is False (#3571) — a lapsed TTL under a still-ALIVE pid. `reclaim_dead_owner_leases` collapsed both into one warning that asserted proof of death unconditionally, discarding the probe answer it had already obtained.

The lease TTL is 1800s and the per-tick re-claim is the only heartbeat, so every loop whose cadence is at least the TTL lapses between its own consecutive ticks — nine enabled loops today. The false "provably dead" was permanent noise on exactly the loops an operator investigating an outage reads first, and it sent the diagnosis of #4140 after a session that had never died.

## What changed

- `teatree.core.loop_lease_liveness.reclaim_reason` — a pure note that branches on the actual probe: "provably dead" is reserved for a pid the probe answered dead; a live pid, an unprobeable pid and a null pid each get a statement that is true.
- The sweep's warning now reads `Reclaimed stale loop lease ... : <reason> — returning the lease to the pool (#3571).`
- Two prose claims of the same falsehood corrected (the method's summary line, the `recovery_sweeps` module docstring).

The TTL-not-pid liveness POLICY is unchanged — it is deliberate per #3571. Only what the log claims about it changed. The optional per-loop TTL suggestion in the issue is not taken here; the message fix stands independently of it.

## Verification

RED observed on the pre-fix code (helper added, log statement still untouched): the headline case logged `Reclaimed dead-owner loop lease 't3-master' (... owner_pid 7 ...): the owning session is provably dead past TTL` while the probe said pid 7 was alive — 3 of 8 new tests failed.

```
uv run --no-sync python -m pytest tests/teatree_core/test_loop_lease_reclaim_message.py \
  tests/teatree_core/test_loop_lease_dead_session_reclaim.py \
  tests/teatree_core/test_loop_lease_liveness.py tests/teatree_core/test_loop_lease.py \
  tests/teatree_core/test_loop_lease_manager.py tests/teatree_core/test_loop_lease_reclaim_is_once.py \
  tests/teatree_core/test_recover_reclaims_dead_leases.py -q --no-migrations
→ 83 passed
```

Consumers of the changed modules (worker / tick-recovery / recover / dream lease / gates / quality ratchets): 200 passed. `dev/test-affected.sh`: 27741 passed, 2 xdist workers crashed under memory pressure on `test_initial_migration_seed.py` and `test_schema_guard.py` — both migration-replay files, both green when re-run on their own (10 passed, 14 passed) and untouched by this diff.

## Architecture pre-check

1. **BLUEPRINT § alignment** — no section changes; this is an observability correction inside the §5.6 loop-lease layer.
2. **FSM phase boundaries** — n/a, no `Ticket`/`Worktree` transition.
3. **Extension-point contracts** — n/a, no `OverlayBase` / scanner / Protocol surface touched.
4. **Component boundaries** — the decision text is a pure predicate over `owner_pid`, so it lives in the ORM-free `loop_lease_liveness` beside `pid_alive_probe`; the manager only formats it.
5. **Dependency direction** — no new import edge; `loop_lease_manager` already imports `loop_lease_liveness`.
6. **Test surface** — `tests/teatree_core/test_loop_lease_reclaim_message.py`: the sweep's warning per probe outcome, plus the note itself over alive / dead / unprobeable / null.
7. **Resilience invariants** — n/a, no external write; the sweep's idempotence is unchanged and still pinned.
8. **Identity and key normalization** — n/a.
9. **Behavior preservation** — nothing removed. The dead-pid branch still says "provably dead"; the reclaim decision, its CAS, and the #3571 TTL policy are byte-identical. No test inverted.
10. **Removability / harness-vs-data** — one pure function with a single call site; deleting it reverts to a literal string. Message wording is harness text, not per-loop policy, so no data surface is warranted.
