### PR TITLE
fix(test-plan): stop pytest collecting the _test_plan domain names (#4167)

### DIFF
--- a/src/teatree/core/management/commands/_test_plan/from_seams.py
+++ b/src/teatree/core/management/commands/_test_plan/from_seams.py
@@ -33,7 +33,7 @@ from teatree.core.management.commands._test_plan.post import (
     find_existing_note,
 )
 from teatree.core.management.commands._test_plan.render import (
-    TestPlanState,
+    PlanState,
     TestPlanValidationError,
     empty_state,
     render_body,
@@ -140,7 +140,7 @@ def _render_scenario(host: CodeHostBackend, *, repo: str, scenario: Scenario, ru
 
 def assemble_scenario_state(
     host: CodeHostBackend, *, repo: str, title: str, scenarios: tuple[Scenario, ...], run: SeamsRun
-) -> TestPlanState:
+) -> PlanState:
     """Fold the authored scenarios + the run's captures + the recorded SHAs into a note state."""
     state = empty_state(ticket=run.ticket_number, title=title)
     state["template"] = _SCENARIO_TEMPLATE

--- a/src/teatree/core/management/commands/_test_plan/manifest.py
+++ b/src/teatree/core/management/commands/_test_plan/manifest.py
@@ -50,6 +50,8 @@ class SideManifest:
 class TestPlanManifest:
     """Parsed + validated ``--manifest``: ticket, MRs, per-side input, template, optional steps."""
 
+    __test__ = False  # not a pytest test class (name starts with 'Test')
+
     ticket: str
     mrs: tuple[str, ...]
     dev: SideManifest

--- a/src/teatree/core/management/commands/_test_plan/mr_post.py
+++ b/src/teatree/core/management/commands/_test_plan/mr_post.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from teatree.core.backend_protocols import CodeHostBackend
 from teatree.core.evidence.test_plan_blocked_gate import check_blocked_body_from_config
 from teatree.core.management.commands._test_plan.post import _comment_id, _verified_embed, find_existing_note
-from teatree.core.management.commands._test_plan.render import test_plan_marker
+from teatree.core.management.commands._test_plan.render import render_ticket_marker
 from teatree.core.on_behalf_gate_recorded import (
     OnBehalfPostBlockedError,
     on_behalf_block_message,
@@ -67,7 +67,7 @@ def _render_mr_note_body(*, title: str, body: str, embeds: list[str], marker_id:
     note_body = f"## {title}\n\n{body}" if body else f"## {title}\n\n_No details provided._"
     if embeds:
         note_body += "\n\n" + "\n\n".join(embeds)
-    return f"{note_body}\n\n{test_plan_marker(ticket_id=marker_id)}"
+    return f"{note_body}\n\n{render_ticket_marker(ticket_id=marker_id)}"
 
 
 def _create_or_update_pr_note(

--- a/src/teatree/core/management/commands/_test_plan/post.py
+++ b/src/teatree/core/management/commands/_test_plan/post.py
@@ -1,7 +1,7 @@
 """Host-facing orchestration for ``e2e post-test-plan`` (teatree #272, #2165).
 
 The ORM + code-host side of the one-note-per-ticket test-plan model. The pure
-string/JSON layer — the manifest parse, the persisted :class:`TestPlanState`,
+string/JSON layer — the manifest parse, the persisted :class:`PlanState`,
 the merge, and the side-by-side render — lives in :mod:`.render`;
 this module resolves the ticket, uploads the artifacts (embedding the relative
 ``/uploads/<secret>/<file>`` reference GitLab claims on save; #2165), merges
@@ -26,9 +26,9 @@ from teatree.core.evidence.test_plan_blocked_gate import BlockedTestPlanPostErro
 from teatree.core.intake.resolve import WorktreeNotFoundError, resolve_worktree
 from teatree.core.management.commands._shared_code_host import NO_CODE_HOST_MESSAGE
 from teatree.core.management.commands._test_plan.render import (
+    PlanState,
     SideManifest,
     TestPlanManifest,
-    TestPlanState,
     TestPlanValidationError,
     WorkflowEmbed,
     empty_state,
@@ -82,6 +82,8 @@ class TestPlanResolutionError(TestPlanValidationError):
     failures alike — both must exit non-zero with no host side effect.
     """
 
+    __test__ = False  # not a pytest test class (name starts with 'Test')
+
 
 class TestPlanMediaError(TestPlanValidationError):
     """An uploaded artifact would not render in the posted note.
@@ -94,11 +96,13 @@ class TestPlanMediaError(TestPlanValidationError):
     failure burns no on-behalf approval and writes no note.
     """
 
+    __test__ = False  # not a pytest test class (name starts with 'Test')
+
 
 @dataclass(frozen=True, slots=True)
 class ExistingNote:
     comment_id: int
-    state: TestPlanState
+    state: PlanState
 
 
 def find_existing_note(comments: list[RawAPIDict], *, ticket_id: str) -> ExistingNote | None:
@@ -138,6 +142,8 @@ class TestPlanPost:
     upload target must follow the note, never the manifest's MRs / CI project.
     """
 
+    __test__ = False  # not a pytest test class (name starts with 'Test')
+
     issue_url: str
     ticket_id: str
     title: str
@@ -157,6 +163,8 @@ class TestPlanFlags:
     is the user-authorised escape for the stills-only gate (a manifest with
     screenshots but no video on any present side is refused without it).
     """
+
+    __test__ = False  # not a pytest test class (name starts with 'Test')
 
     ticket: str = ""
     manifest: str = ""

--- a/src/teatree/core/management/commands/_test_plan/render.py
+++ b/src/teatree/core/management/commands/_test_plan/render.py
@@ -2,7 +2,7 @@
 
 The rendering half of the one-note-per-ticket test-plan model (teatree #272):
 :func:`merge_state` overlays a run's side(s) on the prior
-:class:`~teatree.core.management.commands._test_plan.state.TestPlanState`
+:class:`~teatree.core.management.commands._test_plan.state.PlanState`
 (freezing the side the run does not carry) and :func:`render_body` is a pure
 function of the merged state. The state schema lives in :mod:`.state` and the
 manifest parse in :mod:`.manifest`; this module re-exports both surfaces so
@@ -23,15 +23,15 @@ from teatree.core.management.commands._test_plan.scenario import render_scenario
 from teatree.core.management.commands._test_plan.state import (
     DEFAULT_TEMPLATE,
     KNOWN_TEMPLATES,
+    PlanState,
     SideState,
-    TestPlanState,
     TestPlanValidationError,
     WorkflowEmbed,
     coerce_state,
     empty_state,
     find_ticket_marker,
     parse_state_blob,
-    test_plan_marker,
+    render_ticket_marker,
 )
 from teatree.core.management.commands._test_plan.workflow_templates import render_browser_click_first, render_link_api
 from teatree.utils.url_slug import pr_ref_from_url
@@ -41,10 +41,10 @@ _EMPTY_CELL = "—"
 __all__ = [
     "DEFAULT_TEMPLATE",
     "KNOWN_TEMPLATES",
+    "PlanState",
     "SideManifest",
     "SideState",
     "TestPlanManifest",
-    "TestPlanState",
     "TestPlanValidationError",
     "WorkflowArtifacts",
     "WorkflowEmbed",
@@ -56,7 +56,7 @@ __all__ = [
     "parse_state_blob",
     "render_body",
     "render_mrs_line",
-    "test_plan_marker",
+    "render_ticket_marker",
     "validate_template",
 ]
 
@@ -65,17 +65,17 @@ __all__ = [
 
 
 def merge_state(
-    prior: TestPlanState,
+    prior: PlanState,
     *,
     manifest: TestPlanManifest,
     title: str,
     embeds: dict[str, dict[str, WorkflowEmbed]],
-) -> TestPlanState:
+) -> PlanState:
     """Overlay this run's sides over *prior*, freezing sides not present in *manifest*.
 
     Steps persist across re-runs: a steps-less re-run preserves the prior steps.
     """
-    state: TestPlanState = {
+    state: PlanState = {
         "ticket": manifest.ticket or prior.get("ticket", ""),
         "title": title,
         "mrs": list(manifest.mrs) if manifest.mrs else list(prior.get("mrs", [])),
@@ -179,7 +179,7 @@ def _dev_gap_clause(side: SideState) -> str:
     return "⚠️ Not yet on dev: " + ", ".join(missing) + " — expected gap."
 
 
-def _workflow_names(state: TestPlanState) -> list[str]:
+def _workflow_names(state: PlanState) -> list[str]:
     """Ordered union of both sides' media-bearing workflows and the steps-only ones.
 
     A steps-only manifest (steps recorded, no screenshots/video) keeps its
@@ -198,7 +198,7 @@ def _cells(side: SideState, workflow: str) -> tuple[str, list[str]]:
     return wf.get("video_md") or _EMPTY_CELL, list(wf.get("image_md", []))
 
 
-def _test_plan_block(state: TestPlanState, workflow: str) -> list[str]:
+def _test_plan_block(state: PlanState, workflow: str) -> list[str]:
     """Numbered ``**How to test:**`` step list for *workflow*, or ``[]`` when none."""
     steps = state.get("steps", {}).get(workflow, [])
     if not steps:
@@ -206,7 +206,7 @@ def _test_plan_block(state: TestPlanState, workflow: str) -> list[str]:
     return ["**How to test:**", "", *[f"{i}. {step}" for i, step in enumerate(steps, start=1)], ""]
 
 
-def _workflow_table(state: TestPlanState, workflow: str) -> list[str]:
+def _workflow_table(state: PlanState, workflow: str) -> list[str]:
     """Heading + optional steps + ``| Dev | Local |`` table for one workflow.
 
     A backend-only workflow carries neither video nor screenshots on either
@@ -237,14 +237,14 @@ def _workflow_table(state: TestPlanState, workflow: str) -> list[str]:
     return lines
 
 
-def _render_header(state: TestPlanState) -> list[str]:
+def _render_header(state: PlanState) -> list[str]:
     """Shared preamble for every template: markers, heading, MRs, commits, reconcile."""
     ticket_id = state.get("ticket", "")
     title = state.get("title", "") or ticket_id
     dev, local = state["dev"], state["local"]
     base_index = _commit_base_index(tuple(state.get("mrs", [])))
     lines: list[str] = [
-        test_plan_marker(ticket_id=ticket_id),
+        render_ticket_marker(ticket_id=ticket_id),
         f"<!-- t3-e2e-data {json.dumps(state, separators=(',', ':'), sort_keys=True)} -->",
         f"## Test Plan — {title}",
         "",
@@ -266,7 +266,7 @@ def _render_header(state: TestPlanState) -> list[str]:
     return lines
 
 
-def _blocked_lines(state: TestPlanState) -> list[str]:
+def _blocked_lines(state: PlanState) -> list[str]:
     """Blocked-workflow placeholders: one heading + reason per entry."""
     lines: list[str] = []
     for workflow, reason in (state.get("blocked_workflows") or {}).items():
@@ -274,7 +274,7 @@ def _blocked_lines(state: TestPlanState) -> list[str]:
     return lines
 
 
-def render_body(state: TestPlanState) -> str:
+def render_body(state: PlanState) -> str:
     """Render the full note body from the merged state.
 
     Dispatches on ``state["template"]``: ``"browser-click-first"`` →

--- a/src/teatree/core/management/commands/_test_plan/scenario.py
+++ b/src/teatree/core/management/commands/_test_plan/scenario.py
@@ -161,7 +161,7 @@ def render_scenario_plan(state: Mapping[str, object]) -> list[str]:
 
     Reads its own keys off the persisted state mapping (``scenarios``,
     ``scenario_intro``, ``environment``) so the render layer dispatches with a
-    single argument and this module needs no back-reference to ``TestPlanState``.
+    single argument and this module needs no back-reference to ``PlanState``.
     """
     lines: list[str] = []
     intro = str(state.get("scenario_intro") or "")

--- a/src/teatree/core/management/commands/_test_plan/state.py
+++ b/src/teatree/core/management/commands/_test_plan/state.py
@@ -1,6 +1,6 @@
 """The persisted test-plan state model — the source of truth for the merge.
 
-The typed :class:`TestPlanState` is serialised into the hidden
+The typed :class:`PlanState` is serialised into the hidden
 ``<!-- t3-e2e-data {…} -->`` blob on the one-note-per-ticket test-plan note
 (teatree #272). This module owns the state schema, its defensive JSON
 coercion, and the note-marker parse/emit — every function a pure transform
@@ -37,6 +37,8 @@ _DATA_BLOB_RE = re.compile(r"<!--\s*t3-e2e-data\s+(?P<json>\{.*?\})\s*-->", re.D
 class TestPlanValidationError(ValueError):
     """Raised when a manifest fails pre-post validation; the note is NOT posted."""
 
+    __test__ = False  # not a pytest test class (name starts with 'Test')
+
 
 def _as_dict(value: object) -> Mapping[str, object]:
     """``value`` as a read-only mapping when it is a dict, else ``{}``."""
@@ -65,7 +67,7 @@ class SideState(TypedDict):
     missing_on_dev: NotRequired[list[str]]
 
 
-class TestPlanState(ScenarioSection):
+class PlanState(ScenarioSection):
     """The full persisted note state — serialised into the hidden ``t3-e2e-data`` blob.
 
     ``template``: ``"capture-matrix"`` (default), ``"browser-click-first"``,
@@ -86,7 +88,7 @@ class TestPlanState(ScenarioSection):
     blocked_workflows: NotRequired[dict[str, str]]
 
 
-def empty_state(*, ticket: str, title: str) -> TestPlanState:
+def empty_state(*, ticket: str, title: str) -> PlanState:
     """A fresh state with both sides empty."""
     return {
         "ticket": ticket,
@@ -121,10 +123,10 @@ def _coerce_side(raw: object, *, env: str) -> SideState:
     return side
 
 
-def coerce_state(raw: object) -> TestPlanState:
-    """Build a well-typed :class:`TestPlanState` from a JSON blob; drops malformed fields."""
+def coerce_state(raw: object) -> PlanState:
+    """Build a well-typed :class:`PlanState` from a JSON blob; drops malformed fields."""
     raw_dict = _as_dict(raw)
-    state: TestPlanState = {
+    state: PlanState = {
         "ticket": str(raw_dict.get("ticket") or ""),
         "title": str(raw_dict.get("title") or ""),
         "mrs": [str(m) for m in _as_list(raw_dict.get("mrs"))],
@@ -152,12 +154,12 @@ def _coerce_steps(raw: object) -> dict[str, list[str]]:
     return {str(name): [str(s) for s in _as_list(steps)] for name, steps in _as_dict(raw).items() if _as_list(steps)}
 
 
-def test_plan_marker(*, ticket_id: str) -> str:
+def render_ticket_marker(*, ticket_id: str) -> str:
     """Hidden HTML-comment idempotency marker; matched by :data:`_TICKET_MARKER_RE`."""
     return f"<!-- t3-e2e-evidence ticket={ticket_id} -->"
 
 
-def parse_state_blob(body: str) -> TestPlanState:
+def parse_state_blob(body: str) -> PlanState:
     """Recover the persisted state from a note body, or an empty state when absent/corrupt."""
     match = _DATA_BLOB_RE.search(body)
     if match is None:

--- a/src/teatree/core/management/commands/_test_plan/workflow_templates.py
+++ b/src/teatree/core/management/commands/_test_plan/workflow_templates.py
@@ -15,13 +15,13 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from teatree.core.management.commands._test_plan.state import TestPlanState
+    from teatree.core.management.commands._test_plan.state import PlanState
 
 
 def render_browser_click_first(
-    state: "TestPlanState",
+    state: "PlanState",
     *,
-    workflow_names: "Callable[[TestPlanState], list[str]]",
+    workflow_names: "Callable[[PlanState], list[str]]",
 ) -> list[str]:
     """``browser-click-first`` template: numbered steps then inline screenshots."""
     lines: list[str] = []
@@ -39,10 +39,10 @@ def render_browser_click_first(
 
 
 def render_link_api(
-    state: "TestPlanState",
+    state: "PlanState",
     *,
-    workflow_names: "Callable[[TestPlanState], list[str]]",
-    test_plan_block: "Callable[[TestPlanState, str], list[str]]",
+    workflow_names: "Callable[[PlanState], list[str]]",
+    test_plan_block: "Callable[[PlanState, str], list[str]]",
 ) -> list[str]:
     """``link-api`` template: How-to-test steps then link_md + code_md per workflow, no table, no images."""
     lines: list[str] = []

--- a/src/teatree/quality/mutation_run.py
+++ b/src/teatree/quality/mutation_run.py
@@ -121,7 +121,7 @@ def load_baseline_per_module(pyproject_path: Path | None = None) -> dict[str, in
     return {str(entry["path"]): int(entry.get("count", 0)) for entry in section.get("baseline_surviving", [])}
 
 
-def tests_for(module: str, settings: MutationSettings) -> tuple[str, ...]:
+def module_test_paths(module: str, settings: MutationSettings) -> tuple[str, ...]:
     return settings.module_tests.get(module, settings.module_tests.get("default", ("tests/",)))
 
 
@@ -303,7 +303,7 @@ def run_scoped(
 
     tests_dir: list[str] = []
     for module in scoped:
-        for path in tests_for(module, settings):
+        for path in module_test_paths(module, settings):
             if path not in tests_dir:
                 tests_dir.append(path)
 

--- a/tests/conformance/test_pytest_collection_optout.py
+++ b/tests/conformance/test_pytest_collection_optout.py
@@ -1,0 +1,180 @@
+"""Domain names under ``src`` that pytest would collect must opt out of collection.
+
+pytest collects any module-level class matching ``python_classes`` (``Test*``)
+and any module-level function matching ``python_functions`` (``test*``) from a
+module it is handed. The scoped doctest step of the push gate hands it every
+changed ``src`` module, so a domain class named ``TestPlanPost`` — nothing to do
+with tests — is collected, fails on its ``__init__``, and the whole step errors.
+The blast radius is every IMPORTER too, because the imported name is a
+module-level attribute of the importing module as well: ``_test_plan/post.py``
+alone errored 28 times, blocking any diff that touched it.
+
+Two cures satisfy the walk. ``__test__ = False`` in the class body fixes it at
+the definition for every importer at once, and is what the ``Test*`` domain
+classes carry. A TypedDict body and a function object accept no such marker
+under ``ty`` (``invalid-typed-dict-statement`` / ``unresolved-attribute``), so
+those names are renamed out of the collection globs instead.
+
+This lane is the ratchet that keeps it fixed — the next domain concept named
+``TestSomething`` fails here instead of silently re-blocking the gate. The
+synthetic lanes prove the walk is anti-vacuous: RED on the exact bug shape, GREEN
+on the opted-out form.
+"""
+
+import ast
+import tomllib
+from pathlib import Path
+
+from teatree.core.management.commands._test_plan.post import TestPlanPost
+from teatree.utils.django_db.testdb_clone import TestDbCloneResult
+from tests.conformance._src_tree import REPO_ROOT, src_modules
+
+# Importing the real names at module scope makes THIS module the canary: each is
+# a module-level attribute here too, so a regressed opt-out errors this lane's
+# own collection — the exact failure the guard describes.
+
+# pytest's DEFAULT collection globs. ``TestPytestDefaultsAreNotOverridden`` below
+# pins that this repo does not narrow or widen them, so the walk cannot drift
+# away from what pytest actually collects.
+_CLASS_PREFIX = "Test"
+_FUNCTION_PREFIX = "test"
+
+_OPT_OUT = "__test__"
+
+
+def _assign_targets(stmt: ast.stmt) -> tuple[ast.expr, ...]:
+    """The assignment targets of *stmt*, covering the bare and annotated forms alike.
+
+    Both spellings are live in the tree — ``__test__ = False`` in a plain class and
+    ``__test__: ClassVar[bool] = False`` in a dataclass/enum — so a walk that reads
+    only ``ast.Assign`` reports an already-fixed class as a violation.
+    """
+    if isinstance(stmt, ast.Assign):
+        return tuple(stmt.targets)
+    if isinstance(stmt, ast.AnnAssign):
+        return (stmt.target,)
+    return ()
+
+
+def _class_opts_out(node: ast.ClassDef) -> bool:
+    """True when *node*'s body assigns ``__test__`` (the pytest opt-out marker)."""
+    return any(
+        isinstance(target, ast.Name) and target.id == _OPT_OUT for stmt in node.body for target in _assign_targets(stmt)
+    )
+
+
+def _function_opt_outs(tree: ast.Module) -> set[str]:
+    """Every function name carrying a module-level ``<name>.__test__ = ...`` assignment."""
+    return {
+        target.value.id
+        for stmt in tree.body
+        for target in _assign_targets(stmt)
+        if isinstance(target, ast.Attribute) and target.attr == _OPT_OUT and isinstance(target.value, ast.Name)
+    }
+
+
+def _is_collected(node: ast.stmt, opted_out: frozenset[str]) -> bool:
+    """True when pytest would collect *node* as a test and nothing opted it out."""
+    if isinstance(node, ast.ClassDef):
+        return node.name.startswith(_CLASS_PREFIX) and not _class_opts_out(node)
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+        return node.name.startswith(_FUNCTION_PREFIX) and node.name not in opted_out
+    return False
+
+
+def collectable_names(tree: ast.Module) -> list[tuple[str, int]]:
+    """``(name, lineno)`` for every module-level definition pytest would collect as a test."""
+    opted_out = frozenset(_function_opt_outs(tree))
+    return [
+        (node.name, node.lineno)
+        for node in tree.body
+        if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef) and _is_collected(node, opted_out)
+    ]
+
+
+def _scan(source: str) -> list[str]:
+    return [name for name, _lineno in collectable_names(ast.parse(source))]
+
+
+class TestLiveTreeOptsOut:
+    def test_no_src_name_is_collectable_without_opting_out(self) -> None:
+        violations = [
+            f"  {path.relative_to(REPO_ROOT)}:{lineno} {name}"
+            for path, tree in src_modules()
+            for name, lineno in collectable_names(tree)
+        ]
+        assert not violations, (
+            "pytest would collect these src definitions as tests, erroring the scoped "
+            f"doctest step for every module that imports them — add `{_OPT_OUT} = False`:\n" + "\n".join(violations)
+        )
+
+
+class TestAntiVacuity:
+    """The walk must go RED on the #4167 shape and GREEN on the opted-out form."""
+
+    def test_domain_class_named_test_is_flagged(self) -> None:
+        assert _scan("class TestPlanPost:\n    pass\n") == ["TestPlanPost"]
+
+    def test_domain_class_with_opt_out_is_clean(self) -> None:
+        assert _scan("class TestPlanPost:\n    __test__ = False\n") == []
+
+    def test_domain_class_with_annotated_opt_out_is_clean(self) -> None:
+        assert _scan("class TestShapeReport:\n    __test__: ClassVar[bool] = False\n") == []
+
+    def test_domain_function_named_test_is_flagged(self) -> None:
+        assert _scan("def test_plan_marker(*, ticket_id):\n    return ticket_id\n") == ["test_plan_marker"]
+
+    def test_domain_function_with_opt_out_is_clean(self) -> None:
+        assert (
+            _scan("def test_plan_marker(*, ticket_id):\n    return ticket_id\n\n\ntest_plan_marker.__test__ = False\n")
+            == []
+        )
+
+    def test_async_domain_function_is_flagged(self) -> None:
+        assert _scan("async def tests_for(module):\n    return module\n") == ["tests_for"]
+
+    def test_unrelated_names_are_clean(self) -> None:
+        assert _scan("class PlanPost:\n    pass\n\n\ndef latest_marker():\n    return 1\n") == []
+
+    def test_nested_definition_is_out_of_scope(self) -> None:
+        # pytest collects module-level attributes only; a nested class is invisible to it.
+        assert _scan("class Outer:\n    class TestInner:\n        pass\n") == []
+
+    def test_opt_out_on_another_name_does_not_clear_it(self) -> None:
+        source = "def test_a():\n    pass\n\n\ndef test_b():\n    pass\n\n\ntest_a.__test__ = False\n"
+        assert _scan(source) == ["test_b"]
+
+
+class TestPytestDefaultsAreNotOverridden:
+    """The walk hardcodes pytest's default globs; a repo override would invalidate it."""
+
+    def test_repo_does_not_override_the_collection_globs(self) -> None:
+        ini = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        options = ini["tool"]["pytest"]["ini_options"]
+        overridden = {key for key in ("python_classes", "python_functions") if key in options}
+        assert not overridden, (
+            f"pyproject overrides {sorted(overridden)}; update this lane's prefixes to match "
+            "or the guard no longer describes what pytest collects"
+        )
+
+
+class TestScanRootIsTheWholePackage:
+    def test_walk_covers_more_than_one_subpackage(self) -> None:
+        # Self-completeness: a re-narrowed src walk would silence the guard.
+        subpackages = {path.relative_to(REPO_ROOT / "src" / "teatree").parts[0] for path, _tree in src_modules()}
+        assert {"core", "quality", "utils"} <= subpackages
+
+
+class TestOptOutSurvivesTheRealClasses:
+    """The opt-out must be visible to pytest at RUNTIME, not just present in the AST."""
+
+    def test_dataclass_and_enum_carry_the_runtime_marker(self) -> None:
+        # A slotted dataclass and an Enum both rebuild their class dict; the marker must survive it.
+        assert TestPlanPost.__test__ is False
+        assert TestDbCloneResult.__test__ is False
+
+
+class TestGuardModuleIsItselfExempt:
+    def test_conformance_lane_lives_outside_the_scanned_root(self) -> None:
+        # This module's own Test* classes ARE real tests; the walk must never reach them.
+        assert Path(__file__).resolve() not in {path for path, _tree in src_modules()}

--- a/tests/quality/test_mutation_run.py
+++ b/tests/quality/test_mutation_run.py
@@ -22,10 +22,29 @@ from teatree.quality.mutation_run import (
     build_mutmut_config,
     load_baseline_per_module,
     load_settings,
+    module_test_paths,
     parse_results,
     run_scoped,
 )
 from teatree.utils.run import CommandFailedError, TimeoutExpired
+
+
+class TestModuleTestPaths:
+    def test_mapped_module_gets_its_own_scoped_dirs(self) -> None:
+        settings = MutationSettings(
+            timeout_seconds=1,
+            module_tests={"src/teatree/on_behalf_gate.py": ("tests/teatree_core/",), "default": ("tests/",)},
+            baseline_total=0,
+        )
+        assert module_test_paths("src/teatree/on_behalf_gate.py", settings) == ("tests/teatree_core/",)
+
+    def test_unmapped_module_falls_back_to_the_default_entry(self) -> None:
+        settings = MutationSettings(timeout_seconds=1, module_tests={"default": ("tests/",)}, baseline_total=0)
+        assert module_test_paths("src/teatree/unmapped.py", settings) == ("tests/",)
+
+    def test_no_default_entry_falls_back_to_the_whole_suite(self) -> None:
+        settings = MutationSettings(timeout_seconds=1, module_tests={}, baseline_total=0)
+        assert module_test_paths("src/teatree/unmapped.py", settings) == ("tests/",)
 
 
 class TestBuildMutmutConfig:

--- a/tests/teatree_core/e2e_command/test_post_test_plan.py
+++ b/tests/teatree_core/e2e_command/test_post_test_plan.py
@@ -98,7 +98,7 @@ class TestRenderBody:
         local: _render.SideState | None = None,
         mrs: list[str] | None = None,
         steps: dict[str, list[str]] | None = None,
-    ) -> _render.TestPlanState:
+    ) -> _render.PlanState:
         default_mrs = [
             "https://gitlab.com/org/client/-/merge_requests/6331",
             "https://gitlab.com/org/product/-/merge_requests/7585",
@@ -354,7 +354,7 @@ class TestMergeState:
         )
 
     def test_dev_only_run_preserves_existing_local_column(self) -> None:
-        prior: _render.TestPlanState = {
+        prior: _render.PlanState = {
             "ticket": "8521",
             "title": "t",
             "mrs": [],
@@ -382,7 +382,7 @@ class TestMergeState:
     def test_steps_less_rerun_preserves_prior_steps(self) -> None:
         # A workflow's steps were recorded on a prior run; a later run that omits
         # steps must NOT erase them (workflow-level, persisted across re-renders).
-        prior: _render.TestPlanState = {
+        prior: _render.PlanState = {
             "ticket": "8521",
             "title": "t",
             "mrs": [],
@@ -1184,7 +1184,7 @@ class TestPureHelpers:
     """The marker / state-blob / existing-note helpers are independently testable."""
 
     def test_marker_round_trip(self) -> None:
-        marker = _render.test_plan_marker(ticket_id="8521")
+        marker = _render.render_ticket_marker(ticket_id="8521")
         assert _render.find_ticket_marker(f"prefix {marker} suffix", ticket_id="8521") is True
         assert _render.find_ticket_marker(f"{marker}", ticket_id="9999") is False
 
@@ -1355,7 +1355,7 @@ class TestRetractEvidence(_EvidenceTestBase):
 
 
 class TestBrowserClickFirstTemplate(TestCase):
-    def _state(self, *, steps: list[str] | None = None) -> _render.TestPlanState:
+    def _state(self, *, steps: list[str] | None = None) -> _render.PlanState:
         return {
             "ticket": "8521",
             "title": "Login flow",
@@ -1403,7 +1403,7 @@ class TestBrowserClickFirstTemplate(TestCase):
 class TestBrowserClickFirstStepsWithoutMedia(TestCase):
     """A steps-only manifest (steps, no screenshots/video) must still render the steps."""
 
-    def _steps_only_state(self) -> _render.TestPlanState:
+    def _steps_only_state(self) -> _render.PlanState:
         return {
             "ticket": "8521",
             "title": "Login flow",
@@ -1446,7 +1446,7 @@ class TestBrowserClickFirstStepsWithoutMedia(TestCase):
         assert "2. Click Login" in visible
 
     def test_media_and_steps_both_render(self) -> None:
-        state: _render.TestPlanState = {
+        state: _render.PlanState = {
             "ticket": "8521",
             "title": "Login flow",
             "mrs": [],
@@ -1462,7 +1462,7 @@ class TestBrowserClickFirstStepsWithoutMedia(TestCase):
 
 
 class TestLinkApiTemplate(TestCase):
-    def _state(self) -> _render.TestPlanState:
+    def _state(self) -> _render.PlanState:
         return {
             "ticket": "8521",
             "title": "API check",
@@ -1498,7 +1498,7 @@ class TestLinkApiTemplate(TestCase):
 class TestLinkApiStepsRendered(TestCase):
     """A steps-only ``link-api`` manifest (steps, no link/code embeds) must render the steps."""
 
-    def _steps_only_state(self) -> _render.TestPlanState:
+    def _steps_only_state(self) -> _render.PlanState:
         return {
             "ticket": "8521",
             "title": "API check",
@@ -1542,7 +1542,7 @@ class TestLinkApiStepsRendered(TestCase):
         assert "2. Assert 201" in visible
 
     def test_renders_steps_alongside_link_and_code(self) -> None:
-        state: _render.TestPlanState = {
+        state: _render.PlanState = {
             "ticket": "8521",
             "title": "API check",
             "mrs": [],
@@ -1592,8 +1592,8 @@ class TestScenarioPlanTemplate(TestCase):
 
     def _state(
         self, *, scenarios: list[_scenario.Scenario], intro: str = "", environment: str = ""
-    ) -> _render.TestPlanState:
-        state: _render.TestPlanState = {
+    ) -> _render.PlanState:
+        state: _render.PlanState = {
             "ticket": "1025",
             "title": "Dark mode toggle",
             "mrs": [],
@@ -1690,7 +1690,7 @@ class TestScenarioPlanTemplate(TestCase):
 
 class TestNeverEmptyRender(TestCase):
     def test_raises_on_empty_state(self) -> None:
-        state: _render.TestPlanState = {
+        state: _render.PlanState = {
             "ticket": "8521",
             "title": "Empty",
             "mrs": [],
@@ -1829,7 +1829,7 @@ class TestTemplateThroughManifest(TestCase):
 class TestTemplateRoundTrip(TestCase):
     """A second ``post-test-plan`` re-reads the blob; new fields must survive."""
 
-    def _seeded_state(self) -> _render.TestPlanState:
+    def _seeded_state(self) -> _render.PlanState:
         return {
             "ticket": "8521",
             "title": "Login flow",
@@ -1850,7 +1850,7 @@ class TestTemplateRoundTrip(TestCase):
             "blocked_workflows": {"Checkout": "Not deployed yet"},
         }
 
-    def _reread(self, state: _render.TestPlanState) -> _render.TestPlanState:
+    def _reread(self, state: _render.PlanState) -> _render.PlanState:
         return _render.parse_state_blob(_render.render_body(state))
 
     def test_template_survives_round_trip(self) -> None:
@@ -1873,7 +1873,7 @@ class TestTemplateRoundTrip(TestCase):
 
 class TestCaptureMatrixRendersBlocked(TestCase):
     def test_capture_matrix_renders_blocked_workflow(self) -> None:
-        state: _render.TestPlanState = {
+        state: _render.PlanState = {
             "ticket": "8521",
             "title": "Login flow",
             "mrs": [],

--- a/tests/teatree_core/e2e_command/test_post_test_plan.py
+++ b/tests/teatree_core/e2e_command/test_post_test_plan.py
@@ -35,6 +35,7 @@ from teatree.core.evidence import test_plan_validation as _validation
 from teatree.core.management.commands._test_plan import post as _test_plan
 from teatree.core.management.commands._test_plan import render as _render
 from teatree.core.management.commands._test_plan import scenario as _scenario
+from teatree.core.management.commands._test_plan.render import PlanState, render_body
 from teatree.core.overlay import OverlayMetadata
 from tests.teatree_core.conftest import CommandOverlay
 
@@ -98,7 +99,7 @@ class TestRenderBody:
         local: _render.SideState | None = None,
         mrs: list[str] | None = None,
         steps: dict[str, list[str]] | None = None,
-    ) -> _render.PlanState:
+    ) -> PlanState:
         default_mrs = [
             "https://gitlab.com/org/client/-/merge_requests/6331",
             "https://gitlab.com/org/product/-/merge_requests/7585",
@@ -116,7 +117,7 @@ class TestRenderBody:
         state = self._state(
             local={"commits": {"client": "aaaa", "product": "bbbb"}, "workflows": {"Login": self._embedded()}},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "<!-- t3-e2e-evidence ticket=8521 -->" in body
         assert "<!-- t3-e2e-data " in body
         assert "## Test Plan — My feature" in body
@@ -146,7 +147,7 @@ class TestRenderBody:
                 },
             },
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "### Login" in body
         assert "| Dev | Local |" in body
         # Video row first: dev video left, local video right.
@@ -167,7 +168,7 @@ class TestRenderBody:
                 },
             },
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "| — | ![v](/uploads/s/loc.webm) |" in body
         assert "| — | ![i](/uploads/s/l1.png) |" in body
 
@@ -179,7 +180,7 @@ class TestRenderBody:
                 "workflows": {"Login": self._embedded()},
             },
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "⚠️ Not yet on dev: client!6331 (unmerged), product!7585 (draft) — expected gap." in body
 
     def test_empty_video_row_is_omitted_when_neither_side_has_a_video(self) -> None:
@@ -189,7 +190,7 @@ class TestRenderBody:
         state = self._state(
             local={"commits": {}, "workflows": {"Search": self._embedded(images=("![i](/uploads/s/x.png)",))}},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "| — | — |" not in body  # the empty video row is dropped, not rendered blank
         # The screenshot pair row still renders (dev absent → em-dash left, local image right).
         assert "| — | ![i](/uploads/s/x.png) |" in body
@@ -206,12 +207,12 @@ class TestRenderBody:
                 "workflows": {"Login": self._embedded(video="![v](/uploads/s/loc.webm)")},
             },
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "| — | ![v](/uploads/s/loc.webm) |" in body
 
     def test_mrs_line_omitted_when_no_mrs(self) -> None:
         state = self._state(mrs=[], local={"commits": {}, "workflows": {"Wf": self._embedded(images=("![i](u)",))}})
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "Repos & MRs:" not in body
 
     def test_test_plan_steps_render_numbered_above_the_table(self) -> None:
@@ -219,7 +220,7 @@ class TestRenderBody:
             local={"commits": {}, "workflows": {"Login": self._embedded(images=("![i](/uploads/s/l1.png)",))}},
             steps={"Login": ["Open the app", "Click the Login button", "Expect the dashboard"]},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "**How to test:**" in body
         assert "1. Open the app" in body
         assert "2. Click the Login button" in body
@@ -237,7 +238,7 @@ class TestRenderBody:
             local={"commits": {}, "workflows": {"Search": self._embedded(images=("![i](u)",))}},
             steps={},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "**How to test:**" not in body
 
     def test_backend_only_workflow_suppresses_the_empty_dev_local_table(self) -> None:
@@ -249,7 +250,7 @@ class TestRenderBody:
             local={"commits": {}, "workflows": {}},
             steps={"Backend fee removal": ["Load the offer serializer", "Actual: ✅ fee line absent from payload"]},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "### Backend fee removal" in body
         assert "1. Load the offer serializer" in body
         assert "2. Actual: ✅ fee line absent from payload" in body
@@ -262,7 +263,7 @@ class TestRenderBody:
         state = self._state(
             local={"commits": {}, "workflows": {"Backend claim": self._embedded()}},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "### Backend claim" in body
         assert "| Dev | Local |" not in body
 
@@ -276,7 +277,7 @@ class TestRenderBody:
             },
             steps={"Backend fee removal": ["Load the serializer", "Actual: ✅ absent"]},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "### UI login" in body
         assert "| Dev | Local |" in body  # the media-bearing workflow keeps its table
         assert "| — | ![i](/uploads/s/l1.png) |" in body
@@ -288,7 +289,7 @@ class TestRenderBody:
         state = self._state(
             local={"commits": {"client": "aabbcc"}, "workflows": {"Login": self._embedded()}},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "Local tested: [client `aabbcc`](https://gitlab.com/org/client/-/commit/aabbcc)" in body
 
     def test_commit_sha_without_matching_mr_falls_back_to_bare_codespan(self) -> None:
@@ -297,7 +298,7 @@ class TestRenderBody:
             mrs=["https://gitlab.com/org/client/-/merge_requests/6331"],
             local={"commits": {"backend": "ddeeff"}, "workflows": {"Login": self._embedded()}},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "Local tested: backend `ddeeff`" in body
         assert "](https://gitlab.com/org/backend/-/commit/" not in body
 
@@ -306,7 +307,7 @@ class TestRenderBody:
             mrs=["https://github.com/owner/product/pull/7585"],
             local={"commits": {"product": "c0ffee"}, "workflows": {"Login": self._embedded()}},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "[product `c0ffee`](https://github.com/owner/product/commit/c0ffee)" in body
 
     def test_reconcile_line_shows_same_when_dev_and_local_match(self) -> None:
@@ -314,7 +315,7 @@ class TestRenderBody:
             dev={"commits": {"client": "aabb"}, "missing_on_dev": [], "workflows": {"Login": self._embedded()}},
             local={"commits": {"client": "aabb"}, "workflows": {"Login": self._embedded()}},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "Dev ± Local: client: = same commit" in body
 
     def test_reconcile_line_shows_differ_with_both_shas(self) -> None:
@@ -322,7 +323,7 @@ class TestRenderBody:
             dev={"commits": {"client": "ddee"}, "missing_on_dev": [], "workflows": {"Login": self._embedded()}},
             local={"commits": {"client": "aabb"}, "workflows": {"Login": self._embedded()}},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "Dev ± Local: client: ≠ dev `ddee` vs local `aabb`" in body
 
     def test_reconcile_line_omitted_when_no_repo_on_both_sides(self) -> None:
@@ -330,7 +331,7 @@ class TestRenderBody:
         state = self._state(
             local={"commits": {"client": "aabb"}, "workflows": {"Login": self._embedded()}},
         )
-        body = _test_plan.render_body(state)
+        body = render_body(state)
         assert "Dev ± Local:" not in body
 
 
@@ -354,7 +355,7 @@ class TestMergeState:
         )
 
     def test_dev_only_run_preserves_existing_local_column(self) -> None:
-        prior: _render.PlanState = {
+        prior: PlanState = {
             "ticket": "8521",
             "title": "t",
             "mrs": [],
@@ -382,7 +383,7 @@ class TestMergeState:
     def test_steps_less_rerun_preserves_prior_steps(self) -> None:
         # A workflow's steps were recorded on a prior run; a later run that omits
         # steps must NOT erase them (workflow-level, persisted across re-renders).
-        prior: _render.PlanState = {
+        prior: PlanState = {
             "ticket": "8521",
             "title": "t",
             "mrs": [],
@@ -433,7 +434,7 @@ class TestMergeState:
             },
         )
         local_state["ticket"] = "8521"
-        body_after_local = _test_plan.render_body(local_state)
+        body_after_local = render_body(local_state)
         recovered = _test_plan.parse_state_blob(body_after_local)
 
         dev_state = _test_plan.merge_state(
@@ -446,7 +447,7 @@ class TestMergeState:
             },
         )
         dev_state["ticket"] = "8521"
-        final = _test_plan.render_body(dev_state)
+        final = render_body(dev_state)
         # Both columns are present and paired.
         assert "| ![v](/uploads/s/d.webm) | ![v](/uploads/s/l.webm) |" in final
         assert "| ![i](/uploads/s/d1.png) | ![i](/uploads/s/l1.png) |" in final
@@ -1355,7 +1356,7 @@ class TestRetractEvidence(_EvidenceTestBase):
 
 
 class TestBrowserClickFirstTemplate(TestCase):
-    def _state(self, *, steps: list[str] | None = None) -> _render.PlanState:
+    def _state(self, *, steps: list[str] | None = None) -> PlanState:
         return {
             "ticket": "8521",
             "title": "Login flow",
@@ -1403,7 +1404,7 @@ class TestBrowserClickFirstTemplate(TestCase):
 class TestBrowserClickFirstStepsWithoutMedia(TestCase):
     """A steps-only manifest (steps, no screenshots/video) must still render the steps."""
 
-    def _steps_only_state(self) -> _render.PlanState:
+    def _steps_only_state(self) -> PlanState:
         return {
             "ticket": "8521",
             "title": "Login flow",
@@ -1446,7 +1447,7 @@ class TestBrowserClickFirstStepsWithoutMedia(TestCase):
         assert "2. Click Login" in visible
 
     def test_media_and_steps_both_render(self) -> None:
-        state: _render.PlanState = {
+        state: PlanState = {
             "ticket": "8521",
             "title": "Login flow",
             "mrs": [],
@@ -1462,7 +1463,7 @@ class TestBrowserClickFirstStepsWithoutMedia(TestCase):
 
 
 class TestLinkApiTemplate(TestCase):
-    def _state(self) -> _render.PlanState:
+    def _state(self) -> PlanState:
         return {
             "ticket": "8521",
             "title": "API check",
@@ -1498,7 +1499,7 @@ class TestLinkApiTemplate(TestCase):
 class TestLinkApiStepsRendered(TestCase):
     """A steps-only ``link-api`` manifest (steps, no link/code embeds) must render the steps."""
 
-    def _steps_only_state(self) -> _render.PlanState:
+    def _steps_only_state(self) -> PlanState:
         return {
             "ticket": "8521",
             "title": "API check",
@@ -1542,7 +1543,7 @@ class TestLinkApiStepsRendered(TestCase):
         assert "2. Assert 201" in visible
 
     def test_renders_steps_alongside_link_and_code(self) -> None:
-        state: _render.PlanState = {
+        state: PlanState = {
             "ticket": "8521",
             "title": "API check",
             "mrs": [],
@@ -1590,10 +1591,8 @@ class TestScenarioPlanTemplate(TestCase):
         scenario.update(over)
         return scenario
 
-    def _state(
-        self, *, scenarios: list[_scenario.Scenario], intro: str = "", environment: str = ""
-    ) -> _render.PlanState:
-        state: _render.PlanState = {
+    def _state(self, *, scenarios: list[_scenario.Scenario], intro: str = "", environment: str = "") -> PlanState:
+        state: PlanState = {
             "ticket": "1025",
             "title": "Dark mode toggle",
             "mrs": [],
@@ -1690,7 +1689,7 @@ class TestScenarioPlanTemplate(TestCase):
 
 class TestNeverEmptyRender(TestCase):
     def test_raises_on_empty_state(self) -> None:
-        state: _render.PlanState = {
+        state: PlanState = {
             "ticket": "8521",
             "title": "Empty",
             "mrs": [],
@@ -1829,7 +1828,7 @@ class TestTemplateThroughManifest(TestCase):
 class TestTemplateRoundTrip(TestCase):
     """A second ``post-test-plan`` re-reads the blob; new fields must survive."""
 
-    def _seeded_state(self) -> _render.PlanState:
+    def _seeded_state(self) -> PlanState:
         return {
             "ticket": "8521",
             "title": "Login flow",
@@ -1850,7 +1849,7 @@ class TestTemplateRoundTrip(TestCase):
             "blocked_workflows": {"Checkout": "Not deployed yet"},
         }
 
-    def _reread(self, state: _render.PlanState) -> _render.PlanState:
+    def _reread(self, state: PlanState) -> PlanState:
         return _render.parse_state_blob(_render.render_body(state))
 
     def test_template_survives_round_trip(self) -> None:
@@ -1873,7 +1872,7 @@ class TestTemplateRoundTrip(TestCase):
 
 class TestCaptureMatrixRendersBlocked(TestCase):
     def test_capture_matrix_renders_blocked_workflow(self) -> None:
-        state: _render.PlanState = {
+        state: PlanState = {
             "ticket": "8521",
             "title": "Login flow",
             "mrs": [],

--- a/tests/teatree_core/management/commands/_test_plan/test_state.py
+++ b/tests/teatree_core/management/commands/_test_plan/test_state.py
@@ -9,7 +9,12 @@ value-out assertion on the state layer split out of ``render.py`` (Unit 22).
 import json
 
 from teatree.core.management.commands._test_plan import state as state_mod
-from teatree.core.management.commands._test_plan.state import coerce_state, empty_state, parse_state_blob
+from teatree.core.management.commands._test_plan.state import (
+    coerce_state,
+    empty_state,
+    parse_state_blob,
+    render_ticket_marker,
+)
 
 
 class TestEmptyState:
@@ -74,11 +79,11 @@ class TestParseStateBlob:
 
 class TestMarkers:
     def test_marker_emit_and_find_are_consistent(self) -> None:
-        marker = state_mod.render_ticket_marker(ticket_id="8521")
+        marker = render_ticket_marker(ticket_id="8521")
         assert state_mod.find_ticket_marker(f"body\n{marker}\ntail", ticket_id="8521") is True
 
     def test_find_rejects_a_different_ticket(self) -> None:
-        marker = state_mod.render_ticket_marker(ticket_id="8521")
+        marker = render_ticket_marker(ticket_id="8521")
         assert state_mod.find_ticket_marker(marker, ticket_id="9999") is False
 
     def test_find_is_false_without_a_marker(self) -> None:

--- a/tests/teatree_core/management/commands/_test_plan/test_state.py
+++ b/tests/teatree_core/management/commands/_test_plan/test_state.py
@@ -1,7 +1,7 @@
 """Tests for the persisted test-plan state model (``_test_plan/state.py``).
 
 Pure transforms over the hidden ``t3-e2e-data`` blob: defensive coercion of a
-JSON payload into a typed :class:`TestPlanState`, the note-marker parse/emit,
+JSON payload into a typed :class:`PlanState`, the note-marker parse/emit,
 and the blob round-trip. No ORM, no code host — every case is a value-in /
 value-out assertion on the state layer split out of ``render.py`` (Unit 22).
 """
@@ -74,11 +74,11 @@ class TestParseStateBlob:
 
 class TestMarkers:
     def test_marker_emit_and_find_are_consistent(self) -> None:
-        marker = state_mod.test_plan_marker(ticket_id="8521")
+        marker = state_mod.render_ticket_marker(ticket_id="8521")
         assert state_mod.find_ticket_marker(f"body\n{marker}\ntail", ticket_id="8521") is True
 
     def test_find_rejects_a_different_ticket(self) -> None:
-        marker = state_mod.test_plan_marker(ticket_id="8521")
+        marker = state_mod.render_ticket_marker(ticket_id="8521")
         assert state_mod.find_ticket_marker(marker, ticket_id="9999") is False
 
     def test_find_is_false_without_a_marker(self) -> None:


### PR DESCRIPTION
Closes #4167

## The defect

pytest collects any module-level class matching `python_classes` (`Test*`) and any module-level function matching `python_functions` (`test*`) from a module it is handed. The push gate's scoped doctest step hands it every changed `src` module, so the `_test_plan/` domain names — nothing to do with tests — were collected, failed on their constructors, and errored the step. The blast radius covers every **importer** too, because an imported name is a module-level attribute of the importing module as well.

Measured on `origin/main` at `-n 4`:

| command | before | after |
|---|---|---|
| `pytest --doctest-modules src/teatree/core/management/commands/_test_plan/post.py` | **28 errors** | **0** |
| `pytest --doctest-modules src/teatree/core/management/commands/_test_plan/*.py` | **71 errors** | **0** |

(28 = 4 xdist workers x 7 names. The ticket's 56 is the same 7 names at 8 workers.)

Passing the directory rather than the files collects nothing at all under this repo's pytest config, so the `*.py` form above is the whole-package reproduction.

## The fix

Six classes take `__test__ = False` at the definition, which fixes them for every importer at once:

- `_test_plan/post.py` — `TestPlanResolutionError`, `TestPlanMediaError`, `TestPlanPost`, `TestPlanFlags`
- `_test_plan/state.py` — `TestPlanValidationError`
- `_test_plan/manifest.py` — `TestPlanManifest`

Three names **cannot** carry the marker and are renamed out of pytest's collection globs instead, because `ty` rejects both spellings and there is no suppression-free alternative: a TypedDict body admits only annotated declarations (`invalid-typed-dict-statement`), a function object has no declared `__test__` (`unresolved-attribute`), and `setattr` is rewritten straight back by ruff `B010`.

| old | new | why |
|---|---|---|
| `TestPlanState` | `PlanState` | TypedDict — marker not expressible |
| `test_plan_marker` | `render_ticket_marker` | function object; pairs with the existing `find_ticket_marker` reader |
| `tests_for` (`quality/mutation_run`) | `module_test_paths` | function object; matches the `test*` glob |

`quality/test_shape.py` and `utils/django_db/testdb_clone.py` were already opted out via an annotated `ClassVar`, which is why the guard accepts both spellings.

## The guard

`tests/conformance/test_pytest_collection_optout.py` — an AST walk of `src/teatree` asserting every module-level name pytest would collect carries the opt-out, naming `path:line` for each violation.

**Anti-vacuity, observed:**

- Against the pre-fix tree it went RED, naming all 12 offenders.
- Removing a single `__test__ = False` (from `TestPlanPost`) turned it RED again naming exactly `src/teatree/core/management/commands/_test_plan/post.py:135 TestPlanPost`, plus the runtime-marker lane.
- Synthetic lanes pin the walk on the exact bug shape and on each cleared form (bare marker, annotated `ClassVar` marker, unrelated names, nested definitions, a marker on a *different* name).
- A lane pins that `pyproject.toml` does not override the collection globs the walk hardcodes.
- `TestPlanPost` and `TestDbCloneResult` are imported at module scope, so this lane's *own* collection errors if either opt-out regresses.

## #4160 alias — not revertable yet

[#4160](https://github.com/souliane/teatree/pull/4160) is **OPEN and unmerged**. `origin/main`'s `pr.py` still imports the natural `TestPlanMediaError`, so there is nothing to revert here and touching it would only create a conflict. The alias exists only on that PR's branch:

```
src/teatree/core/management/commands/pr.py:63
  from ...post import TestPlanMediaError as _TestPlanMediaError
```

**Follow-up for whoever lands #4160:** drop the `as _TestPlanMediaError` alias and the underscore at the call site (line 636 on that branch) — this PR makes the point patch unnecessary, and leaving both is exactly the drift #4167 exists to prevent.

## Verification

- `pytest --doctest-modules` over all of `_test_plan/*.py`, `quality/mutation_run.py`, `quality/test_shape.py`, `utils/django_db/testdb_clone.py`, `core/management/commands/pr.py` — 0 errors.
- Bounded test selection over every dir referencing the changed modules: **3587 passed** (conformance, `_test_plan`, e2e_command, evidence, pr_command, quality, cli) and **2009 passed** (management_commands, sync, agents/lane_b, eval).
- `ruff check` / `ruff format --check` / `ty check` — clean tree-wide.
- `t3 tool push-gate`: SCOPED, 9 doctest modules / 12 ast-grep files, no full trigger.
- A tree-wide grep confirms no stale reference to any of the three old names outside the guard's own synthetic fixtures.

`dev/test-affected.sh` escalated to a whole-tree run on this diff (it invoked pytest with `tests` plus the changed files); it was killed and replaced with the bounded selection above.

## Architecture pre-check

1. **BLUEPRINT § alignment** — n/a; no architectural surface changes.
2. **FSM phase boundaries** — n/a; no `Ticket`/`Worktree` transitions.
3. **Extension-point contracts** — n/a; no `OverlayBase`, scanner, hook, or Protocol surface touched.
4. **Component boundaries** — the guard is a `tests/conformance/` walk, matching the existing lanes there; the walk is self-contained rather than a new `src/teatree/quality/` module, since it has no CLI or runtime consumer.
5. **Dependency direction** — no new src-to-src import; the test module imports `teatree.core` and `teatree.utils` from `tests/`, which is unconstrained.
6. **Test surface** — `tests/conformance/test_pytest_collection_optout.py`; the live-tree assertion regresses on any new collectable `src` name, and the synthetic lanes regress on a broken walk.
7. **Resilience invariants** — n/a; no external write.
8. **Identity and key normalization** — n/a.
9. **Behavior preservation** — three renames, all mechanical and fully swept; no behaviour dropped, no gate narrowed, no must-block test inverted. The persisted wire marker string (`t3-e2e-evidence`) is untouched — only the Python function that renders it is renamed, so existing notes still update idempotently.
10. **Removability / harness-vs-data** — the guard is one self-contained test module, deletable with no cascade. It is harness, not data: the rule is pytest's fixed collection contract, not a per-item policy, so it carries no allowlist by design — an allowlist is exactly the drift #4167 exists to prevent.
