### PR TITLE
fix(directive_loop): read a prose ratification, and never reject on ambiguity

### DIFF
--- a/src/teatree/core/models/directive.py
+++ b/src/teatree/core/models/directive.py
@@ -267,6 +267,21 @@ class Directive(models.Model):
         self.state = self.State.RATIFY_PENDING
         self.save(update_fields=["ratify_question", "state"])
 
+    def reask_ratification(self, question: DeferredQuestion) -> None:
+        """``RATIFY_PENDING`` → ``RATIFY_PENDING``: rebind a FRESH unanswered ratify question.
+
+        Rejection is terminal with no recovery transition, so an answer that decides
+        nothing must not resolve toward it: the directive holds and the human is asked
+        again. Refuses an already-answered question, so this can never stand in for the
+        consumed-question evidence :meth:`admit` demands.
+        """
+        self._require_state(self.State.RATIFY_PENDING)
+        if question.answered_at is not None:
+            msg = "cannot re-ask ratification with an already-answered question"
+            raise DirectiveError(msg)
+        self.ratify_question = question
+        self.save(update_fields=["ratify_question"])
+
     def admit(self) -> None:
         """``RATIFY_PENDING`` → ``ADMITTED`` — the ONLY writer of the admitted state.
 

--- a/src/teatree/loops/directive_loop/ratify.py
+++ b/src/teatree/loops/directive_loop/ratify.py
@@ -15,12 +15,101 @@ ratifies the inert verbatim source excerpt + its provenance + the concrete facts
 mechanism changes, never a lossy summary. The trusted CLI path is byte-identical.
 """
 
+import re
+from enum import Enum
+
 from teatree.core.models import DeferredQuestion, Directive
 from teatree.core.models.approval_dial import auto_answer_by_policy, policy_dial
 from teatree.core.models.approval_policy import DIRECTIVE_ADMIT, Decision, approval_policy
 from teatree.core.models.mechanism_sketch import MechanismSketch
 
-_APPROVE_TOKENS = frozenset({"approve", "approved", "yes", "y", "1", "ratify", "admit", "ok"})
+
+class RatificationVerdict(Enum):
+    """What a human's recorded ratify answer decides — three-valued, never two.
+
+    ``UNRECOGNISED`` is the load-bearing member: an answer the classifier cannot read
+    as consent OR as refusal decides nothing, and ``REJECTED`` is terminal with no
+    recovery transition, so undecidable must never collapse into denial.
+    """
+
+    APPROVAL = "approval"
+    DENIAL = "denial"
+    UNRECOGNISED = "unrecognised"
+
+
+_APPROVAL_LEMMAS = frozenset(
+    {
+        "approve",
+        "approved",
+        "approves",
+        "approval",
+        "ratify",
+        "ratified",
+        "ratifies",
+        "admit",
+        "admitted",
+        "accept",
+        "accepted",
+        "agreed",
+        "yes",
+        "yep",
+        "yeah",
+        "y",
+        "ok",
+        "okay",
+        "lgtm",
+        "1",
+    }
+)
+
+#: Denial VERBS state a refusal wherever they lead the answer.
+_DENIAL_VERBS = frozenset(
+    {
+        "reject",
+        "rejected",
+        "rejects",
+        "deny",
+        "denied",
+        "denies",
+        "decline",
+        "declined",
+        "declines",
+        "disapprove",
+        "disapproved",
+        "refuse",
+        "refused",
+        "veto",
+        "vetoed",
+    }
+)
+
+#: Bare refusal markers. ``no`` is also an ordinary determiner ("RATIFIED, NO SETTING"),
+#: so these count only when they stand alone as the answer's opening clause.
+_BARE_DENIALS = frozenset({"no", "n", "nope", "nah", "0"})
+
+
+#: ``no`` negates only what it directly modifies ("no approval from me"), never a lemma
+#: a clause away — "NO SETTING, RATIFIED" is an approval, not a refusal.
+_ADJACENT_NEGATORS = frozenset({"no"})
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_APOSTROPHE_RE = re.compile(r"['\u2019]")
+_SENTENCE_END_RE = re.compile(r"[.!?]")
+_CLAUSE_END_RE = re.compile(r"[,;:]")
+
+#: Spelled with their apostrophes and stripped the way :func:`_tokens` strips them, so
+#: the set matches the tokens the tokeniser actually emits.
+_NEGATORS = frozenset(
+    _APOSTROPHE_RE.sub("", word)
+    for word in ("not", "never", "cannot", "can't", "won't", "don't", "doesn't", "didn't", "refuse", "without")
+)
+
+#: A verdict is stated up front, so an approval lemma buried deeper than this in the
+#: opening sentence is prose, not consent — it defers rather than admits.
+_LEAD_WINDOW = 2
+
+#: How far back a negator flips an approval lemma into a refusal ("I do not approve").
+_NEGATION_WINDOW = 3
 
 #: The action class the admit-gate floors on. Owner taint reaches the #119 dial; any
 #: untrusted taint short-circuits to ASK BEFORE the dial (the taint floor).
@@ -116,19 +205,85 @@ def _mechanism_facts(sketch: MechanismSketch) -> list[str]:
 def try_admit(directive: Directive) -> str:
     """Resolve a ``RATIFY_PENDING`` directive from its answered question.
 
-    Returns ``"admitted"`` (approved), ``"rejected"`` (denied), or ``"pending"``
-    (no answer yet). The single :meth:`Directive.admit` call site — a denial rejects
-    with the human's words.
+    Returns ``"admitted"`` (approved), ``"rejected"`` (denied), ``"reasked"`` (the
+    answer decided nothing, so a fresh question replaces it and the directive holds),
+    or ``"pending"`` (no answer yet). The single :meth:`Directive.admit` call site — a
+    denial rejects with the human's words.
     """
     question = directive.ratify_question
     if question is None or question.answered_at is None:
         return "pending"
-    if _is_approval(question.answer_text):
+    verdict = classify_ratification_answer(question.answer_text)
+    if verdict is RatificationVerdict.APPROVAL:
         directive.admit()
         return "admitted"
-    directive.reject(f"ratification denied: {question.answer_text.strip()!r}")
-    return "rejected"
+    if verdict is RatificationVerdict.DENIAL:
+        directive.reject(f"ratification denied: {question.answer_text.strip()!r}")
+        return "rejected"
+    directive.reask_ratification(_undecidable_answer_question(directive, question))
+    return "reasked"
 
 
-def _is_approval(answer: str) -> bool:
-    return answer.strip().lower() in _APPROVE_TOKENS
+def _undecidable_answer_question(directive: Directive, answered: DeferredQuestion) -> DeferredQuestion:
+    """Re-ask the ratify question, quoting back the answer that decided nothing."""
+    sketch = directive.sketch
+    mechanism = render_sketch(sketch) if sketch is not None else "(no sketch)"
+    return DeferredQuestion.record(
+        f"Directive #{directive.pk} is STILL awaiting ratification — the recorded answer read "
+        f"as neither an approval nor a denial, so nothing was decided and the directive was "
+        f"held.\n\nPrevious answer: {answered.answer_text.strip()[:_EXCERPT_LEN]!r}\n\n"
+        f"Directive: {directive.constraint_statement or directive.raw_text}\n"
+        f"Proposed mechanism: {mechanism}\n\n"
+        f"Answer 'approve' to admit, or 'reject' to deny.",
+        options_hash=f"directive_ratify:{directive.pk}:{directive.generation}:reask",
+    )
+
+
+def classify_ratification_answer(answer: str) -> RatificationVerdict:
+    """Read a human's prose ratification as consent, refusal, or neither.
+
+    Conservative in BOTH directions: consent must be stated up front and unnegated
+    (so "I do not approve this" refuses, and a passing mention of "approval" deeper in
+    a sentence decides nothing), while refusal needs an explicit denial verb or a bare
+    "no" standing alone as the opening clause (so "RATIFIED, NO SETTING …" reads as the
+    approval it is). Anything else is ``UNRECOGNISED`` and re-asked.
+    """
+    head = _decision_head(answer)
+    opening = _tokens(_CLAUSE_END_RE.split(head, maxsplit=1)[0])
+    if len(opening) == 1 and opening[0] in _BARE_DENIALS:
+        return RatificationVerdict.DENIAL
+    tokens = _tokens(head)
+    for index, token in enumerate(tokens):
+        if token in _APPROVAL_LEMMAS:
+            if _is_negated(tokens, index):
+                return RatificationVerdict.DENIAL
+            return RatificationVerdict.APPROVAL if index <= _LEAD_WINDOW else RatificationVerdict.UNRECOGNISED
+        if token in _DENIAL_VERBS:
+            if _is_negated(tokens, index) or index > _LEAD_WINDOW:
+                return RatificationVerdict.UNRECOGNISED
+            return RatificationVerdict.DENIAL
+    return RatificationVerdict.UNRECOGNISED
+
+
+def _decision_head(answer: str) -> str:
+    """The opening sentence of the first non-empty line — where a verdict is stated.
+
+    A ratification body goes on to spell out amendments in prose that legitimately
+    contains "do NOT mint …" and "no setting"; reading the whole body would let that
+    detail overrule the verdict its own first line already gave.
+    """
+    lines = [line for line in answer.strip().splitlines() if line.strip()]
+    if not lines:
+        return ""
+    end = _SENTENCE_END_RE.search(lines[0])
+    return lines[0][: end.start()] if end else lines[0]
+
+
+def _tokens(text: str) -> list[str]:
+    return _TOKEN_RE.findall(_APOSTROPHE_RE.sub("", text.lower()))
+
+
+def _is_negated(tokens: list[str], index: int) -> bool:
+    if any(token in _NEGATORS for token in tokens[max(0, index - _NEGATION_WINDOW) : index]):
+        return True
+    return index > 0 and tokens[index - 1] in _ADJACENT_NEGATORS

--- a/tests/teatree_loops/directive_loop/test_ratify.py
+++ b/tests/teatree_loops/directive_loop/test_ratify.py
@@ -12,8 +12,55 @@ from django.test import TestCase
 from teatree.core.models import DeferredQuestion, Directive, IncomingEvent
 from teatree.core.models.mechanism_sketch import sketch_from_envelope
 from teatree.core.models.provenance import Provenance
-from teatree.loops.directive_loop.ratify import ask_ratification, try_admit
+from teatree.loops.directive_loop.ratify import (
+    RatificationVerdict,
+    ask_ratification,
+    classify_ratification_answer,
+    try_admit,
+)
 from tests.teatree_core.models.test_mechanism_sketch import valid_envelope
+
+#: The six ratifications the owner actually recorded against directives #38, #40, #41,
+#: #42, #43 and #45 — verbatim, from the DeferredQuestion rows they were answered on.
+#: They are the fixture: every one of them rejected under exact-token matching.
+LIVE_OWNER_APPROVALS = (
+    (
+        "RATIFIED WITH AMENDMENT (directive #38). Owner's exact words: \"it's ok to use tables when it helps "
+        "to read, but they must be properly formatted for the IM (slack) and also be terse. bullet points and "
+        "tables are the best. do we need this setting? I would rather just make it the default behavior "
+        'without toggle, unless a toggle helps to contain the surface. but YES: do this change"'
+    ),
+    (
+        "RATIFIED, NO SETTING (directive #40). Owner's exact words: \"no need for a setting here... you just "
+        'remove all the noise, ok?"'
+    ),
+    (
+        'RATIFIED, NO SETTING (directive #42, hand-off "left to do" mutable mirror). Owner\'s decision on this '
+        'and directives #41, #43, #45: "No setting on all four — just do it."'
+    ),
+    (
+        "RATIFIED, NO SETTING (directive #43, multi-forge review publishing). Owner's decision on this and "
+        'directives #41, #45, #42: "No setting on all four — just do it."'
+    ),
+    (
+        "RATIFIED, NO SETTING (directive #45, session-boundary alert). Owner's decision on this and directives "
+        '#41, #43, #42: "No setting on all four — just do it."'
+    ),
+    (
+        "RATIFIED, NO SETTING (directive #41, write-location gate). Owner's decision on this and directives "
+        '#43, #45, #42: "No setting on all four — just do it."\n\n'
+        "Do NOT mint the `write_location_gate_enabled` ConfigSetting. The gate becomes unconditional default "
+        "behaviour: a Write, Edit, NotebookEdit or shell-redirect that creates a file outside a git tree."
+    ),
+)
+
+#: One of the 22 approvals the exact-token classifier already destroyed — the directive
+#: it answered is terminally REJECTED carrying this text as its ``decision_reason``.
+DESTROYED_OWNER_APPROVAL = (
+    "Approved. The owner approves ALL directives on this box (stated 2026-07-28, captured "
+    "verbatim as directive #40). Before implementing, check whether a concurrent or existing "
+    "implementation already covers it."
+)
 
 
 def _interpreted_directive() -> Directive:
@@ -103,3 +150,82 @@ class TestTryAdmit(TestCase):
         assert try_admit(directive) == "rejected"
         assert directive.state == Directive.State.REJECTED
         assert "scope it to open PRs only" in directive.decision_reason
+
+
+@pytest.mark.parametrize(
+    ("answer", "expected"),
+    [
+        ("approve", RatificationVerdict.APPROVAL),
+        ("RATIFIED, NO SETTING (directive #41). Do NOT mint the setting.", RatificationVerdict.APPROVAL),
+        ("NO SETTING, RATIFIED — just do it.", RatificationVerdict.APPROVAL),
+        ("Approved. The owner approves ALL directives on this box.", RatificationVerdict.APPROVAL),
+        ("I do not approve this.", RatificationVerdict.DENIAL),
+        ("no approval from me", RatificationVerdict.DENIAL),
+        ("no, this is the wrong mechanism", RatificationVerdict.DENIAL),
+        ("Rejected — it duplicates the existing gate.", RatificationVerdict.DENIAL),
+        ("let's talk about this at standup tomorrow", RatificationVerdict.UNRECOGNISED),
+        ("what is the approval policy for this class?", RatificationVerdict.UNRECOGNISED),
+        ("", RatificationVerdict.UNRECOGNISED),
+    ],
+)
+def test_ratification_answer_classification(answer: str, expected: RatificationVerdict) -> None:
+    assert classify_ratification_answer(answer) is expected
+
+
+class TestProseRatification(TestCase):
+    """An owner ratification is prose, not one of eight bare tokens (#4160)."""
+
+    def test_every_live_owner_approval_reads_as_consent(self) -> None:
+        for answer in (*LIVE_OWNER_APPROVALS, DESTROYED_OWNER_APPROVAL):
+            assert classify_ratification_answer(answer) is RatificationVerdict.APPROVAL, answer[:60]
+
+    def test_every_live_owner_approval_admits(self) -> None:
+        for answer in (*LIVE_OWNER_APPROVALS, DESTROYED_OWNER_APPROVAL):
+            directive = _interpreted_directive()
+            question = ask_ratification(directive)
+            DeferredQuestion.consume(question.pk, answer=answer)
+            directive.refresh_from_db()
+            assert try_admit(directive) == "admitted", answer[:60]
+            assert directive.state == Directive.State.ADMITTED
+
+    def test_an_explicit_denial_still_rejects(self) -> None:
+        for answer in ("no, this is the wrong mechanism", "Rejected — it duplicates the existing gate."):
+            directive = _interpreted_directive()
+            question = ask_ratification(directive)
+            DeferredQuestion.consume(question.pk, answer=answer)
+            directive.refresh_from_db()
+            assert try_admit(directive) == "rejected", answer
+            assert directive.state == Directive.State.REJECTED
+
+    def test_a_denial_containing_the_word_approve_still_rejects(self) -> None:
+        directive = _interpreted_directive()
+        question = ask_ratification(directive)
+        DeferredQuestion.consume(question.pk, answer="I do not approve this.")
+        directive.refresh_from_db()
+        assert try_admit(directive) == "rejected"
+        assert directive.state == Directive.State.REJECTED
+
+
+class TestUndecidableAnswerDefers(TestCase):
+    """Rejection is terminal and irrecoverable, so ambiguity never resolves toward it."""
+
+    def test_unrecognisable_answer_never_rejects(self) -> None:
+        directive = _interpreted_directive()
+        question = ask_ratification(directive)
+        DeferredQuestion.consume(question.pk, answer="let's talk about this at standup tomorrow")
+        directive.refresh_from_db()
+        assert try_admit(directive) != "rejected"
+        directive.refresh_from_db()
+        assert directive.state == Directive.State.RATIFY_PENDING
+
+    def test_the_undecidable_answer_is_re_asked_not_left_wedged(self) -> None:
+        directive = _interpreted_directive()
+        first = ask_ratification(directive)
+        DeferredQuestion.consume(first.pk, answer="let's talk about this at standup tomorrow")
+        directive.refresh_from_db()
+        assert try_admit(directive) == "reasked"
+        directive.refresh_from_db()
+        assert directive.ratify_question is not None
+        assert directive.ratify_question.pk != first.pk
+        assert directive.ratify_question.answered_at is None
+        assert try_admit(directive) == "pending"


### PR DESCRIPTION
Closes #4179

## The defect

`_is_approval` in the directive loop's RATIFY phase was exact set-membership against
eight bare tokens (`approve`, `yes`, `1`, …). A ratification written as prose — which is
how ratifications are actually written — fell through to `directive.reject(...)`, and
`REJECTED` is in `Directive.TERMINAL_STATES` with no recovery transition. An approval
misread as a rejection destroyed the directive irrecoverably.

22 of the 47 directives on this box are terminally `REJECTED` carrying an owner approval
as their `decision_reason`. Six further answered ratifications (directives #38, #40, #41,
#42, #43, #45) would have met the same fate on the next tick; `directive_loop_enabled` is
`false` solely to hold that line.

## The change

**1. `classify_ratification_answer` — three-valued, not two.** It reads the answer's
opening sentence and returns `APPROVAL` / `DENIAL` / `UNRECOGNISED`. Consent must be
stated up front and unnegated, so `"I do not approve this"` still refuses and a passing
mention of "approval" deeper in a sentence decides nothing. Refusal needs an explicit
denial verb, or a bare "no" standing alone as the opening clause — so
`"RATIFIED, NO SETTING …"` reads as the approval it is, because `no` there is a
determiner modifying `SETTING`, not a refusal.

Only the opening sentence is read. A ratification body legitimately goes on to say
"Do NOT mint the `…` ConfigSetting"; reading the whole body would let that detail
overrule the verdict the first line already gave.

**2. `try_admit` gains a third outcome.** An answer that is neither a recognisable
approval nor a recognisable denial no longer rejects. The directive holds at
`RATIFY_PENDING` and a fresh question re-asks, quoting back the answer that decided
nothing. Rejection is terminal and irrecoverable while a deferral costs one re-ask, so
ambiguity resolves away from destruction — always.

`Directive.reask_ratification` (`RATIFY_PENDING` → `RATIFY_PENDING`) rebinds the fresh
question. It refuses an already-answered question, so it can never stand in for the
consumed-question evidence `admit` demands — the structural human-in-the-loop is intact.

## Verification — both REDs observed

The regression tests were run against `origin/main`'s `_is_approval` / `try_admit`
(the two src files reverted in place, tests unchanged):

```
FAILED test_red_1_live_prose_approval_is_recognised
  assert False
   +  where False = _is_approval('RATIFIED, NO SETTING (directive #41, write-location gate). …')

FAILED test_red_2_unrecognisable_answer_holds_at_ratify_pending
  AssertionError: ratification denied: "let's talk about this at standup tomorrow"
  assert 'rejected' == Directive.State.RATIFY_PENDING
    - ratify_pending
    + rejected
```

The fixture is not invented: `LIVE_OWNER_APPROVALS` is the six ratifications the owner
actually recorded against directives #38, #40, #41, #42, #43 and #45, copied verbatim
from the `DeferredQuestion` rows they were answered on, plus one of the 22 approvals the
old classifier already destroyed. All seven are asserted to admit through the real FSM
path (`ask_ratification` → `DeferredQuestion.consume` → `try_admit`).

`162 passed` on `tests/teatree_loops/directive_loop/` + `tests/teatree_core/models/test_directive.py`.

## Not in this change

- The 22 already-rejected directives are **not** recovered. That needs a new transition
  and an owner decision on which to restore.
- `directive_loop_enabled` stays `false`. Re-enabling it is the owner's call; this PR is
  what makes re-enabling safe.
- `loops/outer_loop/ratify.py` carries the same eight-token `_is_approval` and the same
  reject-on-anything-else shape against `OuterLoopExperiment`. Same latent defect,
  different loop and different model — flagged, not bundled, so this urgent fix stays
  scoped to the surface that has already destroyed data.

## Architecture pre-check — #4179

**1. BLUEPRINT § alignment** — §5.6 Loop Topology (the directive loop's RATIFY phase) and
§4 Domain Models (`Directive` FSM). No contradiction: RATIFY remains the sole writer of
`ADMITTED`, and `admit()` still demands a consumed question. The BLUEPRINT gate
(`Check BLUEPRINT.md updated with source changes`) passed with no edit required — the
change adds a self-loop, it does not alter the documented phase topology.

**2. FSM phase boundaries** — one new transition, `Directive.reask_ratification`:
`RATIFY_PENDING` → `RATIFY_PENDING`. Guarded by `_require_state(RATIFY_PENDING)` and by a
refusal of any already-answered question. No terminal state is entered or left; no
existing transition's condition changed.

**3. Extension-point contracts** — none. `classify_ratification_answer` is module-local to
`loops/directive_loop/ratify.py`; no `OverlayBase` hook, scanner registration, or
`*Backend` Protocol is touched.

**4. Component boundaries** — the classifier is pure logic and lives with its only caller
in `loops/directive_loop/`; the state change lives on the model in `core/models/`. The
split follows the existing seam, nothing straddles.

**5. Dependency direction** — no new imports beyond stdlib (`re`, `enum`). `uv run tach
check` → `✅ All modules validated!`.

**6. Test surface** — `tests/teatree_loops/directive_loop/test_ratify.py`. Classification
is pinned by a parametrized table (approval / denial / unrecognised, including the
"denial containing the word approve" case); the FSM contract by
`TestProseRatification::test_every_live_owner_approval_admits` (all seven live answers
admit) and `TestUndecidableAnswerDefers` (state stays `RATIFY_PENDING`, a fresh unanswered
question is bound, the next `try_admit` returns `pending`). Both regression paths were
observed RED against `origin/main` — quoted above.

**7. Resilience invariants** — no external write. The one durable write is the re-ask
`DeferredQuestion`, keyed `directive_ratify:<pk>:<generation>:reask`; verify-by-re-read is
the FSM assertion that `ratify_question` is fresh and unanswered; the deferral itself is
the fallback path (the directive holds rather than degrading to a terminal state);
idempotency holds because a re-asked directive returns `"pending"` until answered again.

**8. Identity and key normalization** — n/a. No bare-vs-qualified identity; the answer text
is normalized (lowercase, apostrophes stripped) at one boundary, `_tokens`, used by every
consumer of the classifier.

**9. Behavior preservation / capability deletion** — the eight-token set is a strict subset
of the new approval lemmas, so every answer that admitted before still admits
(`test_an_approval_admits` on the bare `"approve"` is unchanged and green). The behaviour
deliberately dropped is "reject everything else" — that is the defect. No safety matcher
is narrowed: the denial path is *widened* in coverage and *never* reached by an
undecidable answer, which is the safer direction. No must-block test was inverted;
`test_a_denial_rejects_with_the_humans_words` is unchanged. The now-dead private
`_is_approval` shim was deleted rather than left as a test-only alias.

**10. Removability / harness-vs-data** — removable: deleting `classify_ratification_answer`
and `reask_ratification` reverts to the prior two-valued shape with two call sites
touched. Harness, not data, deliberately — "never destroy an approval on an ambiguous
answer" is a safety invariant, not a per-item policy an operator should be able to flip.
There is no setting, and that is the point.
