### PR TITLE
fix(statusline): render UNKNOWN for a config read that failed, never off

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -75,96 +75,127 @@ fi
 # *visibility*. The #256 colleague guarantee still holds: with `autoload` off and the
 # opt-in unset the bar shows only the neutral hint, regardless of the marker.
 
-# The canonical ConfigSetting store's GLOBAL `autoload` value, JSON-decoded:
-# `true` / `false` / empty. Read-only via the sqlite3 CLI (so the statusline needs
-# no importable teatree python), mirroring teatree.config.cold_reader's WAL
-# fallback: `mode=ro` first (live writer, sidecars present), then `immutable=1`
-# (quiescent WAL, no sidecars — `mode=ro` then errors). Fails silent (empty) on no
-# sqlite3, a missing DB, or any read error.
 # The host-visible projection of the container-owned control DB (#3499). Every
 # ConfigSetting read below resolves a HOST sqlite path, but a containerized deploy
 # keeps the control DB in a volume the host cannot open at all, so that path is
-# simply absent and each reader returns empty — which reads as "autoload is off"
-# and silently takes the whole statusline with it. The publisher writes this file
-# for exactly this consumer; `teatree.config.cold_db.canonical_projection()` is the
-# Python half of the same fallback. Fails silent (empty) on no jq, no file, or a
-# shape it does not recognise, so a plain-clone host is unaffected.
+# absent (or, after the migration that moved it, a leftover 0-byte stub) and each
+# reader returns empty — which reads as "autoload is off" and silently takes the
+# whole statusline with it. The publisher writes this file for exactly this
+# consumer; `teatree.config.cold_db.canonical_projection()` is the Python half of
+# the same fallback.
+#
+# Echoes the decoded value — empty when the key is simply unset — and returns:
+#   0  the projection ANSWERED (a value, or a readable projection with no such key)
+#   1  there is no projection on this host to answer with
+#   2  a projection is present but could not be parsed
+# The 1/2 split is the whole point: "no store here" is a plain-clone host that has
+# genuinely opted into nothing, while "a store is here and I cannot read it" is an
+# unknown that must never be rendered as a stored value.
 _projection_setting() {
-    command -v jq >/dev/null 2>&1 || return 0
+    command -v jq >/dev/null 2>&1 || return 1
     local proj="${TEATREE_HOST_PROJECTION:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/host-projection.json}"
-    [ -r "$proj" ] || return 0
+    [ -r "$proj" ] || return 1
     # `settings` is keyed by SCOPE; "" is global. Values are stored decoded, so a
     # bool arrives as `true`/`false` — the same text the sqlite read yields.
-    jq -r --arg k "$1" '.settings[""][$k] // empty' "$proj" 2>/dev/null || return 0
+    local out
+    out=$(jq -r --arg k "$1" \
+        'if (.settings | type) != "object" then halt_error(3) else (.settings[""][$k] // empty) end' \
+        "$proj" 2>/dev/null) || return 2
+    printf '%s' "$out"
 }
 
-_autoload_db_value() {
-    local db="${T3_CONFIG_DB:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/db.sqlite3}"
-    if ! command -v sqlite3 >/dev/null 2>&1 || [ ! -f "$db" ]; then
-        _projection_setting "autoload"
-        return 0
+# THE single GLOBAL-scope ConfigSetting read for every key this script gates on, so
+# the keys can never disagree about what "could not be read" means. Read-only via
+# the sqlite3 CLI (the statusline needs no importable teatree python), mirroring
+# teatree.config.cold_reader's WAL fallback: `mode=ro` first (live writer, sidecars
+# present), then `immutable=1` (quiescent WAL, no sidecars — `mode=ro` then errors),
+# then the published projection.
+#
+# Echoes the JSON-decoded value and returns 0 when a tier ANSWERED; empty output
+# there means the store is readable and holds no such row, a genuine absence the
+# caller's default covers. Returns 1 — and echoes nothing — when a store is present
+# on this host but NO tier could read it. That is `unknown`, not `unset`; conflating
+# them is what rendered a confident "off" for a setting the DB actually holds as
+# true (#4041). The DB is tested with `-s`, not `-f`: the control-DB migration left
+# a 0-byte stub at the old host path, and a stub that holds nothing is a store this
+# host cannot see — exactly the case the projection exists to answer.
+_config_setting_read() {
+    local key="$1" db out rc
+    db="${T3_CONFIG_DB:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/db.sqlite3}"
+    if command -v sqlite3 >/dev/null 2>&1 && [ -s "$db" ]; then
+        local q="SELECT value FROM teatree_config_setting WHERE scope='' AND key='${key}' LIMIT 1;"
+        if out=$(sqlite3 "file:${db}?mode=ro" "$q" 2>/dev/null) \
+            || out=$(sqlite3 "file:${db}?immutable=1" "$q" 2>/dev/null); then
+            printf '%s' "$out"
+            return 0
+        fi
+        # A DB file present yet unreadable is a store this host cannot see, exactly
+        # like the container-only volume — fall through rather than report its
+        # contents as empty.
+        _projection_setting "$key" && return 0
+        return 1
     fi
-    local q="SELECT value FROM teatree_config_setting WHERE scope='' AND key='autoload' LIMIT 1;"
-    sqlite3 "file:${db}?mode=ro" "$q" 2>/dev/null \
-        || sqlite3 "file:${db}?immutable=1" "$q" 2>/dev/null \
-        || return 0
+    _projection_setting "$key"
+    rc=$?
+    case "$rc" in
+        0) return 0 ;;
+        2) return 1 ;;
+    esac
+    # No store on this host at all: nothing was ever written here to read, so the
+    # shipped default is the answer rather than a guess. This keeps the #256
+    # colleague guarantee — a plain clone renders the neutral off hint, not a "?".
+    return 0
 }
 
 # The canonical ConfigSetting store's GLOBAL `statusline_chain` (a JSON array of
-# glob patterns), one element per line. Read-only via the sqlite3 CLI + `json_each`
-# (so the statusline needs no importable teatree python), with the same WAL
-# fallback as `_autoload_db_value`. Empty on no sqlite3, a missing DB, no row, or a
-# non-array value.
+# glob patterns), one element per line. Same tiers as `_config_setting_read`, kept
+# separate because the caller wants one pattern per line and the projection holds
+# the array whole. Fail-silent-empty is correct HERE — an unresolved chain renders
+# no extra chips, which is a display absence, not a verdict about owner intent.
 _statusline_chain_db() {
-    local db="${T3_CONFIG_DB:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/db.sqlite3}"
-    if ! command -v sqlite3 >/dev/null 2>&1 || [ ! -f "$db" ]; then
-        # Same fallback, flattened: the caller wants one pattern per line, and the
-        # projection holds the array whole.
-        command -v jq >/dev/null 2>&1 || return 0
-        local proj="${TEATREE_HOST_PROJECTION:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/host-projection.json}"
-        [ -r "$proj" ] || return 0
-        jq -r '.settings[""].statusline_chain // [] | .[]' "$proj" 2>/dev/null || return 0
-        return 0
+    local db out
+    db="${T3_CONFIG_DB:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/db.sqlite3}"
+    if command -v sqlite3 >/dev/null 2>&1 && [ -s "$db" ]; then
+        local q="SELECT je.value FROM teatree_config_setting t, json_each(t.value) je WHERE t.scope='' AND t.key='statusline_chain';"
+        if out=$(sqlite3 "file:${db}?mode=ro" "$q" 2>/dev/null) \
+            || out=$(sqlite3 "file:${db}?immutable=1" "$q" 2>/dev/null); then
+            [ -n "$out" ] && printf '%s\n' "$out"
+            return 0
+        fi
     fi
-    local q="SELECT je.value FROM teatree_config_setting t, json_each(t.value) je WHERE t.scope='' AND t.key='statusline_chain';"
-    sqlite3 "file:${db}?mode=ro" "$q" 2>/dev/null \
-        || sqlite3 "file:${db}?immutable=1" "$q" 2>/dev/null \
-        || return 0
+    command -v jq >/dev/null 2>&1 || return 0
+    local proj="${TEATREE_HOST_PROJECTION:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/host-projection.json}"
+    [ -r "$proj" ] || return 0
+    jq -r '.settings[""].statusline_chain // [] | .[]' "$proj" 2>/dev/null || return 0
 }
 
 # Session-start loop/statusline auto-load is OPT-IN (#256): default OFF so a
 # colleague who merely clones the repo never sees the loop statusline. ``autoload``
 # is the ONE owner flag (it engages the session AND arms its loops). Mirrors
 # hook_router._autoload_enabled — env T3_AUTOLOAD first, then the canonical
-# ConfigSetting DB read via the sqlite3 CLI (_autoload_db_value). autoload is
-# DB-home only (no file fallback); fails closed (silent OFF) on absence.
-autoload_enabled() {
+# ConfigSetting read (_config_setting_read). autoload is DB-home only (no file
+# fallback).
+#
+# Echoes exactly one of `on`, `off`, `unknown`. `unknown` is NOT `off`: it means a
+# store exists here that no tier could read, so the shipped default is a guess and
+# must not be rendered as the owner's stored choice.
+autoload_state() {
     local env_val="${T3_AUTOLOAD:-}"
     if [ -n "$env_val" ]; then
         case "$(printf '%s' "$env_val" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')" in
-            1|true|yes|on) return 0 ;;
-            *) return 1 ;;
+            1|true|yes|on) printf 'on' ;;
+            *) printf 'off' ;;
         esac
-    fi
-    case "$(_autoload_db_value)" in
-        true) return 0 ;;
-    esac
-    return 1
-}
-
-# The canonical ConfigSetting store's GLOBAL `statusline_engaged_render` value
-# (#3502), JSON-decoded: `true` / `false` / empty. Read-only via the sqlite3 CLI
-# with the same WAL fallback and fail-silent-empty contract as `_autoload_db_value`.
-_statusline_engaged_render_db_value() {
-    local db="${T3_CONFIG_DB:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/db.sqlite3}"
-    if ! command -v sqlite3 >/dev/null 2>&1 || [ ! -f "$db" ]; then
-        _projection_setting "statusline_engaged_render"
         return 0
     fi
-    local q="SELECT value FROM teatree_config_setting WHERE scope='' AND key='statusline_engaged_render' LIMIT 1;"
-    sqlite3 "file:${db}?mode=ro" "$q" 2>/dev/null \
-        || sqlite3 "file:${db}?immutable=1" "$q" 2>/dev/null \
-        || return 0
+    # The exit status of the substitution is the reader's, so the unknown signal
+    # survives the subshell that a plain global would not.
+    local value
+    value=$(_config_setting_read autoload) || { printf 'unknown'; return 0; }
+    case "$value" in
+        true) printf 'on' ;;
+        *) printf 'off' ;;
+    esac
 }
 
 # A session is explicitly engaged when it carries either engage marker under
@@ -174,23 +205,39 @@ session_engaged() {
     [ -n "$1" ] && { [ -f "$state_dir/$1.teatree-active" ] || [ -f "$state_dir/$1.t3-engaged" ]; }
 }
 
-# The opt-in render path: the flag is a strict-bool `true` AND this session is
-# explicitly engaged. Default false → a colleague never reaches it (#256).
+# The opt-in render path (`statusline_engaged_render`, #3502): the flag is a
+# strict-bool `true` AND this session is explicitly engaged. Default false → a
+# colleague never reaches it (#256). An unreadable store is not `true`, so this
+# stays closed; the honesty of that state is carried by `autoload_state` instead,
+# which is the flag the hint line is about.
 engaged_render_enabled() {
-    case "$(_statusline_engaged_render_db_value)" in
+    local value
+    value=$(_config_setting_read statusline_engaged_render) || return 1
+    case "$value" in
         true) session_engaged "$1" ;;
         *) return 1 ;;
     esac
 }
 
-if [ -n "$session_id" ] && ! autoload_enabled && ! engaged_render_enabled "$session_id"; then
+teatree_autoload_state=$(autoload_state)
+if [ -n "$session_id" ] && [ "$teatree_autoload_state" != "on" ] && ! engaged_render_enabled "$session_id"; then
     # #3233: CC discards zero-byte statusline output, so a silent ``exit 0``
     # here renders a mysteriously BLANK bar under the non-TTY CC invocation
     # (session_id set) — invisible to every run-the-script-by-hand debug pass.
     # Emit one neutral hint line instead so the bar is never empty; the #256
     # colleague guarantee still holds (the loop statusline stays suppressed —
     # only this one-line how-to shows).
-    printf 'teatree: statusline off (autoload disabled) · enable: t3 <overlay> config_setting set autoload true\n'
+    #
+    # #4041: "I could not read the setting" and "the setting is off" are different
+    # facts, and the second is a verdict the reader has no way to distrust. The
+    # degraded read gets its own line saying so, and points at the check that
+    # explains it — never the enable-it hint, which would be advice to overwrite a
+    # value that may already be true.
+    if [ "$teatree_autoload_state" = "unknown" ]; then
+        printf 'teatree: statusline ? · autoload UNKNOWN — config unreadable here, NOT off · diagnose: t3 doctor check\n'
+    else
+        printf 'teatree: statusline off (autoload disabled) · enable: t3 <overlay> config_setting set autoload true\n'
+    fi
     exit 0
 fi
 

--- a/src/teatree/cli/doctor/checks_cold_hooks.py
+++ b/src/teatree/cli/doctor/checks_cold_hooks.py
@@ -239,7 +239,7 @@ def _check_config_override_tier_healthy() -> bool:
         "frame (deterministic — fix the caller, not the DB), SQLite lock contention against a "
         "large control DB, an exhausted file-handle budget, or a full disk. Fix the underlying "
         "fault; the record clears itself once no further read fails for "
-        f"{MARKER_TTL_SECONDS // 3600}h, or delete {marker_path()} to acknowledge it now."
+        f"{MARKER_TTL_SECONDS // 3600}h, or delete {report.path or marker_path()} to acknowledge it now."
     )
     return False
 

--- a/src/teatree/config/override_read_health.py
+++ b/src/teatree/config/override_read_health.py
@@ -23,6 +23,17 @@ The fault RECORD is a file, not a row. The store that failed is the DB, so recor
 degradation there is the one place guaranteed not to work; the marker sits beside the
 primary control DB, where ``t3 doctor`` and the operator can both find it without reading
 a worker log.
+
+Beside the control DB is not always WRITABLE, though, and that gap made the record useless
+in the venue that needs it most (#4041). The canonical path is inside the container's
+control-DB volume, so a HOST process — a hook, a statusline's ``t3`` call — observes the
+fault and then cannot create ``/var/lib/teatree`` to record it. The recorder caught the
+``OSError`` and logged that the fault "is visible only in this log": a health marker
+conceding it cannot do its job in the exact place the job exists. :func:`marker_paths`
+closes that — when the canonical directory is not writable HERE, a per-user location under
+this venue's own data dir is offered as well, so the record lands where the fault was seen.
+It is offered ONLY on that condition, because an unconditional second location would let a
+stale per-user marker outvote a healthy canonical venue.
 """
 
 import json
@@ -92,6 +103,10 @@ class DegradedReadReport:
     reader captures holds only the ORM frames, which are identical for every fault; the caller
     is the one fact that makes the record actionable, so it travels with it. Empty for a marker
     written before the field existed.
+
+    ``path`` is the file this record was actually read from, so an operator told to delete the
+    marker is told the one that exists rather than the canonical path a fallback venue never
+    wrote to. ``None`` for a report built without reading a file.
     """
 
     scopes: tuple[str, ...]
@@ -99,6 +114,7 @@ class DegradedReadReport:
     first_seen: float
     last_seen: float
     callers: tuple[str, ...] = ()
+    path: Path | None = None
 
     @property
     def age_seconds(self) -> float:
@@ -118,6 +134,43 @@ def marker_path() -> Path:
     return ControlDb(os.environ).primary().parent / MARKER_FILENAME
 
 
+def fallback_marker_path() -> Path:
+    """Where the marker goes for a venue that cannot write beside the control DB.
+
+    This venue's OWN data dir — the same root the host projection is published into, so a
+    host that can read teatree's data can read teatree's health record. Deliberately reuses
+    ``data_dir_root`` rather than minting a second root: it already resolves ``T3_DATA_DIR``
+    then the XDG data home per call, which is exactly "somewhere this process can write".
+    """
+    from teatree.paths import data_dir_root  # noqa: PLC0415 — deferred: env-sensitive path resolution at call time
+
+    return data_dir_root() / MARKER_FILENAME
+
+
+def _dir_is_writable(directory: Path) -> bool:
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return False
+    return os.access(directory, os.W_OK)
+
+
+def marker_paths() -> tuple[Path, ...]:
+    """Every location this venue may find the marker in, canonical first.
+
+    The fallback is appended ONLY when the canonical directory cannot be written here. A
+    venue that can write the canonical marker has one answer and must keep having one:
+    offering the per-user path unconditionally would let a stale host marker outvote a
+    healthy container record, which is the same "unverifiable signal read as evidence"
+    defect one layer up.
+    """
+    canonical = marker_path()
+    if _dir_is_writable(canonical.parent):
+        return (canonical,)
+    fallback = fallback_marker_path()
+    return (canonical,) if fallback == canonical else (canonical, fallback)
+
+
 def record_degraded_read(scope: str, *, caller: str = "") -> None:
     """Record that *scope*'s override read failed, merging into any live marker.
 
@@ -125,31 +178,47 @@ def record_degraded_read(scope: str, *, caller: str = "") -> None:
     scopes do, capped at :data:`MAX_RECORDED_CALLERS` so a caller in a hot loop cannot grow the
     file without bound.
 
+    Written to the first of :func:`marker_paths` this venue can actually write, so a host
+    process that cannot reach the container's control-DB volume still leaves a record where
+    it observed the fault instead of only a log line.
+
     Never raises: the caller is a settings resolution that must still return a value, and
-    a marker that cannot be written must not become a second outage. A write failure is
-    logged, so the log remains the backstop when the filesystem is the problem too.
+    a marker that cannot be written must not become a second outage. Exhausting every
+    candidate is reported as a single WARNING line and no traceback — this function runs
+    under the statusline and ``t3 loop status``, whose output must stay quiet and
+    crash-proof, and the frames of an already-handled ``OSError`` name nothing the operator
+    can act on that the path and message do not already say.
     """
     now = time.time()
-    try:
-        existing = _read_marker()
-        scopes = tuple(sorted({*(existing.scopes if existing else ()), scope}))
-        seen_callers = {*(existing.callers if existing else ()), *([caller] if caller else [])}
-        payload = {
+    existing = _read_marker()
+    scopes = tuple(sorted({*(existing.scopes if existing else ()), scope}))
+    seen_callers = {*(existing.callers if existing else ()), *([caller] if caller else [])}
+    blob = json.dumps(
+        {
             "scopes": list(scopes),
             "callers": sorted(seen_callers)[:MAX_RECORDED_CALLERS],
             "occurrences": (existing.occurrences if existing else 0) + 1,
             "first_seen": existing.first_seen if existing else now,
             "last_seen": now,
         }
-        path = marker_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(payload), encoding="utf-8")
-    except OSError:
-        _logger.exception(
-            "ConfigSetting override read degraded for scope %r AND the degradation marker "
-            "could not be written — this fault is visible only in this log.",
-            scope,
-        )
+    )
+
+    refusals: list[str] = []
+    for candidate in marker_paths():
+        try:
+            candidate.parent.mkdir(parents=True, exist_ok=True)
+            candidate.write_text(blob, encoding="utf-8")
+        except OSError as exc:
+            refusals.append(f"{candidate}: {exc}")
+            continue
+        return
+
+    _logger.warning(
+        "ConfigSetting override read degraded for scope %r AND no degradation marker could be "
+        "written (%s) — this fault is visible only in this log.",
+        scope,
+        "; ".join(refusals) or "no candidate path",
+    )
 
 
 def degraded_read_report() -> DegradedReadReport | None:
@@ -166,16 +235,33 @@ def degraded_read_report() -> DegradedReadReport | None:
 
 
 def clear_degraded_read() -> None:
-    """Drop the marker — the operator has acknowledged/repaired the fault."""
-    try:
-        marker_path().unlink(missing_ok=True)
-    except OSError:
-        _logger.exception("could not clear the ConfigSetting degraded-read marker")
+    """Drop every marker this venue can see — the operator acknowledged/repaired the fault.
+
+    All candidates, not just the canonical one: acknowledging a fault that was recorded in
+    the fallback location has to clear THAT file, or the doctor keeps reporting a fault the
+    operator already dismissed.
+    """
+    for candidate in marker_paths():
+        try:
+            candidate.unlink(missing_ok=True)
+        except OSError as exc:
+            _logger.warning("could not clear the ConfigSetting degraded-read marker %s: %s", candidate, exc)
 
 
 def _read_marker() -> DegradedReadReport | None:
+    """The FRESHEST record across every candidate location.
+
+    Freshest rather than canonical-first: the candidates are venue-local files that never
+    see each other's writes, so the newest ``last_seen`` is the only ordering that answers
+    "is the tier degraded now?" rather than "did it ever degrade in this one directory?".
+    """
+    found = [report for report in (_read_marker_at(path) for path in marker_paths()) if report is not None]
+    return max(found, key=lambda report: report.last_seen) if found else None
+
+
+def _read_marker_at(path: Path) -> DegradedReadReport | None:
     try:
-        raw = json.loads(marker_path().read_text(encoding="utf-8"))
+        raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
     if not isinstance(raw, dict):
@@ -195,6 +281,7 @@ def _read_marker() -> DegradedReadReport | None:
         first_seen=float(first_seen),
         last_seen=float(last_seen),
         callers=tuple(str(entry) for entry in callers) if isinstance(callers, list) else (),
+        path=path,
     )
 
 
@@ -207,6 +294,8 @@ __all__ = [
     "DegradedReadReport",
     "clear_degraded_read",
     "degraded_read_report",
+    "fallback_marker_path",
     "marker_path",
+    "marker_paths",
     "record_degraded_read",
 ]

--- a/tests/teatree_config/test_override_read_degradation.py
+++ b/tests/teatree_config/test_override_read_degradation.py
@@ -13,6 +13,7 @@ resolve to the shipped default.
 """
 
 import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -26,18 +27,21 @@ from django.test import TestCase
 from teatree.config import get_effective_settings
 from teatree.config.enums import Autonomy, Mode, OnBehalfPostMode
 from teatree.config.override_read_health import (
+    MARKER_FILENAME,
     MAX_RECORDED_CALLERS,
     SAFETY_FAIL_CLOSED_STORED_VALUES,
     ConfigOverrideReadError,
     clear_degraded_read,
     degraded_read_report,
+    fallback_marker_path,
     marker_path,
+    marker_paths,
     record_degraded_read,
 )
 from teatree.config.provenance import ValueSource, resolve_settings
 from teatree.config.resolution import fail_closed_overrides, read_setting_layers
 from teatree.core.models import ConfigSetting
-from teatree.paths import ControlDb
+from teatree.paths import ControlDb, data_dir_root
 
 _GLOBAL = "global"
 
@@ -337,3 +341,90 @@ class TestTheMarkerCanBeAcknowledged(TestCase):
         tmp = Path(tempfile.mkdtemp()) / "config-read-degraded.json"
         self.addCleanup(lambda: tmp.unlink(missing_ok=True))
         return tmp
+
+
+class TestTheMarkerIsRecordedWhereTheFaultWasObserved(TestCase):
+    """The record has to land in the venue that SAW the fault, not only in the canonical one (#4041).
+
+    The canonical marker sits inside the container's control-DB volume. A HOST process hits
+    the very read failure this records, then cannot create ``/var/lib/teatree`` to write it
+    down — so ``record_degraded_read`` fell into its own ``except OSError`` and logged that
+    the fault "is visible only in this log". A health marker that cannot be written where
+    the fault happens cannot do its job, and the degradation stayed invisible by
+    construction while every consumer resolved against a shipped default.
+
+    The unwritable canonical dir here is one whose PARENT is a regular file, so ``mkdir``
+    raises for root as well — a permission-bit foil would go vacuous under a root test run.
+    """
+
+    def _unwritable_canonical(self) -> Path:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        (root / "blocking-file").write_text("not a directory")
+        return root / "blocking-file" / "control-db" / MARKER_FILENAME
+
+    def _writable_fallback(self) -> Path:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        return root / MARKER_FILENAME
+
+    def test_the_fallback_resolves_into_this_venues_own_data_dir(self) -> None:
+        # The fallback is only useful if it lands where the venue that observed the fault
+        # can write AND where its operator already looks — the same root the host
+        # projection is published into. A fallback pointing back inside the control-DB
+        # volume would satisfy every other case here while fixing nothing.
+        assert fallback_marker_path() == data_dir_root() / MARKER_FILENAME
+        assert fallback_marker_path() != marker_path()
+
+    def test_the_marker_is_written_when_the_canonical_path_is_unwritable(self) -> None:
+        canonical, fallback = self._unwritable_canonical(), self._writable_fallback()
+        with (
+            mock.patch("teatree.config.override_read_health.marker_path", return_value=canonical),
+            mock.patch("teatree.config.override_read_health.fallback_marker_path", return_value=fallback),
+        ):
+            record_degraded_read("global", caller="hook.py:1 in f")
+            report = degraded_read_report()
+        assert fallback.is_file(), "the fault was observed here and recorded nowhere"
+        assert not canonical.exists()
+        assert report is not None
+        assert report.scopes == ("global",)
+        assert report.path == fallback, "the operator must be told the file that exists"
+
+    def test_recording_a_failure_emits_no_traceback(self) -> None:
+        # C: this runs under the statusline and `t3 loop status`, whose output must stay
+        # quiet. Exhausting every candidate is one WARNING line naming the paths tried.
+        canonical = self._unwritable_canonical()
+        with (
+            mock.patch("teatree.config.override_read_health.marker_path", return_value=canonical),
+            mock.patch("teatree.config.override_read_health.fallback_marker_path", return_value=canonical),
+            self.assertLogs("teatree.config", level="WARNING") as logs,
+        ):
+            record_degraded_read("global")
+        assert len(logs.records) == 1, logs.output
+        assert logs.records[0].exc_info is None, "a handled OSError dumped its frames into the bar"
+        assert str(canonical) in logs.output[0]
+
+    def test_a_writable_canonical_venue_keeps_exactly_one_marker(self) -> None:
+        # The foil: offering the per-user path unconditionally would let a stale host
+        # marker outvote a healthy container record — the same defect one layer up.
+        canonical, fallback = self._writable_fallback(), self._writable_fallback()
+        with (
+            mock.patch("teatree.config.override_read_health.marker_path", return_value=canonical),
+            mock.patch("teatree.config.override_read_health.fallback_marker_path", return_value=fallback),
+        ):
+            record_degraded_read("global")
+            assert marker_paths() == (canonical,)
+        assert canonical.is_file()
+        assert not fallback.exists()
+
+    def test_clearing_drops_the_fallback_record_too(self) -> None:
+        canonical, fallback = self._unwritable_canonical(), self._writable_fallback()
+        with (
+            mock.patch("teatree.config.override_read_health.marker_path", return_value=canonical),
+            mock.patch("teatree.config.override_read_health.fallback_marker_path", return_value=fallback),
+        ):
+            record_degraded_read("global")
+            assert degraded_read_report() is not None
+            clear_degraded_read()
+            assert degraded_read_report() is None
+        assert not fallback.exists()

--- a/tests/test_statusline_shell_parity.py
+++ b/tests/test_statusline_shell_parity.py
@@ -392,3 +392,77 @@ class TestStatuslineReadsTheProjectionWhenTheDbIsNotOnThisHost:
         # The shell must READ the published value, not merely notice the file exists.
         self._publish(sandbox, {"autoload": False})
         assert "projection chip" not in self._render(sandbox)
+
+
+class TestAnUnreadableStoreRendersUnknownNotOff:
+    """Could-not-read and is-off must not render alike (#4041).
+
+    The live defect: the control DB moved into a container-only volume (#4001) and the
+    migration left a 0-byte stub at the old host path. ``[ -f "$db" ]`` saw a file, so the
+    projection fallback never ran; the sqlite read then failed with "no such table", the
+    failure collapsed to an empty value, and the bar announced ``statusline off (autoload
+    disabled)`` while the DB held ``autoload = True``. A confident verdict the reader has
+    no way to distrust is worse than no verdict at all.
+
+    The foils carry this lane: a script that rendered "?" whenever it felt uncertain would
+    pass the unknown case and fail every determinate one, which is the #256 colleague
+    guarantee (a plain clone must get the neutral off hint, never a diagnostic).
+    """
+
+    _UNKNOWN = "UNKNOWN"
+    _OFF = "statusline off"
+
+    def _render(self, sandbox: Path, config_db: Path) -> str:
+        target = sandbox / "zones" / "statusline.txt"
+        target.parent.mkdir(exist_ok=True)
+        render(StatuslineZones(anchors=["[acme] degraded chip"]), target=target, colorize=False)
+        result = _run_shell(sandbox, statusline_file=target, autoload_env=None, config_db=config_db)
+        assert result.returncode == 0, result.stderr
+        return _strip_ansi(result.stdout)
+
+    def _unreadable_db(self, sandbox: Path) -> Path:
+        # Present and non-empty, yet no sqlite reader can open it — the same observable
+        # state as the 0-byte stub and the volume the host cannot reach.
+        db = sandbox / "unreadable.sqlite3"
+        db.write_text("this is not a sqlite database")
+        return db
+
+    def _publish(self, sandbox: Path, body: str) -> None:
+        data_dir = sandbox / "xdg" / "teatree"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        (data_dir / "host-projection.json").write_text(body)
+
+    def test_an_unreadable_store_says_unknown_and_never_off(self, sandbox: Path) -> None:
+        out = self._render(sandbox, self._unreadable_db(sandbox))
+        assert self._UNKNOWN in out, out
+        assert self._OFF not in out, "a read that failed was rendered as a stored 'off'"
+
+    def test_an_unparseable_projection_is_unknown_too(self, sandbox: Path) -> None:
+        # The second tier failing is still a failure to READ, not evidence of absence.
+        self._publish(sandbox, "{not json")
+        out = self._render(sandbox, self._unreadable_db(sandbox))
+        assert self._UNKNOWN in out, out
+        assert self._OFF not in out
+
+    def test_a_host_with_no_store_at_all_still_says_off(self, sandbox: Path) -> None:
+        # Foil for #256: a plain clone stored nothing, so "off" is determinate, not a guess.
+        out = self._render(sandbox, sandbox / "absent.sqlite3")
+        assert self._OFF in out, out
+        assert self._UNKNOWN not in out
+
+    def test_a_readable_stored_false_still_says_off(self, sandbox: Path) -> None:
+        # Foil: a store that answers is never unknown, whatever it answers.
+        db = sandbox / "db.sqlite3"
+        _seed_config_db(db, {"autoload": False})
+        out = self._render(sandbox, db)
+        assert self._OFF in out, out
+        assert self._UNKNOWN not in out
+
+    def test_the_projection_still_resolves_past_an_unreadable_db(self, sandbox: Path) -> None:
+        # The root repair: an unreadable DB must fall THROUGH to the published projection
+        # rather than stop at it. Without this the fix above would render an honest "?" on
+        # a host whose projection could have answered the question outright.
+        self._publish(sandbox, json.dumps({"settings": {"": {"autoload": True}}}))
+        out = self._render(sandbox, self._unreadable_db(sandbox))
+        assert "degraded chip" in out, out
+        assert self._UNKNOWN not in out

--- a/tests/test_teatree_opt_in.py
+++ b/tests/test_teatree_opt_in.py
@@ -718,15 +718,23 @@ class TestStatuslineGating:
         out = self._run_statusline("teatree-sess", state_dir, extra_env={"T3_CONFIG_DB": str(db)})
         assert "statusline off" in out
 
-    def test_engaged_render_broken_db_fails_closed_to_hint(self, tmp_path: Path) -> None:
-        # A corrupt/unreadable DB fails CLOSED (opt-in OFF) -> the hint, never blank.
+    def test_engaged_render_broken_db_fails_closed_to_an_honest_hint(self, tmp_path: Path) -> None:
+        # A corrupt/unreadable DB still fails CLOSED (opt-in OFF) and still never blanks
+        # the bar — both invariants below. What it must NOT do is name a cause it did not
+        # establish: this used to assert the "off (autoload disabled)" hint, and that
+        # wording was the #4041 defect, not the contract. The DB the read failed on may
+        # hold `autoload = True`, so the honest hint is UNKNOWN (see the shell-parity lane
+        # for the full unknown/off matrix).
         state_dir = tmp_path / "state"
         state_dir.mkdir(parents=True, exist_ok=True)
         (state_dir / "teatree-sess.teatree-active").touch()
         garbage = tmp_path / "corrupt.sqlite3"
         garbage.write_bytes(b"this is not a sqlite database at all")
         out = self._run_statusline("teatree-sess", state_dir, extra_env={"T3_CONFIG_DB": str(garbage)})
-        assert "statusline off" in out
+        assert out.strip() != "", "the bar must never be blank (#3233)"
+        assert "model=" not in out, "the opt-in must stay closed on a read it could not make"
+        assert "UNKNOWN" in out
+        assert "autoload disabled" not in out
 
 
 # ── #256: default-off teatree autoload + engagement seam ──────────────────


### PR DESCRIPTION
Extends #4041 (an absent or unverifiable signal is read as evidence of absence). Touches the #4050 boundary but does not try to unify the two views; see the finding at the bottom.

## The reported symptom

On the host, the statusline rendered:

```
teatree: statusline off (autoload disabled) · enable: t3 <overlay> config_setting set autoload true
```

while the control DB holds `autoload = True`. Confirmed in the container:

```
autoload = True  [source: db, global]
```

## The chain, verified link by link

1. `hooks/scripts/statusline.sh` resolves the pre-volume host DB path. The control-DB move into a container-only volume left a **0-byte stub** at that path, so `[ -f "$db" ]` saw a file and the projection fallback never ran. Verified: `sqlite3 file:...?mode=ro` on it returns `no such table: teatree_config_setting`.
2. Both sqlite attempts fail, `|| return 0` yields empty, and empty is indistinguishable from a stored `false`.
3. The gate renders a confident `off` naming a cause it never established.
4. The mechanism meant to surface the degradation fails too. `record_degraded_read` did `marker_path().parent.mkdir(...)`, which on the host resolves under `/var/lib/teatree/control-db` and raises `PermissionError: [Errno 13] Permission denied: '/var/lib/teatree'`. It caught the `OSError` and logged a line conceding the fault was visible nowhere else, with a full traceback that landed in `t3 loop status` output. Reproduced live on the host.

The Python cold tier was **not** affected: `cold_reader` resolves the container path, finds it genuinely absent, and falls through to the projection, returning `SettingRead(value=True, readable=True)`. The defect was shell-tier only.

## What changed

**A — the render.** `autoload_state` resolves to `on` / `off` / `unknown`, and an unknown gets its own line pointing at `t3 doctor check` rather than the enable-it hint (which would be advice to overwrite a value that may already be true). A host with **no store at all** stays determinate `off`, so a plain clone keeps the neutral hint and never sees a diagnostic (#256).

**A, centrally.** One `_config_setting_read` now serves every key the script gates on (`autoload`, `statusline_engaged_render`, and the chain read's tiering), so they cannot disagree about what unreadable means. The root repair rides along: the DB is tested for non-empty, and a present-but-unreadable DB falls **through** to the published projection instead of stopping at it.

**B — the record.** `marker_paths` appends a per-user location under the venue's own data dir when the canonical directory is not writable here, and **only** then — an unconditional second location would let a stale host marker outvote a healthy container record, which is the same defect one layer up. Reads take the freshest across candidates; `clear_degraded_read` clears all of them; the report carries the path it was read from so the doctor names the file that exists.

**C — the noise.** Exhausting every candidate is one WARNING naming the paths tried, not a traceback. The `except` was not widened: each candidate is tried and its refusal recorded, and only genuine exhaustion logs.

## Before / after on the host

Before:

```
teatree: statusline off (autoload disabled) · enable: t3 <overlay> config_setting set autoload true
```

After (same input, same host):

```
SDK mtd ≈$1509/$200 │ ram=92% 28.0/30G · cpu=562% · disk=86% 33G free │ TODO 0/7 ✓ · 4▸
skills: t3:{code,debug,test,ship,review,ticket,interactive,internals} ac-python ac-django
t3-master: you ✓ · schedule: standard · mode: engaged →19:00 · 70 waiting · ...
```

And the genuinely-unreadable case, which used to be the same false `off`:

```
teatree: statusline ? · autoload UNKNOWN — config unreadable here, NOT off · diagnose: t3 doctor check
```

## Tests

Both halves pinned, each observed RED against the pre-fix source first.

- Statusline (`tests/test_statusline_shell_parity.py`): a degraded read renders UNKNOWN and not `off`; an unparseable projection is unknown too; the projection still resolves past an unreadable DB. Foils: a stored `false` and a store-less host both still render `off`, so a script that rendered `?` whenever it felt uncertain fails the lane. RED evidence: all three unknown cases emitted the exact reported line, while both foils passed.
- Marker (`tests/teatree_config/test_override_read_degradation.py`): the marker is written when the canonical path is unwritable, the recorder emits no traceback, a writable canonical venue keeps exactly one file, and clearing drops the fallback. RED evidence: the pre-fix recorder wrote no marker anywhere, reported `None`, and logged an ERROR carrying `exc_info`.
- One existing test asserted the old wording for a corrupt DB. Its real invariants (the bar never blanks, the opt-in stays closed) are kept and now asserted directly; the wording assertion was the defect, not the contract.

Targeted runs: 1436 passed across the statusline, config and doctor suites.

## Finding, not fixed here

The shell tier still resolves a **different** default DB path than `cold_reader` does. Today the stale path is an empty stub so the projection answers correctly, but a host that ever has a readable file there would silently win over the projection with stale values. Aligning the two paths belongs with #4050 rather than in this change, and is called out rather than bundled.

`dev/ci-parity-fast.sh` stages 1 and 2 pass. Its stage 3 classifies `hooks/scripts/statusline.sh` as an unclassifiable path and degrades to the whole 39k-test suite, which this box cannot hold; the targeted suites above were run in its place. A control run of the hooks directory on unmodified `origin/main` produced 17 failures against this branch's 2, with a different set each run — pre-existing host flakiness in the banned-terms/leak-gate lanes, whose fail-closed sentinel is itself the host-cannot-read-the-store state.
