### PR TITLE
fix(pr): refuse pr create with a named remedy when the control DB is unreachable

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -8908,6 +8908,10 @@ Usage: t3 teatree pr create [OPTIONS] TICKET_ID
  ticket to a shippable state once the #788 hollow-ship guard confirms the
  fresh branch has real commits — so already-merged work is never re-shipped.
 
+ A ``Ticket`` row is REQUIRED by design, not by accident: this command IS the
+ FSM ship transition and every gate it runs is keyed on the row. A ticketless
+ checkout that only needs a PR opened uses ``pr ensure-pr`` (#4170).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    ticket_id      TEXT  [required]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/src/teatree/core/management/commands/_pr_control_db.py
+++ b/src/teatree/core/management/commands/_pr_control_db.py
@@ -1,0 +1,62 @@
+"""``pr`` control-DB topology concern (split out of ``pr.py``).
+
+The canonical control DB lives in the ``teatree_control_db`` named volume, which
+has no host path at all, so a host process cannot open it — ever. That is the
+deployment shape, not a misconfiguration to repair. Every ``pr`` path past its
+own preconditions needs the ORM, so a host invocation used to die on a raw
+``OperationalError`` naming neither the cause nor the remedy; the rational next
+move for an agent reading that is a raw ``gh pr create``, which is exactly the
+workaround the "fix ``t3``, never hand-roll around it" rule forbids (#4170).
+
+Kept as a sibling module (same pattern as ``_pr_ticket_resolve.py`` /
+``_pr_preview.py``) so the topology precondition is named by its own file and
+``pr.py`` stays within the module-health LOC budget.
+"""
+
+import os
+from pathlib import Path
+from typing import TypedDict
+
+from django.conf import settings
+
+from teatree.db.boundary import control_db_unreachable_reason
+
+
+class ControlDbUnreachableError(TypedDict):
+    """``pr create`` refused before touching the ORM because the control DB is out of reach."""
+
+    error: str
+    hint: str
+
+
+def configured_db_path() -> Path:
+    """The database THIS process would open — the subject of the topology question.
+
+    Read from the resolved settings rather than from the canonical location, so the
+    answer is about the database actually in play: a test database, a per-worktree
+    isolated copy, and the canonical control DB are three different subjects and only
+    the last one sits behind a container-only mount.
+    """
+    return Path(str(settings.DATABASES["default"]["NAME"]))
+
+
+def unreachable_control_db_reason() -> str | None:
+    """Why this process cannot reach the DB it is configured for, or ``None`` when it can."""
+    return control_db_unreachable_reason(configured_db_path(), env=os.environ)
+
+
+def control_db_unreachable_error(reason: str) -> ControlDbUnreachableError:
+    """The ``pr create`` refusal for an unreachable control DB — a remedy, not a diagnosis.
+
+    Worded so it cannot be mistaken for the OTHER refusal this command produces: a
+    missing ``Ticket`` row is a state fact with a state remedy, while this is a
+    topology fact whose only remedy is running the command where the volume is mounted.
+    """
+    return ControlDbUnreachableError(
+        error=(
+            f"`pr create` cannot open the control DB: {reason}. Nothing on the host can reach it, "
+            f"so re-run this inside the worker container — never fall back to a raw `gh pr create`, "
+            f"which bypasses the ship gates, the FSM transition and the on-behalf gates."
+        ),
+        hint="deploy/t3 <overlay> pr create <ticket-id> (the `t3` shell alias already points there)",
+    )

--- a/src/teatree/core/management/commands/_pr_ticket_resolve.py
+++ b/src/teatree/core/management/commands/_pr_ticket_resolve.py
@@ -11,6 +11,11 @@ is named by its own file (self-documenting hierarchy).
 
 from typing import TypedDict
 
+from teatree.core.management.commands._pr_control_db import (
+    ControlDbUnreachableError,
+    control_db_unreachable_error,
+    unreachable_control_db_reason,
+)
 from teatree.core.models import Ticket
 
 
@@ -40,13 +45,39 @@ def ticket_not_found_error(ref: str) -> TicketNotFoundError:
     overlay-managed PR invariants (title format, FSM transitions,
     on-behalf gates). Name the missing reference and the command that
     provisions the row instead.
+
+    #4170: both supported routes are named, because the refusal reads as a dead end
+    otherwise and a dead end is what sends the next agent to ``gh pr create``. Either
+    provision the row and ship through the FSM, or open the PR ticketlessly via the
+    orphan-branch path — ``pr create`` itself requires a ticket by design, since its
+    gates are keyed on the row.
     """
     hint = f"t3 <overlay> workspace ticket <issue-url> (no Ticket row for {ref!r})"
     return TicketNotFoundError(
         error=(
             f"No Ticket row for {ref!r} in the canonical DB. "
             f"Create one with `t3 <overlay> workspace ticket <issue-url>` "
-            f"(or pass the internal DB pk)."
+            f"(or pass the internal DB pk). To open a PR with no ticket at all, use "
+            f"`t3 <overlay> pr ensure-pr --repo <path> --branch <branch>`."
         ),
         hint=hint,
     )
+
+
+def resolve_ticket_or_refusal(ref: str) -> Ticket | ControlDbUnreachableError | TicketNotFoundError:
+    """The CLI ``ticket_id`` as a ``Ticket``, or the refusal saying why it is not one.
+
+    Two preconditions in a fixed order, because they need different remedies and one
+    error collapsing both would hide which applies (#4170). REACHABILITY is a topology
+    fact — a host process cannot open the container-only control-DB volume, ever — so
+    it is read BEFORE any ORM touch rather than inferred from the ``OperationalError``
+    the first query would otherwise raise. EXISTENCE is a state fact, answerable only
+    once the database is open.
+    """
+    unreachable = unreachable_control_db_reason()
+    if unreachable is not None:
+        return control_db_unreachable_error(unreachable)
+    try:
+        return resolve_ticket(ref)
+    except Ticket.DoesNotExist:
+        return ticket_not_found_error(ref)

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -6,12 +6,9 @@ it runs the deterministic gates, calls ``ticket.ship()`` to enter SHIPPED, and
 returns the PR URL once the worker completes.
 """
 
-import os
 import re
-from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-from django.conf import settings
 from django_typer.management import TyperCommand, command
 
 from teatree.core.backend_factory import code_host_from_overlay
@@ -21,17 +18,14 @@ from teatree.core.management.commands._close_keyword_gate import run_close_keywo
 from teatree.core.management.commands._closes_issue_crosscheck import run_closes_issue_crosscheck
 from teatree.core.management.commands._ensure_pr import EnsurePrResult, create_or_defer_pr, defer_unpushed_pr
 from teatree.core.management.commands._pending_pr_commands import PendingPrCommands
+from teatree.core.management.commands._pr_control_db import ControlDbUnreachableError, unreachable_control_db_reason
 from teatree.core.management.commands._pr_preview import (
     PrValidationError,
     ShipDryRun,
     ship_dry_run,
     validate_pr_metadata,
 )
-from teatree.core.management.commands._pr_ticket_resolve import (
-    TicketNotFoundError,
-    resolve_ticket,
-    ticket_not_found_error,
-)
+from teatree.core.management.commands._pr_ticket_resolve import TicketNotFoundError, resolve_ticket_or_refusal
 from teatree.core.management.commands._pr_worktree import WorktreeMissingError, _resolve_or_adopt_worktree
 from teatree.core.management.commands._shared_code_host import no_code_host_error
 from teatree.core.management.commands._ship.exec import (
@@ -70,7 +64,6 @@ from teatree.core.provision.worktree_adopt import reopen_ticket_for_followup
 from teatree.core.public_identity import MergeResult
 from teatree.core.runners.ship import resolve_and_reconcile_branch, resolve_ship_worktree
 from teatree.core.send_proxy import OutboundBlockedError
-from teatree.db.boundary import control_db_unreachable_reason
 from teatree.types import RawAPIDict
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError
@@ -118,17 +111,6 @@ type CommentResult = dict[str, object]
 
 _IMAGE_URL_RE = re.compile(r"!\[([^\]]*)\]\((/uploads/[^\)]+)\)")
 _EXTERNAL_LINK_RE = re.compile(r"https?://(?:www\.)?(?:notion\.so|linear\.app|jira\.\S+)/\S+")
-
-
-def _configured_db_path() -> Path:
-    """The database THIS process would open — the subject of the topology question.
-
-    Read from the resolved settings rather than from the canonical location, so the
-    answer is about the database actually in play: a test database, a per-worktree
-    isolated copy, and the canonical control DB are three different subjects and only
-    the last one sits behind a container-only mount.
-    """
-    return Path(str(settings.DATABASES["default"]["NAME"]))
 
 
 def _run_precheck_ship_gates(
@@ -335,6 +317,7 @@ class Command(PendingPrCommands, TyperCommand):
         | WorktreeMissingError
         | NoCommitsAheadError
         | TicketNotFoundError
+        | ControlDbUnreachableError
     ):
         """Validate ship gates and trigger the ship transition.
 
@@ -365,15 +348,19 @@ class Command(PendingPrCommands, TyperCommand):
         the invoking on-disk worktree as a new row and reopens the terminal
         ticket to a shippable state once the #788 hollow-ship guard confirms the
         fresh branch has real commits — so already-merged work is never re-shipped.
+
+        A ``Ticket`` row is REQUIRED by design, not by accident: this command IS the
+        FSM ship transition and every gate it runs is keyed on the row. A ticketless
+        checkout that only needs a PR opened uses ``pr ensure-pr`` (#4170).
         """
-        try:
-            ticket = resolve_ticket(ticket_id)
-        except Ticket.DoesNotExist:
-            # #1051: no canonical Ticket row (out-of-FSM autonomous-loop
-            # PR, or a pruned row). Return an actionable error instead of
-            # letting the bare DoesNotExist crash the command and force a
-            # manual `gh pr create` fallback.
-            return ticket_not_found_error(ticket_id)
+        # #1051 / #4170: an unreachable control DB and a missing Ticket row are the two
+        # ways this command can have no ticket to ship, and each carries its own
+        # remedy — never a bare OperationalError or DoesNotExist, which is what sent
+        # three agents to a manual `gh pr create` in one day.
+        resolved_ticket = resolve_ticket_or_refusal(ticket_id)
+        if not isinstance(resolved_ticket, Ticket):
+            return resolved_ticket
+        ticket = resolved_ticket
         # #779: refuse to read the shipping gate from a worktree-isolated DB.
         # The gate reads phase attestations; if this process resolved to a
         # per-worktree DB (uv run from a worktree) it sees a partial phase
@@ -474,7 +461,7 @@ class Command(PendingPrCommands, TyperCommand):
         if early_result is not None:
             return early_result
 
-        unreachable = control_db_unreachable_reason(_configured_db_path(), env=os.environ)
+        unreachable = unreachable_control_db_reason()
         if unreachable is not None:
             return EnsurePrResult(skipped=unreachable, branch=branch_name)
 

--- a/tests/teatree_core/pr_command/test_create_control_db_topology.py
+++ b/tests/teatree_core/pr_command/test_create_control_db_topology.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.core.management.commands import _pr_control_db, _pr_ticket_resolve
+from teatree.core.models import Ticket
+from teatree.paths import CONTROL_DB_DIR_ENV, DB_FILENAME
+
+from ._shared import _MOCK_OVERLAY
+
+
+class TestPrCreateReadsTheControlDbTopologyFirst(TestCase):
+    """``pr create`` states an unreachable control DB instead of dying on it (#4170).
+
+    The canonical control DB lives in a named volume with no host path, so a host
+    invocation used to reach ``resolve_ticket`` and die on a raw ``OperationalError``
+    that named neither the cause nor the remedy — and three agents in one day answered
+    it by falling back to a raw ``gh pr create``, the workaround the standing rule
+    forbids. The topology is read BEFORE any ORM touch because it is a statement about
+    where this code is running, not an exception to recover from afterwards.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._monkeypatch = monkeypatch
+
+    _CONTAINER_ONLY = Path("/nonexistent/container-only/control-db")
+
+    def _aim_at_the_container_only_db(self) -> None:
+        self._monkeypatch.setenv(CONTROL_DB_DIR_ENV, str(self._CONTAINER_ONLY))
+        self._monkeypatch.setattr(_pr_control_db, "configured_db_path", lambda: self._CONTAINER_ONLY / DB_FILENAME)
+
+    def test_refuses_with_the_container_remedy_and_never_touches_the_orm(self) -> None:
+        self._aim_at_the_container_only_db()
+        resolve = MagicMock(side_effect=Ticket.DoesNotExist)
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(_pr_ticket_resolve, "resolve_ticket", resolve),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "create", "4242"))
+
+        error = str(result["error"])
+        assert str(self._CONTAINER_ONLY) in error
+        assert "deploy/t3" in str(result["hint"])
+        resolve.assert_not_called()
+
+    def test_a_reachable_database_still_gets_the_real_answer(self) -> None:
+        """Anti-vacuous: a guard that always fired would mask every ORM answer.
+
+        The test database is not under the container-only mount, so the command must
+        reach ``resolve_ticket`` and report the MISSING TICKET — the second, distinct
+        cause the refusals must never collapse into one.
+        """
+        self._monkeypatch.setenv(CONTROL_DB_DIR_ENV, str(self._CONTAINER_ONLY))
+
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast("dict[str, object]", call_command("pr", "create", "4242"))
+
+        assert "workspace ticket" in str(result["error"])
+        assert "deploy/t3" not in str(result["hint"])
+
+    def test_the_ticketless_refusal_names_the_ticketless_route(self) -> None:
+        """``pr create`` requires a Ticket, so the refusal names the command that does not."""
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast("dict[str, object]", call_command("pr", "create", "4242"))
+
+        assert "ensure-pr" in str(result["error"])

--- a/tests/teatree_core/pr_command/test_ensure_pr.py
+++ b/tests/teatree_core/pr_command/test_ensure_pr.py
@@ -11,6 +11,7 @@ from teatree.core.backend_protocols import BackendResolutionError, PrOpenState, 
 from teatree.core.gates import debt_delta_gate, pr_budget_gate
 from teatree.core.gates.orphan_guard import BranchReport, BranchStatus
 from teatree.core.management.commands import _ensure_pr as ensure_pr_mod
+from teatree.core.management.commands import _pr_control_db
 from teatree.core.management.commands import pr as pr_command
 from teatree.core.management.commands._ensure_pr import create_or_defer_pr
 from teatree.core.models import ConfigSetting, PullRequest, Ticket, Worktree
@@ -609,7 +610,7 @@ class TestEnsurePrReadsTheControlDbTopologyFirst(TestCase):
 
     def test_skips_with_the_topology_reason_when_the_control_db_is_container_only(self) -> None:
         self._monkeypatch.setenv(CONTROL_DB_DIR_ENV, str(self._CONTAINER_ONLY))
-        self._monkeypatch.setattr(pr_command, "_configured_db_path", lambda: self._CONTAINER_ONLY / DB_FILENAME)
+        self._monkeypatch.setattr(_pr_control_db, "configured_db_path", lambda: self._CONTAINER_ONLY / DB_FILENAME)
         classify = MagicMock()
 
         with (


### PR DESCRIPTION
fix(pr): refuse pr create with a named remedy when the control DB is unreachable

Closes #4170

## What this does

`t3 <overlay> pr create` run from the host died on a raw `OperationalError: unable to
open database file`. The canonical control DB lives in the `teatree_control_db` named
volume with no host path, so a host process cannot open it — ever; that is the
deployment shape, not a repairable misconfiguration. `create` called `resolve_ticket()`
first, so the topology fact surfaced as a bare ORM exception naming neither the cause
nor the remedy — and three agents in one day answered it by falling back to raw
`gh pr create`, the workaround the standing "fix `t3`, never hand-roll around it" rule
forbids. An unreadable failure is what converts a documented rule into one everybody
who hits it breaks.

- `_pr_control_db.py` — the control-DB topology precondition as its own concern:
  `configured_db_path` (moved verbatim from `pr.py`), `unreachable_control_db_reason`,
  and the `ControlDbUnreachableError` refusal, which names the container invocation
  and says explicitly not to fall back to a raw `gh pr create`.
- `resolve_ticket_or_refusal` — reachability (a topology fact) then existence (a state
  fact), in that order, so the two causes keep their own remedies instead of collapsing
  into one error that hides which applies. Read before any ORM touch, matching the
  `ensure-pr` guard that already does this.
- `ticket_not_found_error` now names the ticketless route too. `pr create` requires a
  `Ticket` by design — it IS the FSM ship transition and every gate it runs is keyed on
  the row — so the refusal points at `pr ensure-pr`, the orphan-branch path that carries
  no ticket requirement by construction.
- `ensure-pr` keeps its identical skip reason, result shape and ordering, now via the
  shared reason getter.

## Test evidence

`tests/teatree_core/pr_command/test_create_control_db_topology.py`:

- unreachable control DB → the refusal names the directory and the container remedy, and
  `resolve_ticket` is never called (the guard precedes every ORM touch);
- a reachable database still gets the real ORM answer — anti-vacuous, a guard that always
  fired would fail it;
- the ticketless refusal names `workspace ticket` / `pr ensure-pr` and never the container
  remedy, so the two causes stay distinguishable.

Observed RED before the fix: with the three-line reachability check removed,
`test_refuses_with_the_container_remedy_and_never_touches_the_orm` fails with
`assert '/nonexistent/container-only/control-db' in "No Ticket row for '4242' …"`.
Restored → 3 passed. `tests/teatree_core/pr_command/` 105 passed.

`t3 tool verify-gates` exit 0 (commit + push stages). `bash dev/test-affected.sh`:
3616 passed, 10 failed — all 10 reproduce identically on clean `origin/main` in the main
clone (host `doctor` WARNs and network-dependent `gh` calls), none touch this diff.

## Architecture pre-check

1. **BLUEPRINT § alignment** — §4 (ship transition) plus the refusal-that-teaches
   convention already used by the main-clone guard, the raw-merge guard and the
   module-health cap. No BLUEPRINT change: this adds a precondition to an existing
   command, it does not move a boundary.
2. **FSM phase boundaries** — `reviewed/tested → shipped` is the transition `pr create`
   drives; the guard runs before any FSM read or write, so no transition is reached when
   the control DB is unreachable. No new phase.
3. **Extension-point contracts** — none. No `OverlayBase` hook, scanner registration or
   `*Backend` Protocol is touched.
4. **Component boundaries** — a sibling-module split of `pr.py` by concern, matching
   `_pr_preview.py` / `_pr_worktree.py` / `_pr_ticket_resolve.py`. `pr.py` shrinks
   497 → 486 LOC.
5. **Dependency direction** — `_pr_control_db` → `teatree.db.boundary` + `django.conf`,
   the edge `pr.py` already had; no new module boundary, no backwards edge. `tach` green
   in `verify-gates`.
6. **Test surface** — the three assertions above; each names the behaviour that would
   regress.
7. **Resilience invariants** — no external write. verify-by-re-read / fallback-transport
   / heartbeat n/a. Idempotent: the guard is a pure topology read. Return contract: a
   `TypedDict` on the command's existing structured-result union, not prose.
8. **Identity and key normalization** — n/a; no bare-vs-qualified identity. The db path is
   compared against the one canonical `control_db_dir(env)` by the existing predicate.
9. **Behavior preservation** — `configured_db_path` moves verbatim; its one caller
   (`ensure_pr`) keeps the identical reason string, `EnsurePrResult` shape and
   read-before-classification ordering. `ticket_not_found_error` gains a route — additive,
   and the `workspace ticket` text every existing assertion pins is unchanged. No gate
   narrowed, no must-block test inverted.
10. **Removability / harness-vs-data** — removable: deleting `_pr_control_db.py` and the
    resolver's first branch reverts to today's raw `OperationalError` with no other call
    site to unwind. Harness, not data: "which coherence domain can open this database" is
    a topology fact `teatree.paths` already fixes in code, not a per-item policy.

## Open questions & assumptions

- **Should the ticketless case be supported by `pr create` rather than refused?**
  DECIDED (assumed, recorded in code): no. `pr create` IS the ship transition and every
  gate it runs reads the `Ticket` row; `pr ensure-pr` already opens an orphan-branch PR
  with no `Ticket`, so the capability exists and the refusal now points at it. Reversing
  this would mean a second, gate-free create path.
- ASSUMED: the remedy to name is `deploy/t3 <overlay> pr create <ticket-id>`, the
  container-wrapping entry the `t3` shell alias installed by `t3 setup` points at.
- ASSUMED: scope is `pr create`, as the issue names. Every other overlay command run from
  the host hits the same raw error; a CLI-wide chokepoint is deliberately not in this
  change.
- OPEN: `pr ensure-pr` is also unusable from the host (it skips on the same topology
  reason), so the refusal points at a command that must itself run in the container.
  Correct, but it means neither route is a host-side escape hatch.
- OPEN (found while shipping this, not fixed here): a pre-push `ensure-pr` deferral fired
  from inside a worktree records its `PendingPullRequest` obligation in the
  worktree-ISOLATED DB, so the dispatch loop — which drains the canonical control DB —
  never sees it and the branch stays pushed with no PR. Same cross-DB asymmetry class as
  #779. This PR was opened by discharging that stranded obligation by hand.
