### PR TITLE
fix(conformance): clear the #4193 review findings that merged unfixed — tokenizer at source, symmetric spine matching, three real doctrine losses

### DIFF
--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -347,6 +347,8 @@ See [`references/commit-to-fork.md`](references/commit-to-fork.md) for pre-fligh
 
 Before committing to the fork or creating an upstream issue, scan **all public-facing content the agent has authored or is about to author this session** — not just the diff of newly-staged files.
 
+**Scan the whole branch, never just the cache (Non-Negotiable).** The diff you scan must be `git diff @{upstream}..HEAD` — the branch carries commits from prior sessions and compacted work the agent never re-read, and only that range covers every commit between the pushed base and HEAD. `git diff --cached` (and `git diff HEAD~..HEAD`) is **not enough**: it shows the most recent work only, so a leak committed earlier on the branch passes the scan unseen.
+
 The four surfaces to scan (branch-vs-base diff, commit subjects and bodies, PR/issue/comment bodies, memory and config writes), the detector set plus the Streisand-effect word grep, and the `strict` / `relaxed` `T3_PRIVACY` levels are in [`skills/retro/references/privacy-scan.md`](references/privacy-scan.md).
 
 ## What NOT to Do

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -260,7 +260,13 @@ The two stores (`Session.visited_phases` and the `Ticket.state` FSM), how the sh
 
 #### How to satisfy the gate (the only sanctioned path)
 
-The numbered path — locate the reviewing task, acquire the per-MR review-dispatch lock (`t3 <overlay> review lock-acquire`), apply every finding, drive the `review` transition, verify before pushing — is in [`skills/ship/references/review-gate-fsm.md`](references/review-gate-fsm.md). The dispatch itself stays here, because a reference file never reaches a spawned agent:
+The numbered path — locate the reviewing task, acquire the per-MR review-dispatch lock (`t3 <overlay> review lock-acquire`), apply every finding, drive the `review` transition, verify before pushing — is in [`skills/ship/references/review-gate-fsm.md`](references/review-gate-fsm.md). Its three commands are named here too, because a reference file never reaches a spawned agent:
+
+- **Record a phase** with `t3 <overlay> lifecycle visit-phase <ticket_id> <phase>`. Do **NOT** use `t3 <overlay> lifecycle visit-phase <ticket_id> reviewing` to *skip* an independent review: since #694 the gate reconciles `Ticket.state` from `Session.visited_phases`, so a manual visit *will* let `pr create` proceed — which is exactly why recording `reviewing` without a reviewer having actually read the diff defeats the quality gate. Earn the phase, then record it.
+- **Transition directly** with `t3 <overlay> ticket transition <ticket_id> review` when the task id isn't to hand. The FSM still requires a completed `reviewing` task as a `conditions=` predicate, so this only works once one exists.
+- **Verify before pushing** with `t3 <overlay> ticket list --state reviewed` (the `mcp__teatree__ticket_search` tool is preferred; this is the fallback when the MCP server isn't connected). It filters on `--state`/`--overlay` only — there is no `--id` flag.
+
+The reviewer dispatch itself likewise stays here:
 
 **Spawn the reviewer sub-agent from the main conversation** (not from another sub-agent — see [`../rules/SKILL.md`](../rules/SKILL.md) § "Sub-Agent Limitations") via the `Agent` tool. The `prompt:` MUST open with this verbatim block — it is not optional and not a "remember to add it" note. Skill prose does not propagate into a spawned agent's context, so the near-zero-comments rule is lost unless it is inline in the prompt itself:
 

--- a/skills/ship/references/merge-and-history-mechanics.md
+++ b/skills/ship/references/merge-and-history-mechanics.md
@@ -22,7 +22,7 @@ Before touching the PR branch to "prepare" it for a merge, reason through what a
 
 ## Git history rewriting
 
-When rewriting commit messages, use `filter-branch --msg-filter` (matches by full hash). Do NOT use `git rebase -i` with `GIT_SEQUENCE_EDITOR="sed"` — the short hash may differ from `git log --oneline`, causing a silent no-op.
+When rewriting commit messages, use `filter-branch --msg-filter` (matches by full hash). Do NOT use `git rebase -i` with `GIT_SEQUENCE_EDITOR="sed"` — the short hash may differ from the one-line log, causing a silent no-op.
 
 **Post-rewrite verification (Non-Negotiable):** After ANY rebase or filter-branch, verify the hash changed. Same hash = no-op.
 

--- a/src/teatree/loops/dream/engine.py
+++ b/src/teatree/loops/dream/engine.py
@@ -373,6 +373,10 @@ def run_consolidation(
     # separate autocommit BEFORE the write — which is what the distiller used to do —
     # let anything raising in between strand that claim against no rows at all, and the
     # rotation does not revisit a window it skipped until it has wrapped the whole corpus.
+    # Its regression test pins the ORDERING, not the atomicity: dropping this `atomic()`
+    # while still writing the rows before the cursor keeps that test green. What stays
+    # uncovered is a REDO — rows committed, cursor lost, window replayed — never the loss
+    # above; proving atomicity needs a forced mid-transaction failure.
     with transaction.atomic():
         write_outcome = write_clusters(clusters, extract, dry_run=dry_run, overlay=overlay)
         if outcome.next_cursor is not None:

--- a/tests/conformance/test_mandated_command_pinned_by_a_scenario.py
+++ b/tests/conformance/test_mandated_command_pinned_by_a_scenario.py
@@ -18,11 +18,18 @@ The mandate is checked against the SLICE the scenario grades, not the whole file
 A scenario declaring ``agent_sections`` sends only those sections to the model, so
 a command sitting elsewhere in the same SKILL.md — or moved out to a
 ``references/`` file — is unreachable by the agent being graded even though a
-whole-file read still finds it. That is not hypothetical: the ``t3 slack react``
-row below went exactly that way, out of the graded section and into a reference,
-while a whole-file assertion stayed green. The slice is resolved through the
-harness's own ``load_agent_definition`` so this test and the runner can never
-disagree about what the agent actually saw.
+whole-file read still finds it. The slice is the strictly stronger form, and it
+is checked against what the runner itself loads: the slice is resolved through
+the harness's own ``load_agent_definition``, so this test and the runner can
+never disagree about what the agent actually saw.
+
+The related loss on record is broader than a slice, and the distinction matters:
+``t3 slack react`` left ``skills/rules/SKILL.md`` entirely
+(``git show 0fd72ed5a^:skills/rules/SKILL.md`` finds no occurrence; ``0fd72ed5a``
+returned it), so a whole-file assertion would have caught THAT one. The
+slice-scoped loss — present in the file, absent from the graded sections — is
+what this test adds; it has not happened yet, and the point is that it would be
+invisible to the whole-file check if it did.
 """
 
 import re

--- a/tests/conformance/test_non_negotiable_stays_in_the_spine.py
+++ b/tests/conformance/test_non_negotiable_stays_in_the_spine.py
@@ -12,9 +12,18 @@ prose while cross-referencing the spine, which is exactly what progressive
 disclosure should look like, and every one of those must stay green. Only a
 HEADING is a claim to own the rule, so only an orphaned heading fails.
 
+A matching TITLE is not enough. ``_orphans`` compares heading titles, so gutting
+the section under a spine heading while leaving the heading in place restores
+nothing and stays green — the same loss, re-inflicted in heading-preserving form.
+A spine heading therefore only counts as OWNING the rule when the section under
+it (down to the next heading of the same or higher level) is NON-TRIVIAL: enough
+prose to carry a rule, and at least one mandate word. A heading followed only by
+a pointer link no longer satisfies the check.
+
 The baseline is the set already orphaned on ``origin/main``. Shrink-only:
 ``test_the_baseline_has_not_gone_stale`` fails once an entry is fixed without
-being removed, so the list can only drain.
+being removed, and ``test_the_baseline_can_only_drain`` fails when a row is
+ADDED, so the list can only drain.
 """
 
 import re
@@ -23,7 +32,12 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SKILLS = _REPO_ROOT / "skills"
 
-_HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.MULTILINE)
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+_MANDATE_RE = re.compile(r"\b(?:must|never|only|non-negotiable|do NOT|always|forbidden|refuse)\b", re.IGNORECASE)
+
+#: A restored rule needs a body, not just a heading. Below this many non-blank
+#: characters the section is a stub or a bare pointer link, which binds nobody.
+_MIN_SECTION_CHARS = 120
 
 #: Already orphaned on ``origin/main`` — pre-existing, out of scope for the branch
 #: that added this check. SHRINK ONLY: never add a row to silence a new failure.
@@ -37,9 +51,29 @@ _BASELINE: frozenset[tuple[str, str]] = frozenset(
     }
 )
 
+#: The ratchet's real invariant: the list may DRAIN, never GROW. Lower this number
+#: when rows are fixed; raising it is the change reviewers must refuse.
+_CEILING = 5
+
 
 def _headings(path: Path) -> list[str]:
-    return [title.strip() for title in _HEADING_RE.findall(path.read_text(encoding="utf-8"))]
+    return [title.strip() for _, title in _HEADING_RE.findall(path.read_text(encoding="utf-8"))]
+
+
+def _substantive_headings(body: str) -> set[str]:
+    """Titles whose own section carries a rule, not just a heading and a pointer."""
+    matches = list(_HEADING_RE.finditer(body))
+    owning: set[str] = set()
+    for index, match in enumerate(matches):
+        level = len(match.group(1))
+        end = next(
+            (later.start() for later in matches[index + 1 :] if len(later.group(1)) <= level),
+            len(body),
+        )
+        section = body[match.end() : end]
+        if len(section.replace("\n", "").strip()) >= _MIN_SECTION_CHARS and _MANDATE_RE.search(section):
+            owning.add(match.group(2).strip())
+    return owning
 
 
 def _orphans() -> set[tuple[str, str]]:
@@ -48,10 +82,10 @@ def _orphans() -> set[tuple[str, str]]:
         spine = page.parents[1] / "SKILL.md"
         if not spine.is_file():
             continue
-        spine_titles = set(_headings(spine))
+        owning = _substantive_headings(spine.read_text(encoding="utf-8"))
         rel = page.relative_to(_REPO_ROOT).as_posix()
         found.update(
-            (rel, title) for title in _headings(page) if "non-negotiable" in title.lower() and title not in spine_titles
+            (rel, title) for title in _headings(page) if "non-negotiable" in title.lower() and title not in owning
         )
     return found
 
@@ -85,4 +119,12 @@ def test_the_baseline_has_not_gone_stale() -> None:
     assert not fixed, (
         "these baseline rows are no longer orphaned — delete them from _BASELINE so the ratchet "
         "keeps its teeth:\n" + "\n".join(f'  "{title}" in {page}' for page, title in fixed)
+    )
+
+
+def test_the_baseline_can_only_drain() -> None:
+    assert len(_BASELINE) <= _CEILING, (
+        "a row was ADDED to the orphan baseline. Return the rule's trigger and verdict to the "
+        "spine instead; if the addition is genuinely pre-existing on origin/main, say so in "
+        "review and lower nothing."
     )

--- a/tests/conformance/test_reference_is_never_a_doctrines_only_home.py
+++ b/tests/conformance/test_reference_is_never_a_doctrines_only_home.py
@@ -16,19 +16,33 @@ Scoped two ways, because a reference page is SUPPOSED to be full of commands:
     troubleshooting recipe listing ``git reset`` as step 2 is mechanics, which is
     exactly what progressive disclosure puts in a reference. A sentence saying
     the agent must never run it is doctrine, and doctrine needs a spine;
-*   the token is the first two words, plus the first long-form flag when the span
-    carries one. Two words is the doctrine-bearing unit for a subcommand
-    (``t3 slack``, ``gh issue``); a flag is what makes an otherwise-generic verb
-    specific, which is the whole difference between ``git checkout`` (mentioned
-    everywhere) and ``git checkout --ours`` (a data-loss prohibition).
+*   the token is the runner plus up to two command words, plus the long flag
+    IMMEDIATELY following them. Two command words is the doctrine-bearing unit
+    for a subcommand (``t3 ticket clear``, ``gh issue view``); a flag is what
+    makes an otherwise-generic verb specific, which is the whole difference
+    between ``git checkout`` (mentioned everywhere) and ``git checkout --ours``
+    (a data-loss prohibition).
 
-The baseline below is the set already orphaned on ``origin/main``. It is a
-shrink-only ratchet, not a suppression: a NEW orphan fails immediately, and
-``test_the_baseline_has_not_gone_stale`` fails once an entry is fixed without
-being removed, so the list can only drain.
+The house style writes commands as ``t3 <overlay> <group> <sub>``, so a
+whole-word ``<...>``/ellipsis placeholder is SKIPPED rather than collected — the
+alternative dropped 27% of the corpus (24 of 89 spans), including the §17.4
+keystone itself. Skipping placeholders means the reference's token
+(``t3 ticket clear``) no longer spells the spine's text (``t3 <overlay> ticket
+clear``), so spine matching is SYMMETRIC: the spine is parsed with the same
+parser, over its inline backticks AND its fenced blocks, and a token counts as
+present on any of four one-directional clauses. Every clause can only mark a
+token PRESENT, never absent, so the widening strictly reduces false positives.
+
+``_ORPHANED_ON_MAIN`` is the set already orphaned on ``origin/main``, re-derived
+mechanically by running this module's own sweep over ``git archive origin/main
+skills``. It is a shrink-only ratchet, not a suppression: a NEW orphan fails
+immediately, ``test_the_baseline_has_not_gone_stale`` fails once an entry is
+fixed without being removed, and ``test_the_baseline_can_only_drain`` fails when
+a row is ADDED. The list can only drain.
 """
 
 import re
+from collections.abc import Iterator
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -37,7 +51,12 @@ _SKILLS = _REPO_ROOT / "skills"
 _RUNNERS = ("t3", "gh", "glab", "git", "prek")
 _BACKTICKED_RE = re.compile(r"`([^`\n]{2,120})`")
 _MANDATE_RE = re.compile(r"\b(?:must|never|only|non-negotiable|do NOT|always|forbidden|refuse)\b", re.IGNORECASE)
-_LONG_FLAG_RE = re.compile(r"(--[a-z][a-z0-9-]{2,})")
+_FENCE_RE = re.compile(r"^\s*```")
+_PLACEHOLDER_RE = re.compile(r"<[^>]*>\S*|\.\.\.|…")
+_COMMAND_WORD_RE = re.compile(r"[a-z][a-z0-9_-]*")
+_LONG_FLAG_RE = re.compile(r"--[a-z][a-z0-9-]{2,}")
+
+type CommandSignature = tuple[str, tuple[str, ...], str | None]
 
 #: Sub-commands too generic to carry doctrine on their own — the token would be
 #: ``git show``, which nearly every skill mentions, so the check would grade noise.
@@ -63,92 +82,203 @@ _TOO_GENERIC = frozenset(
 #: Already orphaned on ``origin/main`` — pre-existing, and out of scope for the
 #: branch that added this check. SHRINK ONLY: never add a row here to make a new
 #: failure go away; return the command to the spine instead.
-_BASELINE: frozenset[tuple[str, str]] = frozenset(
+_ORPHANED_ON_MAIN: frozenset[tuple[str, str]] = frozenset(
     {
-        ("skills/platforms/references/gitlab.md", "glab auth"),
-        ("skills/platforms/references/gitlab.md", "glab mr"),
-        ("skills/platforms/references/gitlab.md", "glab mr --help"),
-        ("skills/platforms/references/gitlab.md", "glab ci --branch"),
+        ("skills/platforms/references/gitlab.md", "glab auth token"),
+        ("skills/platforms/references/gitlab.md", "glab ci status --branch"),
+        ("skills/platforms/references/gitlab.md", "glab mr list"),
+        ("skills/platforms/references/gitlab.md", "glab mr note"),
+        ("skills/platforms/references/gitlab.md", "glab mr note --help"),
+        ("skills/platforms/references/gitlab.md", "glab mr view"),
         ("skills/platforms/references/gitlab.md", "t3 review"),
-        ("skills/platforms/references/slack.md", "t3 slack"),
-        ("skills/platforms/references/slack.md", "t3 review-request"),
-        ("skills/platforms/references/slack.md", "t3 review-request --mr-url"),
-        ("skills/retro/references/privacy-scan.md", "git diff --cached"),
-        ("skills/rules/references/on-behalf-posting.md", "t3 review --approver"),
-        ("skills/setup/references/recommended-automode-authorizations.md", "gh pr"),
-        # Incidental prose, not a mandate: the sentence prohibits `git rebase -i`
-        # (which the spine does carry) and only names this while explaining why.
-        ("skills/ship/references/merge-and-history-mechanics.md", "git log --oneline"),
-        ("skills/workspace/references/troubleshooting.md", "t3 teatree"),
-        ("skills/workspace/references/troubleshooting.md", "t3 push"),
-        ("skills/workspace/references/troubleshooting.md", "t3 loops --loop"),
-        ("skills/workspace/references/troubleshooting.md", "gh auth"),
-        ("skills/workspace/references/troubleshooting.md", "git update-index --no-skip-worktree"),
-        ("skills/workspace/references/troubleshooting.md", "git remote"),
+        ("skills/platforms/references/slack.md", "t3 review-request check"),
+        ("skills/platforms/references/slack.md", "t3 review-request check --mr-url"),
+        ("skills/platforms/references/slack.md", "t3 slack react"),
+        ("skills/retro/references/commit-to-fork.md", "t3 workspace ticket"),
+        ("skills/rules/references/publishing-mode-doctrine.md", "glab mr merge"),
+        ("skills/setup/references/recommended-automode-authorizations.md", "gh pr merge"),
+        ("skills/workspace/references/troubleshooting.md", "gh auth git-credential"),
+        ("skills/workspace/references/troubleshooting.md", "gh pr create"),
         ("skills/workspace/references/troubleshooting.md", "git clean"),
-        ("skills/workspace/references/troubleshooting.md", "git reset --hard"),
-        ("skills/workspace/references/troubleshooting.md", "git restore --staged"),
         ("skills/workspace/references/troubleshooting.md", "git diff --cached"),
         ("skills/workspace/references/troubleshooting.md", "git merge-base --is-ancestor"),
+        ("skills/workspace/references/troubleshooting.md", "git remote set-url"),
+        ("skills/workspace/references/troubleshooting.md", "git reset --hard"),
+        ("skills/workspace/references/troubleshooting.md", "git restore --staged"),
+        ("skills/workspace/references/troubleshooting.md", "git update-index --no-skip-worktree"),
+        ("skills/workspace/references/troubleshooting.md", "t3 loops tick --loop"),
+        ("skills/workspace/references/troubleshooting.md", "t3 push"),
     }
 )
 
+#: The ratchet's real invariant: the list may DRAIN, never GROW. Lower this number
+#: when rows are fixed; raising it is the change reviewers must refuse.
+_CEILING = 24
 
-def _command_token(span: str) -> str | None:
+#: Anti-vacuity floor on the corpus the parser recognises, not on the baseline.
+#: Fixing an orphan moves the command INTO the spine and leaves the reference's
+#: mandate in place, so this count does not shrink as the ratchet drains. Measured
+#: 56 on this branch (37 on ``origin/main``); a broken glob or a dead mandate regex
+#: produces 0.
+_MANDATED_SPAN_FLOOR = 40
+
+
+def _parse_command(span: str) -> CommandSignature | None:
     words = span.strip().strip("$ ").split()
     if len(words) < 2 or words[0] not in _RUNNERS:
         return None
-    if not re.fullmatch(r"[a-z][a-z0-9-]*", words[1]):
+
+    rest = words[1:]
+    command_words: list[str] = []
+    cursor = 0
+    while cursor < len(rest) and len(command_words) < 2:
+        word = rest[cursor]
+        if _PLACEHOLDER_RE.fullmatch(word):
+            cursor += 1
+        elif _COMMAND_WORD_RE.fullmatch(word):
+            command_words.append(word)
+            cursor += 1
+        else:
+            break
+    if not command_words:
         return None
-    base = f"{words[0]} {words[1]}"
-    if (flag := _LONG_FLAG_RE.search(span)) is not None:
-        # A flag makes a generic verb specific, so it is never dropped as noise.
-        return f"{base} {flag.group(1)}"
-    return None if base in _TOO_GENERIC else base
+
+    trailing = rest[cursor] if cursor < len(rest) else ""
+    flag = trailing if _LONG_FLAG_RE.fullmatch(trailing) else None
+    if flag is None and len(command_words) == 1 and f"{words[0]} {command_words[0]}" in _TOO_GENERIC:
+        return None
+    return words[0], tuple(command_words), flag
 
 
-def _mandated_tokens(page: Path) -> set[str]:
-    tokens: set[str] = set()
+def _render(signature: CommandSignature) -> str:
+    runner, command_words, flag = signature
+    base = " ".join((runner, *command_words))
+    return f"{base} {flag}" if flag else base
+
+
+def _spine_spans(body: str) -> Iterator[str]:
+    """Inline backticked spans plus whole lines of fenced blocks.
+
+    Fences are load-bearing and measured: ``skills/rules/SKILL.md`` and
+    ``skills/ship/SKILL.md`` name commands only inside them, and reading the
+    spine without them invents false positives.
+    """
+    in_fence = False
+    for line in body.splitlines():
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+        elif in_fence:
+            yield line
+        else:
+            yield from _BACKTICKED_RE.findall(line)
+
+
+def _spine_index(body: str) -> set[CommandSignature]:
+    return {signature for span in _spine_spans(body) if (signature := _parse_command(span)) is not None}
+
+
+def _satisfied_by_spine(signature: CommandSignature, index: set[CommandSignature], body: str) -> bool:
+    runner, command_words, _ = signature
+    if signature in index:
+        return True
+    base = " ".join((runner, *command_words))
+    if base not in _TOO_GENERIC and any(runner == other and command_words == words for other, words, _ in index):
+        return True
+    joined = " ".join(command_words)
+    if len(command_words) >= 2 and re.search(rf"(?<![\w-]){re.escape(joined)}(?![\w-])", body):
+        return True
+    return _render(signature) in body
+
+
+def _mandated_signatures(page: Path) -> set[CommandSignature]:
+    signatures: set[CommandSignature] = set()
     for line in page.read_text(encoding="utf-8").splitlines():
         if not _MANDATE_RE.search(line):
             continue
-        tokens.update(token for span in _BACKTICKED_RE.findall(line) if (token := _command_token(span)) is not None)
-    return tokens
+        signatures.update(
+            signature for span in _BACKTICKED_RE.findall(line) if (signature := _parse_command(span)) is not None
+        )
+    return signatures
 
 
-def _orphans() -> set[tuple[str, str]]:
+def _pages(skills_root: Path) -> list[Path]:
+    return sorted(skills_root.glob("*/references/*.md"))
+
+
+def _orphans(skills_root: Path = _SKILLS) -> set[tuple[str, str]]:
     """Every ``(reference page, mandated command)`` whose sibling spine omits it."""
     found: set[tuple[str, str]] = set()
-    for page in sorted(_SKILLS.glob("*/references/*.md")):
+    for page in _pages(skills_root):
         spine = page.parents[1] / "SKILL.md"
         if not spine.is_file():
             continue
         body = spine.read_text(encoding="utf-8")
-        rel = page.relative_to(_REPO_ROOT).as_posix()
-        found.update((rel, token) for token in _mandated_tokens(page) if token not in body)
+        index = _spine_index(body)
+        rel = page.relative_to(skills_root.parent).as_posix()
+        found.update(
+            (rel, _render(signature))
+            for signature in _mandated_signatures(page)
+            if not _satisfied_by_spine(signature, index, body)
+        )
     return found
+
+
+def _mandated_span_count(skills_root: Path = _SKILLS) -> int:
+    return sum(len(_mandated_signatures(page)) for page in _pages(skills_root))
+
+
+def _plant(skills_root: Path, spine_body: str) -> None:
+    references = skills_root / "planted" / "references"
+    references.mkdir(parents=True)
+    (skills_root / "planted" / "SKILL.md").write_text(spine_body, encoding="utf-8")
+    (references / "page.md").write_text(
+        "You must never run `t3 <overlay> planted-group planted-sub --force`.\n", encoding="utf-8"
+    )
 
 
 def test_the_sweep_actually_reads_reference_pages() -> None:
     # Anti-vacuity: a glob that matched nothing, or a mandate regex that matched
     # nothing, would make every assertion below pass having checked no file.
-    assert len(list(_SKILLS.glob("*/references/*.md"))) >= 5
-    assert len(_BASELINE) >= 10
+    assert len(_pages(_SKILLS)) >= 5
+    assert _mandated_span_count() >= _MANDATED_SPAN_FLOOR
+
+
+def test_the_sweep_finds_a_planted_orphan(tmp_path: Path) -> None:
+    # The control for the clearing test below: if the parser stops producing
+    # tokens at all, this reds before that one's green can mean anything.
+    _plant(skills_root := tmp_path / "skills", "# Planted\n\nNothing here names the command.\n")
+    assert ("skills/planted/references/page.md", "t3 planted-group planted-sub --force") in _orphans(skills_root)
+
+
+def test_the_sweep_clears_a_planted_command_named_in_the_spine(tmp_path: Path) -> None:
+    _plant(
+        skills_root := tmp_path / "skills",
+        "# Planted\n\nRun `t3 <overlay> planted-group planted-sub` to do it.\n",
+    )
+    assert not _orphans(skills_root)
 
 
 def test_no_new_command_is_mandated_only_in_a_reference() -> None:
-    new = sorted(_orphans() - _BASELINE)
+    new = sorted(_orphans() - _ORPHANED_ON_MAIN)
     assert not new, (
         "these commands are MANDATED in a reference but appear nowhere in the sibling SKILL.md, so "
         "skill injection reaches no sub-agent with them:\n"
         + "\n".join(f"  {token!r} in {page}" for page, token in new)
-        + "\nName the command in the spine; the reference keeps the recipe. Do NOT add it to _BASELINE."
+        + "\nName the command in the spine; the reference keeps the recipe. Do NOT add it to _ORPHANED_ON_MAIN."
     )
 
 
 def test_the_baseline_has_not_gone_stale() -> None:
-    fixed = sorted(_BASELINE - _orphans())
+    fixed = sorted(_ORPHANED_ON_MAIN - _orphans())
     assert not fixed, (
-        "these baseline rows are no longer orphaned — delete them from _BASELINE so the ratchet "
+        "these baseline rows are no longer orphaned — delete them from _ORPHANED_ON_MAIN so the ratchet "
         "keeps its teeth:\n" + "\n".join(f"  {token!r} in {page}" for page, token in fixed)
+    )
+
+
+def test_the_baseline_can_only_drain() -> None:
+    assert len(_ORPHANED_ON_MAIN) <= _CEILING, (
+        "a row was ADDED to the orphan baseline. Return the command to the spine instead; "
+        "if the addition is genuinely pre-existing on origin/main, say so in review and "
+        "lower nothing."
     )

--- a/tests/conformance/test_reference_is_never_a_doctrines_only_home.py
+++ b/tests/conformance/test_reference_is_never_a_doctrines_only_home.py
@@ -33,9 +33,12 @@ parser, over its inline backticks AND its fenced blocks, and a token counts as
 present on any of four one-directional clauses. Every clause can only mark a
 token PRESENT, never absent, so the widening strictly reduces false positives.
 
-``_ORPHANED_ON_MAIN`` is the set already orphaned on ``origin/main``, re-derived
-mechanically by running this module's own sweep over ``git archive origin/main
-skills``. It is a shrink-only ratchet, not a suppression: a NEW orphan fails
+``_ORPHANED_ON_MAIN`` is the set that PREDATES this guard, re-derived
+mechanically by running this module's own sweep over the skills tree as it stood
+BEFORE the vendor-sync branch landed. The five orphans that branch introduced are
+deliberately NOT in it — they are returned to the spines by this change, which is
+why ``origin/main`` reports 29 orphans today and this branch reports 24. It is a
+shrink-only ratchet, not a suppression: a NEW orphan fails
 immediately, ``test_the_baseline_has_not_gone_stale`` fails once an entry is
 fixed without being removed, and ``test_the_baseline_can_only_drain`` fails when
 a row is ADDED. The list can only drain.
@@ -79,9 +82,10 @@ _TOO_GENERIC = frozenset(
     }
 )
 
-#: Already orphaned on ``origin/main`` — pre-existing, and out of scope for the
-#: branch that added this check. SHRINK ONLY: never add a row here to make a new
-#: failure go away; return the command to the spine instead.
+#: Orphaned BEFORE the vendor-sync branch — pre-existing, and out of scope for the
+#: change that added this check. The five that branch introduced are absent by
+#: design: they are fixed in the spines, not recorded here. SHRINK ONLY: never add
+#: a row here to make a new failure go away; return the command to the spine instead.
 _ORPHANED_ON_MAIN: frozenset[tuple[str, str]] = frozenset(
     {
         ("skills/platforms/references/gitlab.md", "glab auth token"),
@@ -118,8 +122,8 @@ _CEILING = 24
 #: Anti-vacuity floor on the corpus the parser recognises, not on the baseline.
 #: Fixing an orphan moves the command INTO the spine and leaves the reference's
 #: mandate in place, so this count does not shrink as the ratchet drains. Measured
-#: 56 on this branch (37 on ``origin/main``); a broken glob or a dead mandate regex
-#: produces 0.
+#: 56 here and 57 on ``origin/main`` — the difference is the one incidental mention
+#: this change de-backticks. A broken glob or a dead mandate regex produces 0.
 _MANDATED_SPAN_FLOOR = 40
 
 

--- a/tests/teatree_loops/test_loop_staleness.py
+++ b/tests/teatree_loops/test_loop_staleness.py
@@ -388,6 +388,24 @@ class TestLoopHealth(_LoopTableCase):
         assert "idle by configuration: review" in rendered
         assert "FAIL" not in rendered
 
+    def test_a_force_masked_loop_does_not_fail_the_health_verdict(self) -> None:
+        # The colleague gate above is one arm of _is_suppressed; this is the other. An
+        # operator who ran `t3 loop override review off` must not be told the factory is
+        # broken — the FORCED plane is as deliberate as a mode mask, and it is the only
+        # arm no health-verdict test exercised.
+        _loop("tickets", ran_ago=dt.timedelta(seconds=30))
+        _loop("review", ran_ago=dt.timedelta(hours=7))
+        LoopState.objects.override("review", on=False)
+        health = self._health(
+            admitted=["tickets"],
+            mode=_mode(),
+            registry=(_mini("tickets"), _mini("review")),
+        )
+        rendered = "\n".join(health.lines())
+        assert health.ok
+        assert [loop.name for loop in health.stale if loop.suppressed] == ["review"]
+        assert "FAIL" not in rendered
+
     def test_unexplained_stale_loop_fails_even_beside_healthy_ones(self) -> None:
         _loop("tickets", ran_ago=dt.timedelta(seconds=30))
         _loop("dispatch", ran_ago=dt.timedelta(hours=7))


### PR DESCRIPTION
Follow-up to #4193, which merged as `ef9f70437` while its cold review was outstanding. The review's
three findings shipped onto main unfixed; this clears them.

All three were in the conformance guard set that #4193 added to *prevent* doctrine loss.

## The tokenizer, fixed at source — no second exemption bucket

`_command_token` becomes `_parse_command`, returning `(runner, cmd_words, flag)`, and
`_LONG_FLAG_RE.search(span)` is replaced by flag adjacency. All three self-granted baseline rows
dissolve rather than being relabelled:

- `t3 review --approver` — a tokenizer artifact. With adjacency the token is
  `t3 review approve-on-behalf`, which is present at `skills/rules/SKILL.md:281`. It appears in
  neither the branch nor the main orphan set.
- `git diff --cached` — a **genuine loss**, not a sanctioned split. `grep -c` returns 0 for both
  `git diff @{upstream}` and `git diff --cached` in `skills/retro/SKILL.md`: the spine linked the
  reference but named neither command, so the branch-vs-cache doctrine reached no sub-agent. Fixed
  by naming it in the Privacy Scan section.
- `git log --oneline` — a mandate-attribution false positive; the `Do NOT` governs `git rebase -i`,
  which is in the ship spine twice. De-backticked the incidental mention.

`_BASELINE` becomes `_ORPHANED_ON_MAIN` with a git-free shrink-only ceiling. No runtime
re-derivation against `origin/main` — the conformance shard has no `fetch-depth: 0`, so that would
need a skip, and a skip is a vacuity hole in the guard being hardened.

## The widening, and the three real losses it exposes

The old `re.fullmatch(r"[a-z][a-z0-9-]*", words[1])` returned `None` on any `<placeholder>`, so it
silently skipped **24 of 89** backticked mandate spans — 27% of what it claimed to check, including
the repo's own `t3 <overlay> …` house style.

Spine matching is now symmetric: the same parser indexes inline backticks **and fenced blocks**
(`skills/rules/SKILL.md:528` and `skills/ship/SKILL.md:469` live in fences), with a runner-less
two-word naming clause and the legacy substring fallback. A naive widening against the old substring
matcher produced 34 orphans including four provably-present commands.

Three genuine losses fixed in `skills/ship/SKILL.md` §4b — mandated in
`skills/ship/references/review-gate-fsm.md` with nothing in the spine:

- `t3 <overlay> lifecycle visit-phase`, carrying the *"do NOT use it to skip an independent review"*
  prohibition
- `t3 <overlay> ticket transition`
- `t3 <overlay> ticket list --state`

## Provenance note

The baseline's docstring said "already orphaned on `origin/main`". After #4193 merged that is no
longer true — main now carries 29, including the 5 this change fixes. The constant is **not**
re-derived against the new main: doing so would convert those 5 into exactly the self-granted
suppression the guard exists to prevent. It stays at the 24 that predate the guard, and the comment
now says so.

## Mutation evidence — pre-change GREEN beside post-change RED

| guard | before | after |
|---|---|---|
| widened sweep — evacuate the §17.4 keystone line (grep-confirmed sole spine home) | GREEN, fully blind | RED — the 4 predicted orphans |
| non-negotiable body — gut the section, keep the heading | GREEN | RED, names the pair |
| shrink-only ceiling — append a row | GREEN (no such assertion existed; the old floor *rewards* growth) | RED — "a row was ADDED" |
| span floor — stub `_MANDATE_RE` to `zzz-never` | GREEN, blind to a dead mandate regex | RED — 0 spans vs floor 40 |
| planted-orphan control — `_parse_command` returns None | n/a | RED |
| planted-clear control — `_satisfied_by_spine` exact-string | n/a | RED |
| forced-plane test — narrow `_is_suppressed` to the mode mask | GREEN, all 8 `TestLoopHealth` pass | RED, and the only health-verdict-level test that reds |

The keystone mutation was re-run after rebasing onto main — same 4 orphans, still RED.

The old floor's defect is numeric: `len(_BASELINE) >= 10` at 23 rows reds the anti-vacuity assertion
itself once 14 orphans are fixed. Replaced by a drain-independent span floor plus the ceiling.

Also restores the forced-plane health test dropped in #4193's merge, routed through the real
`LoopState.objects.override` seam.

## Verification

416 passed / 3 xfailed across `tests/conformance/` and `tests/teatree_loops/test_loop_staleness.py`,
plus 81 across the six skill-markdown guards. Bounded at `PYTEST_XDIST_AUTO_NUM_WORKERS=2`. All
mutations reverted; ruff clean; full pre-commit and pre-push sets passed on every commit. No gate
relaxed, no `--no-verify`.

## Incidental, not fixed

`_HOLDS_SEAM = "teatree.loop.loop_state_db.control_planes_in_db"` in `test_loop_staleness.py` is a
**dead patch** — `loops/enable_verdict.py:30` binds the name at import, so patching it never reaches
the read path. Harmless today (the real DB read yields the same empty planes the patch intended) and
`test_patch_targets_resolve` stays green because the target does resolve. The restored test routes
around it via the real seam. Worth its own issue.
