### PR TITLE
fix(cli): a returned structured refusal exits non-zero (#4210)

### DIFF
--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -696,7 +696,7 @@
       ]
     },
     {
-      "help": "",
+      "help": "A ``TyperCommand`` whose returned refusal exits non-zero when run from argv.\n\nGated on ``_called_from_command_line`` \u2014 the flag Django's ``run_from_argv``\nsets and ``call_command`` does not \u2014 because the two callers need opposite\nthings from one refusal: a shell needs a failing status, an in-process\nconsumer needs the dict.",
       "name": "pr",
       "subcommands": [
         {

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -356,6 +356,8 @@ Drive the T4 autoresearch outer loop (propose→ratify→implement→measure→k
 
 ## `pr`
 
+A ``TyperCommand`` whose returned refusal exits non-zero when run from argv.
+
 | Subcommand | Description |
 | --- | --- |
 | `create` | Validate ship gates and trigger the ship transition |

--- a/skills/internals/SKILL.md
+++ b/skills/internals/SKILL.md
@@ -172,6 +172,15 @@ Teatree's CLI groups (`t3 <overlay> <group> <sub>`) are django-typer `TyperComma
 - `typer.Exit` is still correct in `src/teatree/cli/*.py` files that go through the typer runner directly (different call site).
 - Anti-pattern: returning an error string from a management command instead of raising. The CLI exits 0 and CI reports green on real failures.
 
+### Structured refusals: return the dict, inherit the non-zero exit
+
+A refusal that an in-process caller must route on (the `mcp` write tools, the loop) is RETURNED as `{"error": …, "hint": …}`, not raised — raising would destroy the value those callers read. That is the one sanctioned form of the anti-pattern above, and it is only sanctioned because the exit code is restored at the boundary: inherit `teatree.core.management.refusal_exit.RefusalExitTyperCommand` instead of `TyperCommand`, and a returned refusal exits `1` on the argv path while `call_command` still gets the dict verbatim.
+
+- The predicate is one pure function, `refusal_exit_code(result)` — non-zero iff the result is a mapping with a truthy `error`. A new refusal shape therefore needs an `error` key and nothing else; a shape without one silently exits 0 again.
+- The gate is `_called_from_command_line`, the flag Django's `run_from_argv` sets and `call_command` does not — so the shell and the in-process consumer get opposite, correct answers from one refusal.
+- Canonical example: `src/teatree/core/management/commands/pr.py` `Command` — its control-DB, missing-ticket, missing-worktree and ship-gate refusals all exit non-zero, so `t3 <overlay> ship <id> && t3 <overlay> ticket clear …` stops on a refused ship.
+- A command that has no in-process consumer of its failure still uses `raise SystemExit(N)` — that is simpler and stays the default.
+
 ### Annotated typer options must have defaults for `call_command`
 
 `Annotated[str, typer.Option(help="...")]` parameters without a default value make the command unusable via Django's `call_command` — it raises `Missing parameter: <name>` even when the caller passes the kwarg. Give every `typer.Option`-annotated parameter a default (e.g. `= ""`) and validate at runtime (`if not phase.strip(): raise SystemExit(1)`). This keeps both CLI and `call_command` call sites happy.

--- a/skills/internals/SKILL.md
+++ b/skills/internals/SKILL.md
@@ -178,6 +178,7 @@ A refusal that an in-process caller must route on (the `mcp` write tools, the lo
 
 - The predicate is one pure function, `refusal_exit_code(result)` — non-zero iff the result is a mapping with a truthy `error`. A new refusal shape therefore needs an `error` key and nothing else; a shape without one silently exits 0 again.
 - The gate is `_called_from_command_line`, the flag Django's `run_from_argv` sets and `call_command` does not — so the shell and the in-process consumer get opposite, correct answers from one refusal.
+- Loud is the default; `soft_refusal_commands` exempts named subcommands, so a *new* refusal is loud without being listed anywhere. Exempt one only when its caller depends on a *soft* refusal: `pr ensure-pr` is the pre-push hook's entry point, where reporting and letting the push through is the designed behaviour (#792).
 - Canonical example: `src/teatree/core/management/commands/pr.py` `Command` — its control-DB, missing-ticket, missing-worktree and ship-gate refusals all exit non-zero, so `t3 <overlay> ship <id> && t3 <overlay> ticket clear …` stops on a refused ship.
 - A command that has no in-process consumer of its failure still uses `raise SystemExit(N)` — that is simpler and stays the default.
 

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -9,7 +9,7 @@ returns the PR URL once the worker completes.
 import re
 from typing import TYPE_CHECKING, cast
 
-from django_typer.management import TyperCommand, command
+from django_typer.management import command
 
 from teatree.core.backend_factory import code_host_from_overlay
 from teatree.core.evidence.test_plan_blocked_gate import BlockedTestPlanPostError
@@ -55,6 +55,7 @@ from teatree.core.management.commands._ship.gates import run_pr_budget_gate as _
 from teatree.core.management.commands._ship.gates import run_visual_qa_gate as _run_visual_qa_gate
 from teatree.core.management.commands._test_plan.mr_post import MrTestPlanPost, post_mr_test_plan_comment
 from teatree.core.management.commands._test_plan.post import TestPlanMediaError as _TestPlanMediaError
+from teatree.core.management.refusal_exit import RefusalExitTyperCommand
 from teatree.core.modelkit.phases import normalize_phase
 from teatree.core.models import Ticket, Worktree
 from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError
@@ -268,7 +269,10 @@ def _validate_repo_and_resolve_branch(repo: str, repo_path: str, branch: str) ->
     return branch_name, None
 
 
-class Command(PendingPrCommands, TyperCommand):
+class Command(PendingPrCommands, RefusalExitTyperCommand):
+    # #4210: every refusal below is RETURNED, not raised, so an in-process caller
+    # can route on it — the base class is what stops the shell reading that as a
+    # success and running the next command in a `ship && clear` chain.
     @command()
     # PLR0913: this signature IS the CLI contract — django-typer derives
     # --title/--dry-run/--skip-validation/--skip-visual-qa/--sync by

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -7,7 +7,7 @@ returns the PR URL once the worker completes.
 """
 
 import re
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from django_typer.management import command
 
@@ -272,7 +272,11 @@ def _validate_repo_and_resolve_branch(repo: str, repo_path: str, branch: str) ->
 class Command(PendingPrCommands, RefusalExitTyperCommand):
     # #4210: every refusal below is RETURNED, not raised, so an in-process caller
     # can route on it — the base class is what stops the shell reading that as a
-    # success and running the next command in a `ship && clear` chain.
+    # success and running the next command in a `ship && clear` chain. `ensure-pr`
+    # is the one exemption: it runs inside the pre-push hook, where reporting a
+    # refusal and letting the push through is the designed behaviour (#792).
+    soft_refusal_commands: ClassVar[frozenset[str]] = frozenset({"ensure-pr"})
+
     @command()
     # PLR0913: this signature IS the CLI contract — django-typer derives
     # --title/--dry-run/--skip-validation/--skip-visual-qa/--sync by

--- a/src/teatree/core/management/refusal_exit.py
+++ b/src/teatree/core/management/refusal_exit.py
@@ -1,0 +1,49 @@
+"""A returned structured refusal becomes a non-zero process exit (#4210).
+
+A command that RETURNS ``{"error": …}`` instead of raising hands an in-process
+caller a value to route on — the shape ``mcp`` and the loop read. But Django's
+``run_from_argv`` discards the return, so the process exits 0: ``t3 <overlay>
+ship <id> && t3 <overlay> ticket clear …`` runs the second command having
+shipped nothing, and a ``set -e`` lane proceeds on a refusal. That is the
+anti-pattern named in ``/t3:internals`` § Management Command Patterns.
+
+The seam is the boundary, not the call sites: one base class maps a returned
+refusal to a non-zero exit on the argv path alone, so the structured value still
+reaches in-process callers unchanged and only the shell sees a failure.
+"""
+
+from collections.abc import Mapping
+from typing import cast
+
+from django_typer.management import TyperCommand
+
+#: The key a refusal is recognised by — the convention every ``error``-shaped
+#: result ``TypedDict`` under ``commands/`` already follows.
+REFUSAL_KEY = "error"
+
+REFUSAL_EXIT_CODE = 1
+
+
+def refusal_exit_code(result: object) -> int:
+    """The exit code *result* implies — non-zero iff it carries a non-empty refusal."""
+    if not isinstance(result, Mapping):
+        return 0
+    refusal = cast("Mapping[str, object]", result)
+    return REFUSAL_EXIT_CODE if refusal.get(REFUSAL_KEY) else 0
+
+
+class RefusalExitTyperCommand(TyperCommand):
+    """A ``TyperCommand`` whose returned refusal exits non-zero when run from argv.
+
+    Gated on ``_called_from_command_line`` — the flag Django's ``run_from_argv``
+    sets and ``call_command`` does not — because the two callers need opposite
+    things from one refusal: a shell needs a failing status, an in-process
+    consumer needs the dict.
+    """
+
+    def execute(self, *args: object, **options: object) -> object:
+        result = super().execute(*args, **options)
+        code = refusal_exit_code(result)
+        if code and self._called_from_command_line:
+            raise SystemExit(code)
+        return result

--- a/src/teatree/core/management/refusal_exit.py
+++ b/src/teatree/core/management/refusal_exit.py
@@ -13,7 +13,7 @@ reaches in-process callers unchanged and only the shell sees a failure.
 """
 
 from collections.abc import Mapping
-from typing import cast
+from typing import ClassVar, cast
 
 from django_typer.management import TyperCommand
 
@@ -32,6 +32,11 @@ def refusal_exit_code(result: object) -> int:
     return REFUSAL_EXIT_CODE if refusal.get(REFUSAL_KEY) else 0
 
 
+def invoked_subcommand(args: tuple[object, ...]) -> str:
+    """The subcommand name in a ``TyperCommand``'s argv remainder — its first bare token."""
+    return next((arg for arg in args if isinstance(arg, str) and not arg.startswith("-")), "")
+
+
 class RefusalExitTyperCommand(TyperCommand):
     """A ``TyperCommand`` whose returned refusal exits non-zero when run from argv.
 
@@ -41,9 +46,16 @@ class RefusalExitTyperCommand(TyperCommand):
     consumer needs the dict.
     """
 
+    #: Subcommands exempt from the seam — loud is the default, so a new refusal is
+    #: loud without being listed anywhere. Exempt one only when its caller depends
+    #: on a SOFT refusal: a pre-push hook must report and let the push through.
+    soft_refusal_commands: ClassVar[frozenset[str]] = frozenset()
+
     def execute(self, *args: object, **options: object) -> object:
         result = super().execute(*args, **options)
+        if not self._called_from_command_line or invoked_subcommand(args) in self.soft_refusal_commands:
+            return result
         code = refusal_exit_code(result)
-        if code and self._called_from_command_line:
+        if code:
             raise SystemExit(code)
         return result

--- a/tests/teatree_core/management/test_refusal_exit.py
+++ b/tests/teatree_core/management/test_refusal_exit.py
@@ -10,7 +10,12 @@ import pytest
 from django.core.management import call_command
 from django_typer.management import command
 
-from teatree.core.management.refusal_exit import REFUSAL_EXIT_CODE, RefusalExitTyperCommand, refusal_exit_code
+from teatree.core.management.refusal_exit import (
+    REFUSAL_EXIT_CODE,
+    RefusalExitTyperCommand,
+    invoked_subcommand,
+    refusal_exit_code,
+)
 
 
 class TestRefusalExitCode:
@@ -57,3 +62,34 @@ class TestRefusalExitTyperCommand:
         result = call_command(_StubCommand(), "refuse")
 
         assert result == {"error": "nothing shipped", "hint": "re-run inside the container"}
+
+
+class _PartlyExemptCommand(RefusalExitTyperCommand):
+    """One refusing subcommand whose caller needs it soft, one that must stay loud."""
+
+    soft_refusal_commands = frozenset({"refuse-soft"})
+
+    @command(name="refuse-soft")
+    def refuse_soft(self) -> dict[str, str]:
+        return {"error": "deferred; the push proceeds"}
+
+    @command(name="refuse-loud")
+    def refuse_loud(self) -> dict[str, str]:
+        return {"error": "nothing shipped"}
+
+
+class TestSoftRefusalCommandsExemptsOnlyWhatItNames:
+    def test_an_exempt_subcommand_exits_zero(self) -> None:
+        assert _PartlyExemptCommand().run_from_argv(["manage.py", "stub", "refuse-soft"]) is None
+
+    def test_a_sibling_outside_the_exemption_stays_loud(self) -> None:
+        """Polarity: exempting one subcommand must not quiet the rest of the command."""
+        with pytest.raises(SystemExit) as exc:
+            _PartlyExemptCommand().run_from_argv(["manage.py", "stub", "refuse-loud"])
+
+        assert exc.value.code == REFUSAL_EXIT_CODE
+
+    def test_the_subcommand_is_read_past_leading_flags(self) -> None:
+        assert invoked_subcommand(("--no-color", "create", "4242")) == "create"
+        assert invoked_subcommand(("ensure-pr", "--branch", "create")) == "ensure-pr"
+        assert invoked_subcommand(()) == ""

--- a/tests/teatree_core/management/test_refusal_exit.py
+++ b/tests/teatree_core/management/test_refusal_exit.py
@@ -1,0 +1,59 @@
+"""A returned structured refusal exits non-zero on the argv path only (#4210).
+
+The two callers of the same command need opposite things from the same refusal:
+a shell needs a failing status so ``ship && clear`` stops, an in-process consumer
+needs the structured dict to route on. Driven through a stub command so the seam
+is exercised without a database.
+"""
+
+import pytest
+from django.core.management import call_command
+from django_typer.management import command
+
+from teatree.core.management.refusal_exit import REFUSAL_EXIT_CODE, RefusalExitTyperCommand, refusal_exit_code
+
+
+class TestRefusalExitCode:
+    def test_a_non_empty_error_key_is_a_refusal(self) -> None:
+        assert refusal_exit_code({"error": "nothing shipped", "hint": "run it in the container"}) == REFUSAL_EXIT_CODE
+
+    def test_a_result_with_no_error_key_is_success(self) -> None:
+        assert refusal_exit_code({"ticket_id": 4210, "state": "shipped", "queued": True}) == 0
+
+    def test_a_blank_error_is_success(self) -> None:
+        """``EnsurePrResult`` is ``total=False``: an unset/blank ``error`` is not a refusal."""
+        assert refusal_exit_code({"branch": "main", "error": ""}) == 0
+
+    def test_a_non_mapping_result_is_success(self) -> None:
+        assert refusal_exit_code("t3-teatree") == 0
+        assert refusal_exit_code(None) == 0
+        assert refusal_exit_code(["error"]) == 0
+
+
+class _StubCommand(RefusalExitTyperCommand):
+    """A two-outcome stand-in for a real command, so the seam needs no ORM."""
+
+    @command(name="refuse")
+    def refuse(self) -> dict[str, str]:
+        return {"error": "nothing shipped", "hint": "re-run inside the container"}
+
+    @command(name="succeed")
+    def succeed(self) -> dict[str, object]:
+        return {"ticket_id": 4210, "state": "shipped"}
+
+
+class TestRefusalExitTyperCommand:
+    def test_the_argv_path_exits_non_zero_on_a_refusal(self) -> None:
+        with pytest.raises(SystemExit) as exc:
+            _StubCommand().run_from_argv(["manage.py", "stub", "refuse"])
+
+        assert exc.value.code == REFUSAL_EXIT_CODE
+
+    def test_the_argv_path_still_exits_zero_on_a_success(self) -> None:
+        """Anti-vacuous: a seam that always fired would fail every clean run."""
+        assert _StubCommand().run_from_argv(["manage.py", "stub", "succeed"]) is None
+
+    def test_an_in_process_caller_receives_the_refusal_dict_unchanged(self) -> None:
+        result = call_command(_StubCommand(), "refuse")
+
+        assert result == {"error": "nothing shipped", "hint": "re-run inside the container"}

--- a/tests/teatree_core/pr_command/test_create_refusal_exit_code.py
+++ b/tests/teatree_core/pr_command/test_create_refusal_exit_code.py
@@ -1,0 +1,75 @@
+"""``pr create`` refusals exit non-zero on the argv path (#4210).
+
+#4206 replaced a host-side ``OperationalError`` traceback with a named refusal
+and, in doing so, turned exit 1 into exit 0 — so ``t3 <overlay> ship <id> &&
+t3 <overlay> ticket clear …`` ran the second command having shipped nothing.
+The message is load-bearing and unchanged; only the status moves.
+
+The control-DB refusal is read before any ORM touch by design (#4170), so these
+drive the real command with no database.
+"""
+
+from pathlib import Path
+from typing import cast, get_args, get_type_hints
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+
+from teatree.core.management.commands import _pr_control_db, _pr_ticket_resolve
+from teatree.core.management.commands.pr import Command
+from teatree.core.management.refusal_exit import REFUSAL_EXIT_CODE, RefusalExitTyperCommand
+from teatree.core.models import Ticket
+from teatree.paths import CONTROL_DB_DIR_ENV, DB_FILENAME
+
+from ._shared import _MOCK_OVERLAY
+
+_CONTAINER_ONLY = Path("/nonexistent/container-only/control-db")
+
+#: The result shapes ``create`` returns on a path that DID ship (or previewed) —
+#: everything else in its return union is a refusal and must carry ``error``.
+_SUCCESS_SHAPES = frozenset({"ShipEnqueued", "ShipExecuted", "ShipDryRun"})
+
+
+@pytest.fixture
+def _container_only_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(CONTROL_DB_DIR_ENV, str(_CONTAINER_ONLY))
+    monkeypatch.setattr(_pr_control_db, "configured_db_path", lambda: _CONTAINER_ONLY / DB_FILENAME)
+
+
+@pytest.mark.usefixtures("_container_only_db")
+class TestHostSidePrCreateRefusalExitsNonZero:
+    def test_the_argv_path_exits_non_zero(self) -> None:
+        resolve = MagicMock(side_effect=Ticket.DoesNotExist)
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(_pr_ticket_resolve, "resolve_ticket", resolve),
+            pytest.raises(SystemExit) as exc,
+        ):
+            Command().run_from_argv(["manage.py", "pr", "create", "4242"])
+
+        assert exc.value.code == REFUSAL_EXIT_CODE
+        resolve.assert_not_called()
+
+    def test_the_message_and_hint_are_unchanged_for_an_in_process_caller(self) -> None:
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast("dict[str, object]", call_command("pr", "create", "4242"))
+
+        assert str(_CONTAINER_ONLY) in str(result["error"])
+        assert "deploy/t3" in str(result["hint"])
+
+
+class TestEveryRefusalCreateCanReturnIsKeyedOnError:
+    """The seam keys on ``error``; a refusal shape lacking it would exit 0 again."""
+
+    def test_the_command_carries_the_seam(self) -> None:
+        assert issubclass(Command, RefusalExitTyperCommand)
+
+    def test_each_non_success_return_shape_declares_an_error_key(self) -> None:
+        members = get_args(get_type_hints(Command.create)["return"])
+        refusals = [shape for shape in members if shape.__name__ not in _SUCCESS_SHAPES]
+
+        assert refusals, "the return union lost every refusal shape — the pin is vacuous"
+        for shape in refusals:
+            assert "error" in get_type_hints(shape), f"{shape.__name__} would exit 0 on a refusal"

--- a/tests/teatree_core/pr_command/test_create_refusal_exit_code.py
+++ b/tests/teatree_core/pr_command/test_create_refusal_exit_code.py
@@ -60,6 +60,20 @@ class TestHostSidePrCreateRefusalExitsNonZero:
         assert "deploy/t3" in str(result["hint"])
 
 
+class TestEnsurePrKeepsItsSoftRefusal:
+    """``ensure-pr`` is the pre-push hook's entry: a refusal reports, never wedges the push."""
+
+    def test_it_is_the_only_exemption(self) -> None:
+        assert Command.soft_refusal_commands == frozenset({"ensure-pr"})
+
+    def test_a_refused_ensure_pr_still_exits_zero(self, tmp_path: Path) -> None:
+        """A real refusal — ``--repo`` is not a git checkout — reports and returns."""
+        in_process = cast("dict[str, object]", call_command("pr", "ensure-pr", repo=str(tmp_path)))
+        assert in_process["error"], "the invocation must actually refuse, or the pin is vacuous"
+
+        assert Command().run_from_argv(["manage.py", "pr", "ensure-pr", "--repo", str(tmp_path)]) is None
+
+
 class TestEveryRefusalCreateCanReturnIsKeyedOnError:
     """The seam keys on ``error``; a refusal shape lacking it would exit 0 again."""
 


### PR DESCRIPTION
## Why

[#4206](https://github.com/souliane/teatree/pull/4206) replaced a host-side `OperationalError` traceback with a named, structured refusal — the right shape, but it also turned exit 1 into exit 0. Django's `run_from_argv` discards a command's return value, so `t3 <overlay> ship <id> && t3 <overlay> ticket clear …` ran the second command having shipped nothing, and any `set -e` lane proceeded on a refusal. The operator saw a clear message and a success code at the same time.

Not a revert: the structured return is load-bearing — `mcp/write_tools.py` and the loop inspect the dict. The exit code is restored at the boundary instead.

## What

**The seam** — `src/teatree/core/management/refusal_exit.py`:

- `refusal_exit_code(result)` — non-zero iff the result is a mapping with a truthy `error`. A new refusal shape needs an `error` key and nothing else.
- `RefusalExitTyperCommand.execute` raises `SystemExit(1)` on such a result **only** when `_called_from_command_line` is set — the flag Django's `run_from_argv` sets and `call_command` does not. In-process callers keep the dict verbatim.
- `soft_refusal_commands` (ClassVar, **default empty**) exempts named subcommands. Polarity is exemption, not inclusion, so a *new* refusal is loud without being enrolled anywhere — an inclusion list would have re-created the exact trap this ticket is about.
- `invoked_subcommand(args)` reads the first bare token of the argv remainder, so leading flags cannot hide the subcommand.

**The adoption** — `src/teatree/core/management/commands/pr.py`:

- `Command` inherits the seam, so `create`'s control-DB-unreachable, ticket-not-found, worktree-missing and per-ship-gate refusals all exit 1 — as do `merge`, `sweep`, `post-test-plan` and `discharge-pending`. `t3 <overlay> ship` dispatches to `pr create` (`src/teatree/cli/overlay.py:296`), which is the chain named in the ticket.
- `ensure-pr` is the **one** exemption: it is the pre-push hook's entry point (`.pre-commit-config.yaml`, `stages: [push]`), so a returned refusal exiting 1 would fail the hook and wedge the push — the [#792](https://github.com/souliane/teatree/issues/792) deadlock its deferral logic exists to avoid, re-introduced from the other side.

**The convention** — `skills/internals` § "Management Command Patterns": the sanctioned exception documented next to the anti-pattern it is an exception to, plus loud-by-default and the one exemption's reason.

## Measured on this branch

| command | message | exit |
|---|---|---|
| `python -m teatree pr create 999999999` | unchanged | **1** (was 0) |
| `python -m teatree pr ensure-pr --repo /var/tmp` | unchanged | **0** (unchanged) |

Anti-vacuous in both directions (mutation controls run locally):

- exemption ignored → `test_an_exempt_subcommand_exits_zero` and `test_a_refused_ensure_pr_still_exits_zero` go RED.
- everything treated as soft → `test_a_sibling_outside_the_exemption_stays_loud`, `test_the_argv_path_exits_non_zero_on_a_refusal` and `test_the_argv_path_exits_non_zero` go RED.

`t3 tool verify-gates` exit 0 (commit + push stages). Affected-tests lane: 9591 passed; the 11 failures are pre-existing and environmental — 10 reproduce identically with the seam fully disabled (doctor control-DB-path checks, a `gh api` network call), and the lane-ceiling one is green outside the full lane.

## Architecture pre-check — [#4210](https://github.com/souliane/teatree/issues/4210)

**1. BLUEPRINT § alignment** — § 8 Command Tiers: `pr` is a Runtime (django-typer) command group. The claim: a Runtime command's returned refusal must reach the shell as a non-zero status while `call_command` still receives the dict. No BLUEPRINT text contradicts this, so no BLUEPRINT edit is needed; the convention lives in `skills/internals`.

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition is added, moved, or gated differently; the ship-gate refusal's *content* is unchanged, only the process status carrying it.

**3. Extension-point contracts** — no `OverlayBase` hook, scanner registration, or `*Backend` Protocol is touched. `RefusalExitTyperCommand` is a new intra-core base class with exactly one consumer (`commands/pr.py`); `grep -rn RefusalExitTyperCommand src` confirms no other subclass.

**4. Component boundaries** — `src/teatree/core/management/` (the management-command layer), sibling to `commands/`. It is command-invocation plumbing, not business logic, so it belongs in neither `core/models` nor `cli/`.

**5. Dependency direction** — one new import edge, `core.management.commands.pr → core.management.refusal_exit`, which is intra-package and forward. `uv run tach check` and import-linter both Passed in the commit-hook run.

**6. Test surface**

- `tests/teatree_core/management/test_refusal_exit.py` — the predicate, the argv/in-process split, and the exemption polarity (an exempt subcommand exits 0 while a refusing sibling in the same command still exits 1).
- `tests/teatree_core/pr_command/test_create_refusal_exit_code.py` — `pr create`'s real refusal exits `REFUSAL_EXIT_CODE`, its message/hint are unchanged for `call_command`, `ensure-pr` is the only exemption, and every non-success shape in `create`'s return union declares an `error` key (so a future refusal cannot silently regress to exit 0).

**7. Resilience invariants** — no external write is added. The change is confined to how an existing local result maps to a process status, so verify-by-re-read, fallback-transport, idempotency, heartbeat and the sub-agent return contract are all unaffected. Idempotency is in fact protected: `ensure-pr`'s deferral obligation still exits 0, so the pre-push hook's retry path is preserved.

**8. Identity and key normalization** — the subcommand name is the identity in play. `invoked_subcommand` canonicalizes the argv remainder to that one token by skipping flags; it strips no qualifier to force a match, and the exemption set is compared against the full subcommand name (`ensure-pr`, not `pr`).

**9. Behavior preservation / capability deletion** — enumerated against `git show origin/main:src/teatree/core/management/commands/pr.py`:

- every refusal's message, hint and dict shape — **preserved verbatim**; only the status changes.
- `call_command` return values for every subcommand — **preserved** (`_called_from_command_line` is unset there).
- `ensure-pr`'s soft refusal, on which the pre-push hook depends — **preserved** by the exemption; without it every push would be wedged by a refusal that is designed to be reported and passed over.
- No privacy / leak / security matcher is narrowed and no must-block test is inverted. `pr check-gates` returns an `allowed`/`reason` pair with no `error` key, so it still exits 0 on a blocked gate — left as-is: it is a query, not a refusal.

**10. Removability / harness-vs-data** — removable in one step: delete `refusal_exit.py`, swap `pr.Command`'s base back to `TyperCommand`, drop two test files. Blast radius is one class declaration; every call site is untouched. Harness-vs-data: the *predicate* is harness (one pure function, uniform across commands), while the *per-command policy* — which subcommands are exempt — is a declarative `ClassVar` on the command that owns the contract, not a branch inside the seam.

## Open questions & assumptions

- **assumed** — `_called_from_command_line` is the right gate. It is the flag Django's own `run_from_argv` sets and `call_command` does not, which is exactly the shell-vs-in-process split the acceptance criteria require.
- **assumed** — `error` is the refusal key. Every `error`-shaped result TypedDict under `commands/` already uses it; a test pins that every non-success shape in `create`'s return union declares one.
- **assumed** — `ensure-pr` is the only subcommand of `pr` whose caller depends on a soft refusal. Every shell caller in the tree was checked: `merge`, `sweep`, `post-test-plan` and `discharge-pending` are invoked by a human or an agent, never by a hook that must proceed on failure. The only in-process caller of `ensure-pr` (`src/teatree/loop/scanners/pending_pr.py:73`) goes through `call_command`, which the seam never touches.
- **assumed** — the subcommand name is the first bare token of the argv remainder. Measured: Django hands `execute` `('ensure-pr', '--repo', <path>)`.
- **decided (ticket scope)** — exemption list over inclusion list, so the default stays fail-loud and matches the `/t3:internals` anti-pattern rule.
- **decided (ticket scope)** — the ticket's "siblings" question is answered for every refusal in the `pr` command, which the base-class swap covers wholesale.
- **open** — other command modules that also return an `error` key (`ticket`, `lifecycle`, `review`, `do`, `repro`, `_rubric_commands`, `_plan_gate_commands`). Deliberately NOT switched here: flipping their exit codes changes shell semantics for lanes this ticket has no coverage over. The reusable seam plus the documented convention make each adoption a reviewed, per-command step.
- **open** — `pr check-gates` still exits 0 on a blocked gate (no `error` key). Left as-is: it is a query, not a refusal, and changing it is a separate decision.

Closes [#4210](https://github.com/souliane/teatree/issues/4210)
