### PR TITLE
fix(hooks): unfork the turn walk, the push target, and the Slack read/write split

### DIFF
--- a/hooks/scripts/django_bootstrap.py
+++ b/hooks/scripts/django_bootstrap.py
@@ -5,11 +5,46 @@ gate handlers resolve overlays / models through the app registry. This
 self-contained utility (src-path insert + ``django.setup()`` + bool return)
 has ZERO dependency on ``hook_router``, so both ``hook_router`` and the sibling
 gate modules import it directly without a cycle.
+
+A FAILED bootstrap is audible. ``run-hook.sh`` deliberately falls back to a
+version-floor-only interpreter with no Django and prints nothing, so without a
+line here every ORM-backed gate degrades to a silent allow that an operator
+reading the session cannot tell from a clean pass. The line is emitted once per
+process (the gates call this repeatedly) and names the missing capability, not
+the gate — each degraded gate says SKIPPED itself, through
+``gate_result.warn_gate_skipped``.
 """
 
 import os
 import sys
 from pathlib import Path
+
+#: Whether this process already named the missing capability. The bootstrap is
+#: called by every ORM-backed gate in the chain; one line is the signal, ten is
+#: noise the operator learns to skip past.
+_MISSING_CAPABILITY_WARNED = False
+
+
+def _django_setup() -> None:
+    """Import Django and initialise the app registry against teatree's settings."""
+    import django  # noqa: PLC0415 — deferred: Django import at call time
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
+    django.setup()
+
+
+def _warn_missing_capability(exc: BaseException) -> None:
+    """Name the missing capability on stderr, once per process."""
+    global _MISSING_CAPABILITY_WARNED  # noqa: PLW0603 — process-scoped dedup for a stderr line
+    if _MISSING_CAPABILITY_WARNED:
+        return
+    _MISSING_CAPABILITY_WARNED = True
+    sys.stderr.write(
+        f"NOTE: the hook interpreter cannot import Django ({type(exc).__name__}: {exc}). "
+        "Every ORM-backed gate in this hook process is SKIPPED, not passed — each one "
+        "allows its call unvalidated. Point the hooks at an interpreter with teatree's "
+        "dependencies installed to restore them.\n"
+    )
 
 
 def bootstrap_teatree_django() -> bool:
@@ -17,16 +52,15 @@ def bootstrap_teatree_django() -> bool:
 
     Returns ``True`` when the bootstrap succeeded (the away-mode handler
     can record a ``DeferredQuestion`` row) and ``False`` when ``teatree``
-    is unavailable (the handler then fails open — never intercepts).
+    is unavailable — the handler then fails open (never intercepts) and the
+    missing capability is named on stderr (:func:`_warn_missing_capability`).
     """
     src_dir = Path(__file__).resolve().parents[2] / "src"
     if str(src_dir) not in sys.path:
         sys.path.insert(0, str(src_dir))
     try:
-        import django  # noqa: PLC0415 — deferred: Django import at call time
-
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
-        django.setup()
-    except Exception:  # noqa: BLE001 — crash-proof hook: any failure degrades silently, never breaks the tool call
+        _django_setup()
+    except Exception as exc:  # noqa: BLE001 — crash-proof hook: any failure degrades, never breaks the tool call
+        _warn_missing_capability(exc)
         return False
     return True

--- a/hooks/scripts/mcp_slack_write_guard.py
+++ b/hooks/scripts/mcp_slack_write_guard.py
@@ -5,8 +5,11 @@ upload) bypasses teatree's Slack egress chokepoint (``src/teatree/backends/slack
 under the on-behalf gate, the voice classifier, the verify-by-re-read contract),
 so a message can land under the user's identity with none of those guarantees.
 This gate closes that bypass at the ``PreToolUse`` boundary: a Slack MCP WRITE is
-denied and redirected to the sanctioned CLI; a Slack MCP READ (history / list /
-search / get) passes through untouched.
+denied and redirected to the sanctioned CLI; a recognised Slack MCP READ (history
+/ list / search / get / info / …) passes through untouched. The classification is
+default-DENY (:func:`is_slack_mcp_write`) — a tool whose shape the READ roster
+does not recognise is a write, so a Slack MCP surface added after this roster
+cannot slip through on a missing verb.
 
 Narrower and complementary to ``handle_block_self_dm_via_mcp`` (which refuses only
 a self-DM write, fail-closed on unreadable config): this gate refuses EVERY Slack
@@ -31,23 +34,33 @@ import sys
 sys.modules.setdefault("mcp_slack_write_guard", sys.modules[__name__])
 sys.modules.setdefault("hooks.scripts.mcp_slack_write_guard", sys.modules[__name__])
 
-#: Write-verb fragments a Slack MCP write tool's suffix carries. Conservative by
-#: construction — a read tool (``get_channel_history``, ``list_channels``,
-#: ``search_messages``, ``get_users``) carries none of these, so it passes.
-_SLACK_WRITE_VERBS: frozenset[str] = frozenset(
+#: Verbs that make a Slack MCP tool a READ. Everything else — including a tool
+#: whose name this roster has never seen — is treated as a WRITE, so a Slack MCP
+#: surface the roster predates (``slack_create_conversation``,
+#: ``slack_create_canvas``) fails CLOSED instead of passing on a missing write
+#: verb. The inverse (a write-verb roster) also mis-classified the other way: a
+#: pure read whose NOUN carries a write verb (``slack_get_reactions``) was denied
+#: with no CLI equivalent to redirect it to.
+_SLACK_READ_VERBS: frozenset[str] = frozenset(
     {
-        "send",
-        "post",
-        "reply",
-        "reaction",
-        "react",
-        "update",
-        "delete",
-        "upload",
-        "schedule",
-        "write",
+        "fetch",
+        "get",
+        "history",
+        "info",
+        "list",
+        "members",
+        "permalink",
+        "profile",
+        "read",
+        "replies",
+        "search",
+        "view",
     }
 )
+
+#: A tool suffix's words, split on both ``_`` and camelCase (``conversations_list``
+#: and ``conversationsHistory`` are the two spellings live Slack MCP servers use).
+_NAME_WORD_RE = re.compile(r"[a-z]+|[A-Z][a-z]*")
 
 #: Per-call never-lockout escape: ``[slack-mcp-ok: <reason>]`` in any string field
 #: of the tool input allows that single call (a vetted one-off). Empty reason rejects.
@@ -59,8 +72,11 @@ _DENY_REASON = (
     "`t3` CLI instead: DM the user with `t3 teatree notify send -` (bot token); post to "
     "a colleague channel with `t3 <overlay> notify post --channel <id> --text <body>` "
     "(on-behalf gated); react with `t3 slack react`; comment on an MR/PR with "
-    "`t3 <overlay> review post-comment`. Slack MCP READS (history/list/search/get) are "
-    "unaffected. One-off escape: put `[slack-mcp-ok: <reason>]` in the message text."
+    "`t3 <overlay> review post-comment`. Recognised Slack MCP READS "
+    "(get/list/search/history/info/read/view/fetch/replies/members) are unaffected; a "
+    "Slack MCP tool this gate does not recognise is treated as a WRITE, so a genuine "
+    "read it has not seen lands here too. One-off escape: put `[slack-mcp-ok: <reason>]` "
+    "in the message text."
 )
 
 
@@ -70,11 +86,19 @@ def is_slack_mcp_tool(tool_name: str) -> bool:
 
 
 def is_slack_mcp_write(tool_name: str) -> bool:
-    """Whether *tool_name* is a Slack MCP WRITE (a write verb in its suffix)."""
+    """Whether *tool_name* is a Slack MCP WRITE — i.e. anything not a recognised READ.
+
+    Default-DENY: only a suffix carrying a :data:`_SLACK_READ_VERBS` word is a
+    read. A Slack MCP tool this roster has never seen is a write, because the
+    cost of the two errors is not symmetric — an unrecognised read is one denied
+    call the operator escapes with ``[slack-mcp-ok: …]``, an unrecognised write
+    is a post under the user's identity outside the egress chokepoint.
+    """
     if not is_slack_mcp_tool(tool_name):
         return False
-    suffix = tool_name.rsplit("__", 1)[-1].lower()
-    return any(verb in suffix for verb in _SLACK_WRITE_VERBS)
+    suffix = tool_name.rsplit("__", 1)[-1]
+    words = {word.lower() for word in _NAME_WORD_RE.findall(suffix)}
+    return not (words & _SLACK_READ_VERBS)
 
 
 def _has_escape_token(tool_input: dict) -> bool:
@@ -95,8 +119,8 @@ def _gate_enabled() -> bool:
 def handle_block_mcp_slack_write(data: dict) -> bool:
     """Deny a direct MCP Slack WRITE, redirecting to the sanctioned ``t3`` CLI.
 
-    Fires on any ``mcp__*slack*`` tool whose suffix carries a write verb; a Slack
-    READ tool passes through. Never-lockout: the ``[teatree]
+    Fires on any ``mcp__*slack*`` tool that is not a recognised READ; a Slack READ
+    tool passes through. Never-lockout: the ``[teatree]
     mcp_slack_write_gate_enabled = false`` kill-switch disables it, a
     ``[slack-mcp-ok: <reason>]`` token in the tool input allows a single call, and
     the deny routes through the router's shared ``_fail_open_or_deny`` chokepoint

--- a/hooks/scripts/turn_inspect.py
+++ b/hooks/scripts/turn_inspect.py
@@ -8,13 +8,24 @@ consideration Stop gate). Factored OUT of ``hook_router`` (a shrink-only capped
 god-module): a new gate that needs the same walk imports it from here rather than
 growing the router.
 
-The transcript readers (``_read_transcript_entries`` / ``_entry_role`` /
-``_entry_content``) live in ``hook_router`` and are imported lazily at call time
-— ``hook_router`` imports this module at top level, so importing it back at top
-level here would be a cycle.
+All three project over ONE turn-boundary walk (:func:`current_turn_assistant_blocks`)
+that reads ``question_gates``' predicates for what an entry's role and blocks are
+and for what counts as the user speaking. A tool RESULT is recorded as a ``user``
+entry whose blocks are all ``tool_result``, so a walk that breaks at the first
+``user`` entry cuts the turn at the first tool call — and every real tool-using
+turn then projects to nothing. Keeping one walk with one boundary predicate is
+what stops the three copies drifting apart the way this module drifted from
+``question_gates.last_assistant_turn`` after the same fix landed there.
 """
 
 import sys
+
+from hooks.scripts.question_gates import (
+    _entry_message_blocks,
+    _entry_message_role,
+    is_tool_result_only,
+    read_transcript_entries,
+)
 
 # Alias the bare and ``hooks.scripts.`` identities so the router and any test
 # patching a helper here operate on ONE module object.
@@ -22,41 +33,52 @@ sys.modules.setdefault("turn_inspect", sys.modules[__name__])
 sys.modules.setdefault("hooks.scripts.turn_inspect", sys.modules[__name__])
 
 
-def current_turn_tool_commands(transcript_path: str) -> list[str]:
-    """Flattened text of every tool_use input in the most recent turn.
+def current_turn_assistant_blocks(transcript_path: str) -> list[dict]:
+    """Every assistant content block of the most recent turn, in transcript order.
 
-    Walks the transcript newest->oldest to the most recent ``user`` boundary
-    and collects, for each ``tool_use`` block after it, the strings that can
-    carry an id + state-read verb: ``Bash`` ``command`` and ``Agent`` / ``Task``
-    ``prompt`` + ``description``. These feed the same-turn-verification check
-    so a ``gh pr view <id>`` in the turn clears the warning for that id.
+    Walks newest→oldest to the most recent GENUINE ``user`` entry. A ``user``
+    entry whose blocks are all ``tool_result`` is the harness recording a tool's
+    output, not the user typing, so it is walked past
+    (:func:`question_gates.is_tool_result_only`) — breaking there would end the
+    turn at its first tool call.
     """
-    from hooks.scripts.hook_router import (  # noqa: PLC0415 deferred back-import
-        _entry_content,
-        _entry_role,
-        _read_transcript_entries,
-    )
-
-    entries = _read_transcript_entries(transcript_path)
-    if not entries:
-        return []
-    commands: list[str] = []
-    for entry in reversed(entries):
-        role = _entry_role(entry)
+    blocks: list[dict] = []
+    for entry in reversed(read_transcript_entries(transcript_path)):
+        role = _entry_message_role(entry)
         if role == "user":
+            if is_tool_result_only(_entry_message_blocks(entry)):
+                continue
             break
         if role != "assistant":
             continue
-        for block in _entry_content(entry):
-            if not isinstance(block, dict) or block.get("type") != "tool_use":
-                continue
-            tool_input = block.get("input")
-            if not isinstance(tool_input, dict):
-                continue
-            for field in ("command", "prompt", "description"):
-                value = tool_input.get(field)
-                if isinstance(value, str) and value:
-                    commands.append(value)
+        blocks.extend(block for block in _entry_message_blocks(entry) if isinstance(block, dict))
+    blocks.reverse()
+    return blocks
+
+
+#: ``tool_use`` input fields that can carry an id + state-read verb.
+_COMMAND_FIELDS: tuple[str, ...] = ("command", "prompt", "description")
+
+
+def current_turn_tool_commands(transcript_path: str) -> list[str]:
+    """Flattened text of every tool_use input in the most recent turn.
+
+    Collects, for each ``tool_use`` block of the turn, the strings that can carry
+    an id + state-read verb: ``Bash`` ``command`` and ``Agent`` / ``Task``
+    ``prompt`` + ``description``. These feed the same-turn-verification check so a
+    ``gh pr view <id>`` in the turn clears the warning for that id.
+    """
+    commands: list[str] = []
+    for block in current_turn_assistant_blocks(transcript_path):
+        if block.get("type") != "tool_use":
+            continue
+        tool_input = block.get("input")
+        if not isinstance(tool_input, dict):
+            continue
+        for field in _COMMAND_FIELDS:
+            value = tool_input.get(field)
+            if isinstance(value, str) and value:
+                commands.append(value)
     return commands
 
 
@@ -84,38 +106,12 @@ def _edit_block_path(block: dict) -> str | None:
 
 
 def current_turn_edits(transcript_path: str) -> list[str]:
-    """File paths edited by the assistant in the most recent turn.
+    """File paths edited by the assistant in the most recent turn, in transcript order.
 
-    Walks the transcript newest→oldest; the most recent ``user`` entry
-    is the boundary. Returns the file paths from every ``Edit`` /
-    ``Write`` / ``NotebookEdit`` ``tool_use`` block after that
-    boundary, in transcript order. Duplicates kept — the caller
-    classifies + dedupes.
+    Duplicates kept — the caller classifies + dedupes.
     """
-    from hooks.scripts.hook_router import (  # noqa: PLC0415 deferred back-import
-        _entry_content,
-        _entry_role,
-        _read_transcript_entries,
-    )
-
-    entries = _read_transcript_entries(transcript_path)
-    if not entries:
-        return []
-    edits: list[str] = []
-    for entry in reversed(entries):
-        role = _entry_role(entry)
-        if role == "user":
-            break
-        if role != "assistant":
-            continue
-        for block in _entry_content(entry):
-            if not isinstance(block, dict):
-                continue
-            path = _edit_block_path(block)
-            if path is not None:
-                edits.append(path)
-    edits.reverse()
-    return edits
+    paths = (_edit_block_path(block) for block in current_turn_assistant_blocks(transcript_path))
+    return [path for path in paths if path is not None]
 
 
 def current_turn_assistant_text(transcript_path: str) -> str:
@@ -123,23 +119,9 @@ def current_turn_assistant_text(transcript_path: str) -> str:
 
     Used to detect a teatree-issue reference that clears the gate.
     """
-    from hooks.scripts.hook_router import (  # noqa: PLC0415 deferred back-import
-        _entry_content,
-        _entry_role,
-        _read_transcript_entries,
-    )
-
     chunks: list[str] = []
-    entries = _read_transcript_entries(transcript_path)
-    for entry in reversed(entries):
-        role = _entry_role(entry)
-        if role == "user":
-            break
-        if role != "assistant":
-            continue
-        for block in _entry_content(entry):
-            if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text")
-                if isinstance(text, str):
-                    chunks.append(text)
+    for block in current_turn_assistant_blocks(transcript_path):
+        text = block.get("text")
+        if block.get("type") == "text" and isinstance(text, str):
+            chunks.append(text)
     return "\n".join(chunks)

--- a/hooks/scripts/unknown_repo_push_gate.py
+++ b/hooks/scripts/unknown_repo_push_gate.py
@@ -32,6 +32,9 @@ import sys
 from pathlib import Path
 
 from hooks.scripts.django_bootstrap import bootstrap_teatree_django
+from hooks.scripts.gate_result import warn_gate_skipped
+from hooks.scripts.managed_repo import teatree_src_on_path
+from hooks.scripts.mr_cli_fields import strip_quoted_and_heredoc
 
 # Alias the bare and ``hooks.scripts.`` identities so the handler the router
 # registers and a test patching a helper here operate on ONE module object.
@@ -40,9 +43,14 @@ sys.modules.setdefault("hooks.scripts.unknown_repo_push_gate", sys.modules[__nam
 
 # A real push to a remote — not a local/query form. ``--dry-run`` (and ``-n``)
 # perform no write, so they are exempt. A bare ``git push`` (no remote arg)
-# still pushes the current branch, so the remote token is not required.
-_SCOPE_GIT_PUSH_RE = re.compile(r"\bgit\s+push\b")
-_SCOPE_GIT_PUSH_DRY_RUN_RE = re.compile(r"\bgit\s+push\b[^\n|;&]*?(?:--dry-run|\s-n\b)")
+# still pushes the current branch, so the remote token is not required. The
+# verb is anchored at a COMMAND position (start of the command or after a
+# separator) and git's global flags may sit between ``git`` and ``push`` —
+# ``git -C <dir> push`` is the form every sibling gate already handles, and
+# requiring the two words adjacent let it through unevaluated.
+_PUSH_PREFIX = r"(?:^|[;&|]\s*)(?:sudo\s+)?git\s+(?:(?:-C|-c|--git-dir|--work-tree|--namespace)(?:=\S+|\s+\S+)\s+)*"
+_SCOPE_GIT_PUSH_RE = re.compile(_PUSH_PREFIX + r"push\b")
+_SCOPE_GIT_PUSH_DRY_RUN_RE = re.compile(_PUSH_PREFIX + r"push\b[^\n|;&]*?(?:--dry-run|\s-n\b)")
 _SCOPE_PUSH_OK_RE = re.compile(r"\[scope-push-ok:\s*(\S[^\]]*?)\s*\]")
 
 
@@ -87,16 +95,50 @@ def _classify_push_for_cwd(cwd: Path) -> str:
     :func:`teatree.core.gates.owned_repo_guard.classify_active_push`. Any
     import/resolution EXCEPTION (incl. a failed bootstrap) fails OPEN to
     ``allow`` (never-lockout on the internal-exception axis) — distinct from a
-    clean ``require_approval`` verdict, which holds the push.
+    clean ``require_approval`` verdict, which holds the push. Each degraded
+    ``allow`` says so on stderr (:func:`gate_result.warn_gate_skipped`): an
+    unvalidated push and a scoped-and-cleared one are the same silence otherwise.
     """
     if not bootstrap_teatree_django():
+        warn_gate_skipped("unknown-repo push SCOPE", "the hook interpreter cannot import Django")
         return "allow"
     try:
         from teatree.core.gates.owned_repo_guard import classify_active_push  # noqa: PLC0415 — cold-hook import
 
         return str(classify_active_push(cwd))
-    except Exception:  # noqa: BLE001 — fail OPEN; a broken resolver must not wedge a push.
+    except Exception as exc:  # noqa: BLE001 — fail OPEN; a broken resolver must not wedge a push.
+        warn_gate_skipped("unknown-repo push SCOPE", f"the scope resolver failed ({type(exc).__name__}: {exc})")
         return "allow"
+
+
+def _push_target_dir(command: str, cwd: Path | None) -> Path | None:
+    """The dir whose repo this push LANDS in, or ``None`` when it cannot be pinned.
+
+    Resolved by the canonical static resolver
+    :func:`teatree.hooks._commit_repo_dir.resolve_commit_dir`, the same one
+    ``main_clone_guard`` / ``single_branch_repo_guard`` /
+    ``headless_authoring_gate`` use, so ``git -C <dir>``, ``cd <dir> &&`` and
+    ``--git-dir`` all name the repo actually being pushed. Keying on the ambient
+    ``cwd`` instead classified the SESSION's repo, and a session sits in one repo
+    while pushing to another all day.
+
+    ``None`` — the fail-OPEN answer — for an unresolvable target (the
+    sentinel, no cwd, a resolver that cannot be imported): an unknown target is
+    not evidence that a push leaves the operator's scope.
+    """
+    try:
+        with teatree_src_on_path():
+            from teatree.hooks._commit_repo_dir import (  # noqa: PLC0415, PLC2701 — cold-hook import
+                UNRESOLVABLE_REPO_DIR,
+                resolve_commit_dir,
+            )
+
+            landing = resolve_commit_dir(command, cwd)
+        if landing == UNRESOLVABLE_REPO_DIR or not isinstance(landing, Path):
+            return None
+    except Exception:  # noqa: BLE001 — fail OPEN; an unimportable resolver must not wedge a push.
+        return None
+    return landing if landing.is_dir() else None
 
 
 _UNKNOWN_REPO_PUSH_REASON = (
@@ -117,11 +159,18 @@ def _unknown_repo_push_is_in_scope(data: dict) -> bool:
     are exempt), with the gate enabled and no per-call
     ``[scope-push-ok: <reason>]`` token present. A present token is honoured
     here (with a stderr NOTE) so the handler stays a single decision.
+
+    The verb is matched against the quote/heredoc-stripped skeleton, as in every
+    sibling gate: the same words inside a ``-m`` message or a heredoc body are
+    text, not an invocation.
     """
     if data.get("tool_name") != "Bash":
         return False
     command = data.get("tool_input", {}).get("command", "")
-    if not command or not _SCOPE_GIT_PUSH_RE.search(command) or _SCOPE_GIT_PUSH_DRY_RUN_RE.search(command):
+    if not command:
+        return False
+    skeleton = strip_quoted_and_heredoc(command)
+    if not _SCOPE_GIT_PUSH_RE.search(skeleton) or _SCOPE_GIT_PUSH_DRY_RUN_RE.search(skeleton):
         return False
     if not _unknown_repo_push_gate_enabled():
         return False
@@ -142,12 +191,13 @@ def handle_block_unknown_repo_push(data: dict) -> bool:
     2. the gate is enabled (``[teatree] unknown_repo_push_gate_enabled``,
         default True) and no per-call ``[scope-push-ok: <reason>]`` token is
         present;
-    3. the cwd resolves to a directory, and
-    4. the cwd repo is classified ``require_approval`` — i.e. some overlay
+    3. the push's LANDING dir resolves (:func:`_push_target_dir` — ``git -C``,
+        a leading ``cd``, ``--git-dir``, else the ambient cwd), and
+    4. that repo is classified ``require_approval`` — i.e. some overlay
         opted into scope gating yet NO overlay owns its ``(host, namespace)``.
 
     Every other case ALLOWS: a non-push command, a dry-run, an unresolvable
-    cwd, no opted-in overlay, or a repo some overlay owns. The deny routes
+    target, no opted-in overlay, or a repo some overlay owns. The deny routes
     through :func:`_fail_open_or_deny` so the self-rescue allowlist + master
     fail-open switch + circuit breaker all apply (never-lockout).
     """
@@ -155,9 +205,9 @@ def handle_block_unknown_repo_push(data: dict) -> bool:
 
     if not _unknown_repo_push_is_in_scope(data):
         return False
-    cwd = _resolve_cwd_repo(data)
-    if cwd is None:
+    target = _push_target_dir(data.get("tool_input", {}).get("command", ""), _resolve_cwd_repo(data))
+    if target is None:
         return False
-    if _classify_push_for_cwd(cwd) != "require_approval":
+    if _classify_push_for_cwd(target) != "require_approval":
         return False
     return _fail_open_or_deny(data, _UNKNOWN_REPO_PUSH_REASON)

--- a/src/teatree/hooks/_repo_visibility.py
+++ b/src/teatree/hooks/_repo_visibility.py
@@ -7,9 +7,12 @@ private?" question and nothing about command classification:
 - the DB-home ``private_repos`` slug-namespace allowlist (the reliable,
     network-free, recommended mechanism), read from the canonical
     ``ConfigSetting`` store via the Django-free :mod:`teatree.config.cold_reader`,
-- the day-cached ``gh``/``glab`` live-visibility probe (best-effort
-    fallback; the binary is resolved against an augmented PATH so it works
-    inside the restricted PreToolUse subprocess), and
+- the cached ``gh``/``glab`` live-visibility probe (best-effort fallback; the
+    binary is resolved against an augmented PATH so it works inside the
+    restricted PreToolUse subprocess). The cache TTL is asymmetric by risk
+    (:func:`_verdict_ttl`): a PUBLIC verdict is held for a day, a non-public one
+    for minutes, since only a stale non-public verdict can skip the scan on a
+    now-public surface.
 - the slug resolution from a repo ``cwd``.
 
 Detection is conservative and offline-first; an unknown/unresolvable repo is
@@ -38,15 +41,25 @@ class _VisibilityEntry(TypedDict):
 # A slug must have at least ``owner/repo`` (host-prefixed slugs add more).
 _MIN_SLUG_PARTS: Final[int] = 2
 
-# How long a cached POSITIVE visibility verdict stays fresh. Repo visibility
-# changes rarely; a day-long cache keeps the offline path fast.
-_VISIBILITY_TTL_S: Final[int] = 24 * 60 * 60
+# How long a cached PUBLIC verdict stays fresh. Repo visibility changes rarely;
+# a day-long cache keeps the offline path fast. Staleness in this direction is
+# harmless -- a repo that went private is merely scanned as if it were still
+# public, which over-scans and never leaks.
+_PUBLIC_VERDICT: Final[str] = "PUBLIC"
+_PUBLIC_TTL_S: Final[int] = 24 * 60 * 60
+
+# How long a cached NON-PUBLIC verdict (PRIVATE, INTERNAL, ...) stays fresh.
+# Far shorter, because this is the only dangerous staleness direction: a
+# non-public verdict makes every leak gate SKIP the scan for that slug, so once
+# the operator flips the repo public, each minute the stale verdict survives is
+# a minute of unscanned public egress.
+_NON_PUBLIC_TTL_S: Final[int] = 15 * 60
 
 # Sentinel + TTL for a NEGATIVE cache entry: a probe that RAN but could not
 # resolve visibility (tool absent, auth differs, slug unrecognised). Without it,
 # every unresolved slug re-probes at the full 5s budget PER segment on every
 # publish, stacking toward the 30s hook ceiling. The negative entry is short-
-# lived (distinct from the 24h positive TTL) because an unresolvable repo may
+# lived (distinct from the 24h PUBLIC TTL) because an unresolvable repo may
 # become resolvable soon (auth fixed, tool installed).
 _UNKNOWN_VERDICT: Final[str] = "UNKNOWN"
 _UNKNOWN_TTL_S: Final[int] = 5 * 60
@@ -244,10 +257,16 @@ def _read_visibility_cache(slug: str) -> str | None:
     verdict = entry.get("visibility")
     if not isinstance(ts, (int, float)) or not isinstance(verdict, str):
         return None
-    ttl = _UNKNOWN_TTL_S if verdict == _UNKNOWN_VERDICT else _VISIBILITY_TTL_S
-    if time.time() - ts > ttl:
+    if time.time() - ts > _verdict_ttl(verdict):
         return None
     return verdict
+
+
+def _verdict_ttl(verdict: str) -> int:
+    """How long a cached ``verdict`` stays fresh, per its staleness risk."""
+    if verdict == _UNKNOWN_VERDICT:
+        return _UNKNOWN_TTL_S
+    return _PUBLIC_TTL_S if verdict == _PUBLIC_VERDICT else _NON_PUBLIC_TTL_S
 
 
 def _write_visibility_cache(slug: str, verdict: str) -> None:

--- a/tests/teatree_hooks/test_repo_visibility_probe.py
+++ b/tests/teatree_hooks/test_repo_visibility_probe.py
@@ -96,6 +96,39 @@ class TestNegativeVisibilityCaching:
         assert _repo_visibility._read_visibility_cache("github.com/octo/secret") == "PRIVATE"
 
 
+class TestNonPublicVerdictExpiresSooner:
+    """Only private→public staleness can leak, so a NON-PUBLIC verdict expires far sooner.
+
+    A cached ``PRIVATE`` makes every leak gate SKIP the scan for that slug. Once the
+    operator flips the repo public, that skip is an unscanned public egress — so the
+    verdict that authorises the skip must go stale in minutes, while a ``PUBLIC``
+    verdict (whose staleness only ever over-scans) keeps the day-long cache.
+    """
+
+    def test_private_verdict_expires_before_the_public_ttl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PRIVATE")
+        _repo_visibility.slug_visibility("github.com/octo/secret")
+        future = time.time() + _repo_visibility._NON_PUBLIC_TTL_S + 1
+        monkeypatch.setattr(_repo_visibility.time, "time", lambda: future)
+        assert _repo_visibility._read_visibility_cache("github.com/octo/secret") is None
+
+    def test_public_verdict_is_still_fresh_at_that_age(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        _repo_visibility.slug_visibility("github.com/octo/open")
+        future = time.time() + _repo_visibility._NON_PUBLIC_TTL_S + 1
+        monkeypatch.setattr(_repo_visibility.time, "time", lambda: future)
+        assert _repo_visibility._read_visibility_cache("github.com/octo/open") == "PUBLIC"
+
+    def test_a_flipped_repo_is_reprobed_within_the_short_ttl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The end-to-end consequence: the next publish after the flip reads PUBLIC, not the cached PRIVATE."""
+        verdicts = iter(["PRIVATE", "PUBLIC"])
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: next(verdicts))
+        assert _repo_visibility.slug_visibility("github.com/octo/flipped") == "PRIVATE"
+        future = time.time() + _repo_visibility._NON_PUBLIC_TTL_S + 1
+        monkeypatch.setattr(_repo_visibility.time, "time", lambda: future)
+        assert _repo_visibility.slug_visibility("github.com/octo/flipped") == "PUBLIC"
+
+
 class TestGitRemoteResolverTimeoutFailsSafe:
     """The git-remote origin resolver returns ``""`` on a timed-out ``git`` call."""
 

--- a/tests/test_consideration_gate_stop_hook.py
+++ b/tests/test_consideration_gate_stop_hook.py
@@ -351,7 +351,7 @@ class TestCrashProof:
         def _boom(_path: str) -> list[dict]:
             raise boom
 
-        monkeypatch.setattr("hooks.scripts.hook_router._read_transcript_entries", _boom)
+        monkeypatch.setattr("hooks.scripts.turn_inspect.read_transcript_entries", _boom)
 
         rv, out = _run_hook({"session_id": "s1", "transcript_path": "/tmp/nope.jsonl"}, monkeypatch)
 

--- a/tests/test_django_bootstrap_warn.py
+++ b/tests/test_django_bootstrap_warn.py
@@ -1,0 +1,60 @@
+# test-path: cross-cutting — tests hooks/scripts/django_bootstrap.py, which has no src/teatree/ mirror.
+"""A failed Django bootstrap must be AUDIBLE — a mute skip reads as a clean pass.
+
+``run-hook.sh`` deliberately falls back to a version-floor-only interpreter with
+no Django and prints nothing. On such a host every ORM-backed gate degrades to a
+silent allow, and an operator inspecting the session sees a clean run and
+concludes the gates passed. The bootstrap therefore names the missing capability
+once per process, and the gates that degrade on it say SKIPPED rather than
+nothing.
+"""
+
+import pytest
+
+from hooks.scripts import django_bootstrap
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(django_bootstrap, "_MISSING_CAPABILITY_WARNED", False)
+
+
+_NO_DJANGO = ModuleNotFoundError("No module named 'django'")
+
+
+def _break_django_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``django.setup()`` fail the way a Django-less interpreter does."""
+
+    def _boom() -> None:
+        raise _NO_DJANGO
+
+    monkeypatch.setattr(django_bootstrap, "_django_setup", _boom)
+
+
+class TestFailureIsAudible:
+    def test_failed_bootstrap_names_the_missing_capability(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _break_django_setup(monkeypatch)
+
+        assert django_bootstrap.bootstrap_teatree_django() is False
+
+        err = capsys.readouterr().err
+        assert "cannot import Django" in err
+        assert "No module named 'django'" in err
+
+    def test_the_warning_is_emitted_once_per_process(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _break_django_setup(monkeypatch)
+
+        django_bootstrap.bootstrap_teatree_django()
+        django_bootstrap.bootstrap_teatree_django()
+
+        assert capsys.readouterr().err.count("cannot import Django") == 1
+
+
+class TestSuccessIsSilent:
+    def test_successful_bootstrap_says_nothing(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert django_bootstrap.bootstrap_teatree_django() is True
+        assert capsys.readouterr().err == ""

--- a/tests/test_hook_router_unknown_repo_push.py
+++ b/tests/test_hook_router_unknown_repo_push.py
@@ -117,6 +117,39 @@ class TestBlocksUnknownRepoPush:
         assert deny["permissionDecision"] == "deny"
         assert "owned_repos" in deny["permissionDecisionReason"]
 
+    def test_git_dash_c_push_is_classified_by_the_named_repo(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``git -C <dir> push`` names the repo; the ambient cwd does not."""
+        owned = _repo_with_remote(tmp_path / "session", "git@github.com:souliane/teatree.git")
+        unknown = _repo_with_remote(tmp_path / "elsewhere", "git@github.com:randomuser/randomrepo.git")
+        event = _push_event(f"git -C {unknown} push origin main", owned)
+        assert router.handle_block_unknown_repo_push(event) is True
+        assert _parse_deny(capsys) is not None
+
+    def test_cd_prefixed_push_is_classified_by_the_cd_target(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        owned = _repo_with_remote(tmp_path / "session2", "git@github.com:souliane/teatree.git")
+        unknown = _repo_with_remote(tmp_path / "elsewhere2", "git@github.com:randomuser/randomrepo.git")
+        event = _push_event(f"cd {unknown} && git push origin main", owned)
+        assert router.handle_block_unknown_repo_push(event) is True
+        assert _parse_deny(capsys) is not None
+
+    def test_dash_c_push_to_an_owned_repo_is_allowed(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """The other direction: the named repo is owned even though the session sits elsewhere."""
+        unknown = _repo_with_remote(tmp_path / "session3", "git@github.com:randomuser/randomrepo.git")
+        owned = _repo_with_remote(tmp_path / "elsewhere3", "git@github.com:souliane/teatree.git")
+        event = _push_event(f"git -C {owned} push origin main", unknown)
+        assert router.handle_block_unknown_repo_push(event) is False
+        assert _parse_deny(capsys) is None
+
+    def test_push_inside_a_quoted_string_is_not_a_push(self, tmp_path: Path) -> None:
+        """The verb is read off the quote-stripped skeleton, as in every sibling gate."""
+        repo = _repo_with_remote(tmp_path / "quoted", "git@github.com:randomuser/randomrepo.git")
+        event = _push_event("git commit -m 'do not git push this yet'", repo)
+        assert router.handle_block_unknown_repo_push(event) is False
+
     def test_non_push_command_is_ignored(self, tmp_path: Path) -> None:
         repo = _repo_with_remote(tmp_path / "unknown2", "git@github.com:randomuser/randomrepo.git")
         assert router.handle_block_unknown_repo_push(_push_event("git status", repo)) is False
@@ -124,6 +157,48 @@ class TestBlocksUnknownRepoPush:
     def test_dry_run_push_is_ignored(self, tmp_path: Path) -> None:
         repo = _repo_with_remote(tmp_path / "unknown3", "git@github.com:randomuser/randomrepo.git")
         assert router.handle_block_unknown_repo_push(_push_event("git push --dry-run origin HEAD", repo)) is False
+
+    def test_dash_c_dry_run_push_is_ignored(self, tmp_path: Path) -> None:
+        repo = _repo_with_remote(tmp_path / "unknown4", "git@github.com:randomuser/randomrepo.git")
+        event = _push_event(f"git -C {repo} push --dry-run origin HEAD", repo)
+        assert router.handle_block_unknown_repo_push(event) is False
+
+
+class TestDegradedPathIsAudible:
+    """An allow the gate could not actually evaluate must not read like a cleared push."""
+
+    def test_missing_django_says_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = _repo_with_remote(tmp_path / "nodjango", "git@github.com:randomuser/randomrepo.git")
+        monkeypatch.setattr(scope_gate, "bootstrap_teatree_django", lambda: False)
+
+        assert router.handle_block_unknown_repo_push(_push_event("git push origin HEAD", repo)) is False
+
+        assert "SKIPPED is not PASSED" in capsys.readouterr().err
+
+    def test_broken_resolver_says_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = _repo_with_remote(tmp_path / "brokenresolver", "git@github.com:randomuser/randomrepo.git")
+
+        registry_down = RuntimeError("overlay registry unavailable")
+
+        def _boom(_cwd: Path) -> str:
+            raise registry_down
+
+        monkeypatch.setattr("teatree.core.gates.owned_repo_guard.classify_active_push", _boom)
+
+        assert router.handle_block_unknown_repo_push(_push_event("git push origin HEAD", repo)) is False
+
+        assert "SKIPPED is not PASSED" in capsys.readouterr().err
+
+    def test_a_cleared_push_stays_silent(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        repo = _repo_with_remote(tmp_path / "cleared", "git@github.com:souliane/teatree.git")
+
+        assert router.handle_block_unknown_repo_push(_push_event("git push origin HEAD", repo)) is False
+
+        assert "SKIPPED is not PASSED" not in capsys.readouterr().err
 
 
 class TestNeverLockout:

--- a/tests/test_hooks_shared_resolver_fitness.py
+++ b/tests/test_hooks_shared_resolver_fitness.py
@@ -1,0 +1,109 @@
+# test-path: cross-cutting — a fitness test over hooks/scripts/, which has no src/teatree/ mirror.
+"""Extraction out of the router must be SUBTRACTIVE, not duplicative.
+
+``hook_router`` is shrink-only and 11x over the module-health LOC cap, so logic
+keeps being split into siblings. Each split has been copying the helper at its
+then-current correctness instead of importing it back, and the copies then drift
+apart with no arbiter:
+
+The transcript turn-boundary walk existed in ``question_gates`` (fixed to walk
+past a ``tool_result`` entry) and again in ``turn_inspect`` (not fixed), which
+left the consideration Stop gate inert on every tool-using turn. The
+commit-target resolver existed as ``_commit_repo_dir.resolve_commit_dir`` (used
+by three gates) and again as a bare ambient-cwd read in the unknown-repo push
+gate, which classified the session's repo rather than the pushed one.
+
+These two assertions are the arbiter the copies lacked. They read source, not
+behaviour, because the failure mode is a NEW copy — which by construction no
+behavioural test covers yet.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_HOOK_SCRIPTS = Path(__file__).resolve().parent.parent / "hooks" / "scripts"
+
+#: The gates that decide WHICH repo a git command writes to. Each must ask the
+#: one canonical static resolver. The roster is explicit because reading the
+#: ambient cwd is legitimate elsewhere — the banned-terms and quote gates pass it
+#: as an INPUT to a resolver rather than using it as the answer.
+_GIT_TARGET_GATES: tuple[str, ...] = (
+    "main_clone_guard.py",
+    "single_branch_repo_guard.py",
+    "headless_authoring_gate.py",
+    "unknown_repo_push_gate.py",
+)
+
+
+def _hook_modules() -> list[Path]:
+    return sorted(_HOOK_SCRIPTS.rglob("*.py"))
+
+
+def _names_used(node: ast.AST) -> set[str]:
+    return {sub.id for sub in ast.walk(node) if isinstance(sub, ast.Name)} | {
+        sub.attr for sub in ast.walk(node) if isinstance(sub, ast.Attribute)
+    }
+
+
+def _is_turn_boundary_walk(func: ast.FunctionDef) -> bool:
+    """Whether *func* walks a transcript newest→oldest and STOPS at a ``user`` entry.
+
+    The three marks together: a ``reversed(...)`` loop, a comparison against the
+    ``"user"`` role, and a ``break`` that ends the turn there. A phase-partition
+    walk with role cursors (no ``break``) is a different shape and is not claimed.
+    """
+    has_reversed_loop = any(
+        isinstance(sub, ast.For)
+        and isinstance(sub.iter, ast.Call)
+        and isinstance(sub.iter.func, ast.Name)
+        and sub.iter.func.id == "reversed"
+        for sub in ast.walk(func)
+    )
+    compares_user = any(
+        isinstance(sub, ast.Constant) and sub.value == "user" for sub in ast.walk(func) if isinstance(sub, ast.Constant)
+    )
+    breaks = any(isinstance(sub, ast.Break) for sub in ast.walk(func))
+    return has_reversed_loop and compares_user and breaks
+
+
+def _turn_boundary_walks() -> list[tuple[Path, ast.FunctionDef]]:
+    found: list[tuple[Path, ast.FunctionDef]] = []
+    for path in _hook_modules():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        found += [
+            (path, node)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and _is_turn_boundary_walk(node)
+        ]
+    return found
+
+
+class TestOneTurnBoundaryPredicate:
+    def test_the_walks_exist_at_all(self) -> None:
+        """Guards the detector itself: an assertion over an empty set proves nothing."""
+        assert _turn_boundary_walks(), "no turn-boundary walk found — the AST detector no longer matches"
+
+    def test_every_walk_consumes_the_shared_tool_result_predicate(self) -> None:
+        offenders = [
+            f"{path.name}:{func.name}"
+            for path, func in _turn_boundary_walks()
+            if "is_tool_result_only" not in _names_used(func)
+        ]
+        assert not offenders, (
+            "a transcript walk ends the turn at a `user` entry without asking "
+            f"`question_gates.is_tool_result_only`: {offenders}. A tool RESULT is a `user` "
+            "entry, so such a walk cuts the turn at its first tool call and projects nothing."
+        )
+
+
+class TestOneCommitTargetResolver:
+    @pytest.mark.parametrize("module", _GIT_TARGET_GATES)
+    def test_git_target_gate_uses_the_canonical_resolver(self, module: str) -> None:
+        source = (_HOOK_SCRIPTS / module).read_text(encoding="utf-8")
+        assert "resolve_commit_dir" in source, (
+            f"{module} decides which repo a git command writes to, so it must resolve that dir "
+            "through `teatree.hooks._commit_repo_dir.resolve_commit_dir` — the ambient cwd is the "
+            "SESSION's repo, and a session commits and pushes elsewhere all day."
+        )

--- a/tests/test_mcp_slack_write_guard_hook.py
+++ b/tests/test_mcp_slack_write_guard_hook.py
@@ -50,6 +50,29 @@ class TestDeniesSlackMcpWrites:
         assert "t3" in json.dumps(deny)
 
 
+class TestDeniesUnrecognisedSlackTools:
+    """An unrecognised Slack MCP tool is a WRITE until its READ shape is recognised.
+
+    Every one of these carries no write verb, so the old verb-substring
+    classifier passed them through — a channel created and a canvas published
+    under the user's OAuth identity, outside the egress chokepoint.
+    """
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            "mcp__claude_ai_Slack__slack_create_conversation",
+            "mcp__claude_ai_Slack__slack_create_canvas",
+            "mcp__slack__conversations_invite",
+            "mcp__slack__slack_pin_message",
+            "mcp__slack__admin_conversations_archive",
+        ],
+    )
+    def test_unrecognised_slack_tool_is_denied(self, tool_name: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_mcp_slack_write(_event(tool_name)) is True
+        assert _parse_deny(capsys) is not None
+
+
 class TestAllowsReadsAndNonSlack:
     @pytest.mark.parametrize(
         "tool_name",
@@ -58,6 +81,11 @@ class TestAllowsReadsAndNonSlack:
             "mcp__slack__conversations_list",
             "mcp__slack__search_messages",
             "mcp__slack__slack_get_users",
+            "mcp__slack__conversationsHistory",
+            "mcp__slack__users_info",
+            # A pure READ whose noun happens to carry a write verb — the
+            # substring classifier blocked it and pointed at no CLI equivalent.
+            "mcp__claude_ai_Slack__slack_get_reactions",
             "mcp__glab__glab_mr_create",
             "mcp__notion__create_page",
             "Bash",
@@ -73,6 +101,9 @@ class TestClassifier:
         assert is_slack_mcp_write("mcp__slack__slack_send_message") is True
         assert is_slack_mcp_write("mcp__slack__slack_get_channel_history") is False
         assert is_slack_mcp_write("mcp__glab__glab_mr_create") is False
+
+    def test_unknown_slack_tool_fails_closed(self) -> None:
+        assert is_slack_mcp_write("mcp__slack__slack_frobnicate_workspace") is True
 
 
 class TestNeverLockout:

--- a/tests/test_turn_inspect.py
+++ b/tests/test_turn_inspect.py
@@ -1,0 +1,135 @@
+# test-path: cross-cutting — tests hooks/scripts/turn_inspect.py, which has no src/teatree/ mirror.
+"""Turn-boundary projections read by the consideration and closure-reverify Stop gates.
+
+A tool RESULT is recorded as a ``user`` entry whose blocks are all ``tool_result``,
+so a walk that stops at the FIRST ``user`` entry cuts the turn at the first tool
+call — and every real tool-using turn then projects to nothing, leaving the
+consideration gate inert and the closure-reverify gate unable to see the
+verification command that clears it. These fixtures put a ``tool_result`` entry
+between the tool use and the final assistant text, which is the shape the defect
+lives in.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hooks.scripts.turn_inspect import current_turn_assistant_text, current_turn_edits, current_turn_tool_commands
+
+
+def _write_transcript(tmp_path: Path, entries: list[dict[str, Any]]) -> str:
+    path = tmp_path / "transcript.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+    return str(path)
+
+
+def _user_turn(text: str = "do the thing") -> dict[str, Any]:
+    return {"type": "user", "message": {"role": "user", "content": text}}
+
+
+def _tool_result(tool_use_id: str = "toolu_1") -> dict[str, Any]:
+    """The entry the harness writes back after a tool runs — a ``user`` entry that is not the user."""
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": tool_use_id, "content": "ok"}],
+        },
+    }
+
+
+def _assistant_tool_use(name: str, tool_input: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "tool_use", "name": name, "input": tool_input}]},
+    }
+
+
+def _assistant_text(text: str) -> dict[str, Any]:
+    return {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": text}]}}
+
+
+def _tool_using_turn(tmp_path: Path) -> str:
+    """The real shape of a tool-using turn: prompt, tool_use, tool_result, final text."""
+    return _write_transcript(
+        tmp_path,
+        [
+            _user_turn("earlier prompt"),
+            _assistant_text("earlier answer"),
+            _user_turn(),
+            _assistant_tool_use("Edit", {"file_path": "/tmp/agent-settings.json", "new_string": "x"}),
+            _tool_result(),
+            _assistant_tool_use("Bash", {"command": "gh pr view 4217", "description": "check the PR"}),
+            _tool_result("toolu_2"),
+            _assistant_text("closed #4217"),
+        ],
+    )
+
+
+class TestWalksPastToolResults:
+    def test_edits_before_a_tool_result_are_seen(self, tmp_path: Path) -> None:
+        assert current_turn_edits(_tool_using_turn(tmp_path)) == ["/tmp/agent-settings.json"]
+
+    def test_tool_commands_before_a_tool_result_are_seen(self, tmp_path: Path) -> None:
+        commands = current_turn_tool_commands(_tool_using_turn(tmp_path))
+        assert "gh pr view 4217" in commands
+        assert "check the PR" in commands
+
+    def test_assistant_text_before_a_tool_result_is_seen(self, tmp_path: Path) -> None:
+        text = current_turn_assistant_text(_tool_using_turn(tmp_path))
+        assert "closed #4217" in text
+        assert "earlier answer" not in text
+
+
+class TestStopsAtTheGenuineUserBoundary:
+    """The previous turn stays out — the boundary moved past tool results, not past the user."""
+
+    def test_prior_turn_edit_is_excluded(self, tmp_path: Path) -> None:
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_turn("earlier prompt"),
+                _assistant_tool_use("Write", {"file_path": "/tmp/prior-turn.txt", "content": "x"}),
+                _user_turn(),
+                _assistant_tool_use("Write", {"file_path": "/tmp/this-turn.txt", "content": "x"}),
+                _tool_result(),
+                _assistant_text("done"),
+            ],
+        )
+        assert current_turn_edits(transcript) == ["/tmp/this-turn.txt"]
+
+    def test_prior_turn_command_is_excluded(self, tmp_path: Path) -> None:
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user_turn("earlier prompt"),
+                _assistant_tool_use("Bash", {"command": "gh pr view 1"}),
+                _user_turn(),
+                _assistant_tool_use("Bash", {"command": "gh pr view 2"}),
+                _tool_result(),
+                _assistant_text("done"),
+            ],
+        )
+        assert current_turn_tool_commands(transcript) == ["gh pr view 2"]
+
+
+class TestDegradedInputs:
+    def test_missing_transcript_yields_empty(self, tmp_path: Path) -> None:
+        missing = str(tmp_path / "absent.jsonl")
+        assert current_turn_edits(missing) == []
+        assert current_turn_tool_commands(missing) == []
+        assert current_turn_assistant_text(missing) == ""
+
+    def test_empty_user_content_still_ends_the_turn(self, tmp_path: Path) -> None:
+        """An empty-content user entry is not a tool result, so it stays a boundary."""
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _assistant_tool_use("Write", {"file_path": "/tmp/prior.txt", "content": "x"}),
+                {"type": "user", "message": {"role": "user", "content": []}},
+                _assistant_text("done"),
+            ],
+        )
+        assert current_turn_edits(transcript) == []

--- a/tests/test_unknown_repo_push_gate_subprocess.py
+++ b/tests/test_unknown_repo_push_gate_subprocess.py
@@ -89,11 +89,13 @@ def home_with_opt_in() -> Iterator[Path]:
         yield home
 
 
-def _drive_push(repo: Path, home: Path) -> subprocess.CompletedProcess[str]:
+def _drive_push(
+    repo: Path, home: Path, command: str = "git push origin HEAD", cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
     payload = {
         "tool_name": "Bash",
-        "tool_input": {"command": "git push origin HEAD"},
-        "cwd": str(repo),
+        "tool_input": {"command": command},
+        "cwd": str(cwd if cwd is not None else repo),
         "session_id": "subproc-scope-live",
     }
     code = _DRIVER.format(payload=json.dumps(payload))
@@ -123,6 +125,22 @@ def test_unknown_repo_push_denies_in_the_real_subprocess(tmp_path: Path, home_wi
     decision = json.loads(result.stdout)
     assert decision["permissionDecision"] == "deny"
     assert "owned_repos" in decision["permissionDecisionReason"]
+
+
+def test_dash_c_push_denies_in_the_real_subprocess(tmp_path: Path, home_with_opt_in: Path) -> None:
+    """The landing-dir resolver must reach the un-bootstrapped subprocess too.
+
+    ``git -C <unknown> push`` from an OWNED session cwd: the target repo decides,
+    and resolving it imports ``teatree.hooks._commit_repo_dir`` in a process where
+    ``teatree`` is only importable via the gate's own src-path insert.
+    """
+    unknown = _repo_with_remote(tmp_path / "dashc-unk", "git@github.com:randomuser/randomrepo.git")
+    session = _repo_with_remote(tmp_path / "dashc-own", "git@github.com:souliane/teatree.git")
+    result = _drive_push(unknown, home_with_opt_in, command=f"git -C {unknown} push origin main", cwd=session)
+    assert result.returncode == 2, (
+        "a `git -C <unknown-repo> push` must DENY on the TARGET repo, not the session cwd; "
+        f"got exit {result.returncode}, stdout={result.stdout!r}, stderr={result.stderr!r}"
+    )
 
 
 def test_owned_repo_push_allows_in_the_real_subprocess(tmp_path: Path, home_with_opt_in: Path) -> None:


### PR DESCRIPTION
fix(hooks): unfork the turn walk, the push target, and the Slack read/write split

## What
Five findings from the 2026-08-05 holistic review, all one class: a gate that
reads as passing while it never evaluated anything.

turn_inspect's three transcript walks broke at the first role=user entry — which
a tool_result IS — so on every tool-using turn (i.e. every real turn) the
consideration gate saw no edits and the closure-reverify gate saw no verification
commands. The three walks collapse into one that consumes question_gates'
is_tool_result_only, the same predicate that fixed last_assistant_turn.

The Slack MCP write guard classified by write-verb substring, so
slack_create_conversation / slack_create_canvas were undenied writes while the
read slack_get_reactions was blocked. It is now an enumerated READ roster with
default-DENY, so a Slack surface the roster predates fails closed.

The unknown-repo push SCOPE gate required "git push" adjacent, so
"git -C <dir> push" never reached it, and it classified the ambient cwd rather
than the repo being pushed. It now reads the verb off the quote-stripped
skeleton at a command position and resolves the target through the canonical
resolve_commit_dir.

A failed Django bootstrap returned a bare False with no diagnostic; it now names
the missing capability once per process, and the push gate's degraded allow says
SKIPPED through gate_result.warn_gate_skipped.

A PRIVATE repo-visibility verdict was cached as long as a PUBLIC one, so for a
day after a repo went public every leak gate skipped it. Non-public verdicts now
expire in minutes; only that direction can leak.

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.