### PR TITLE
fix(core): key the merge joins on the repo slug, gate both merge paths, stop doctor mutating on a plain run

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3104,9 +3104,10 @@ Usage: t3 doctor check [OPTIONS]
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --repair                   Allow doctor to APPLY fixes that mutate state:    │
 │                            re-point a relocated/hijacked t3 editable install │
-│                            (#3231) AND clear a stale entrypoint-seeded       │
-│                            provision_max_concurrency pin (#3434). A plain    │
-│                            run never mutates.                                │
+│                            (#3231), clear a stale entrypoint-seeded          │
+│                            provision_max_concurrency pin (#3434), and        │
+│                            re-register the t3 Claude plugin. A plain run     │
+│                            never mutates.                                    │
 │ --slack-roundtrip          Deep Slack round-trip: additionally run a LIVE    │
 │                            auth.test per Slack backend (#3411).              │
 │ --json                     Emit findings as JSON for the watchdog container. │
@@ -10692,13 +10693,11 @@ Usage: t3 teatree ticket e2e-bypass [OPTIONS] TICKET_ID
 │ *    ticket_id      INTEGER  [required]                                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ *  --approver        TEXT  Human user id authorising the bypass; a           │
-│                            maker/coding-agent/loop id is refused (#1967).    │
-│                            [required]                                        │
-│ *  --head-sha        TEXT  Full 40-char hex SHA of the reviewed tree the     │
-│                            bypass authorises.                                │
-│                            [required]                                        │
-│    --help                  Show this message and exit.                       │
+│ --approver        TEXT  Human user id authorising the bypass; a              │
+│                         maker/coding-agent/loop id is refused (#1967).       │
+│ --head-sha        TEXT  Full 40-char hex SHA of the reviewed tree the bypass │
+│                         authorises.                                          │
+│ --help                  Show this message and exit.                          │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -10741,11 +10740,10 @@ Usage: t3 teatree ticket dod-override [OPTIONS] TICKET_ID
 │ *    ticket_id      INTEGER  [required]                                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ *  --reason        TEXT  Why this UI-visible ticket may ship without a       │
-│                          local-stack E2E (#88).                              │
-│                          [required]                                          │
-│    --by            TEXT  Who is recording the override (audit trail).        │
-│    --help                Show this message and exit.                         │
+│ --reason        TEXT  Why this UI-visible ticket may ship without a          │
+│                       local-stack E2E (#88).                                 │
+│ --by            TEXT  Who is recording the override (audit trail).           │
+│ --help                Show this message and exit.                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -12205,17 +12203,14 @@ Usage: t3 teatree notify send [OPTIONS] BODY
 │                      [required]                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ *  --idempotency-key        TEXT  Required dedupe key (the helper enforces   │
-│                                   it).                                       │
-│                                   [required]                                 │
-│    --user-id                TEXT  Slack user id to DM (defaults to the       │
-│                                   configured user).                          │
-│    --kind                   TEXT  Notification kind: info | answer |         │
-│                                   question.                                  │
-│                                   [default: info]                            │
-│    --overlay                TEXT  Set T3_OVERLAY_NAME for the call           │
-│                                   (per-overlay bot routing).                 │
-│    --help                         Show this message and exit.                │
+│ --idempotency-key        TEXT  Required dedupe key (the helper enforces it). │
+│ --user-id                TEXT  Slack user id to DM (defaults to the          │
+│                                configured user).                             │
+│ --kind                   TEXT  Notification kind: info | answer | question.  │
+│                                [default: info]                               │
+│ --overlay                TEXT  Set T3_OVERLAY_NAME for the call (per-overlay │
+│                                bot routing).                                 │
+│ --help                         Show this message and exit.                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -12228,17 +12223,15 @@ Usage: t3 teatree notify post [OPTIONS]
  (exit 0 on ``ok``).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ *  --channel          TEXT  Destination: the user's own DM (→bot) or a       │
-│                             colleague/channel (→xoxp).                       │
-│                             [required]                                       │
-│ *  --text             TEXT  Slack mrkdwn body. Use ``-`` to read the body    │
-│                             from stdin.                                      │
-│                             [required]                                       │
-│    --thread-ts        TEXT  Thread ``ts`` to reply into (omit to post a new  │
-│                             top-level message).                              │
-│    --overlay          TEXT  Set T3_OVERLAY_NAME for the call (per-overlay    │
-│                             credentials).                                    │
-│    --help                   Show this message and exit.                      │
+│ --channel          TEXT  Destination: the user's own DM (→bot) or a          │
+│                          colleague/channel (→xoxp).                          │
+│ --text             TEXT  Slack mrkdwn body. Use ``-`` to read the body from  │
+│                          stdin.                                              │
+│ --thread-ts        TEXT  Thread ``ts`` to reply into (omit to post a new     │
+│                          top-level message).                                 │
+│ --overlay          TEXT  Set T3_OVERLAY_NAME for the call (per-overlay       │
+│                          credentials).                                       │
+│ --help                   Show this message and exit.                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -12251,16 +12244,13 @@ Usage: t3 teatree notify react [OPTIONS]
  colleague/channel→xoxp (exit 0 on ``ok``).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ *  --channel        TEXT  Destination the message is in: self-DM (bot) or    │
-│                           colleague/channel (xoxp).                          │
-│                           [required]                                         │
-│ *  --ts             TEXT  Timestamp ``ts`` of the message to react to.       │
-│                           [required]                                         │
-│ *  --emoji          TEXT  Emoji name (with or without surrounding colons).   │
-│                           [required]                                         │
-│    --overlay        TEXT  Set T3_OVERLAY_NAME for the call (per-overlay      │
-│                           credentials).                                      │
-│    --help                 Show this message and exit.                        │
+│ --channel        TEXT  Destination the message is in: self-DM (bot) or       │
+│                        colleague/channel (xoxp).                             │
+│ --ts             TEXT  Timestamp ``ts`` of the message to react to.          │
+│ --emoji          TEXT  Emoji name (with or without surrounding colons).      │
+│ --overlay        TEXT  Set T3_OVERLAY_NAME for the call (per-overlay         │
+│                        credentials).                                         │
+│ --help                 Show this message and exit.                           │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/doctor/app.py
+++ b/src/teatree/cli/doctor/app.py
@@ -216,8 +216,9 @@ def check(
         "--repair",
         help=(
             "Allow doctor to APPLY fixes that mutate state: re-point a relocated/hijacked "
-            "t3 editable install (#3231) AND clear a stale entrypoint-seeded "
-            "provision_max_concurrency pin (#3434). A plain run never mutates."
+            "t3 editable install (#3231), clear a stale entrypoint-seeded "
+            "provision_max_concurrency pin (#3434), and re-register the t3 Claude plugin. "
+            "A plain run never mutates."
         ),
     ),
     slack_roundtrip: bool = typer.Option(
@@ -405,12 +406,18 @@ def _run_config_posture_advisories() -> None:
     _check_config_rows_shadowing_shipped_defaults()
 
 
-def _run_advisory_finalisers() -> None:
-    """Surfacing-only passes that never gate the exit code."""
+def _run_advisory_finalisers(*, repair: bool) -> None:
+    """Surfacing-only passes that never gate the exit code.
+
+    ``repair`` reaches the plugin-registration pass because it WRITES: a plain run
+    reports the drift and touches nothing, honouring ``--repair``'s own promise that
+    "a plain run never mutates" — this pass used to rewrite the operator's
+    ``~/.claude/settings.json`` on every session start regardless.
+    """
     _check_singletons()
     _check_legacy_overlay_alias()
     report_missing_authorizations(typer.echo)
-    _ensure_plugin_registered()
+    _ensure_plugin_registered(repair=repair)
 
 
 def run_doctor_checks(*, repair: bool = False, slack_roundtrip: bool = False) -> bool:
@@ -651,7 +658,7 @@ def run_doctor_checks(*, repair: bool = False, slack_roundtrip: bool = False) ->
     # connectivity gate — it reuses the same live `claude mcp list` probe.
     _check_teatree_mcp_registration()
 
-    _run_advisory_finalisers()
+    _run_advisory_finalisers(repair=repair)
 
     if ok:
         typer.echo("All checks passed")

--- a/src/teatree/cli/doctor/checks_db_integrity.py
+++ b/src/teatree/cli/doctor/checks_db_integrity.py
@@ -196,6 +196,12 @@ def _check_host_projection_is_current() -> bool:
     The source generation is read from the database FILE rather than through the ORM,
     because the file is what the publisher projects from: comparing against whichever
     connection happens to be open would answer about a different database.
+
+    A source that cannot be read FAILs. The faults that make it unreadable — a long
+    writer holding the lock, a WAL recovery in progress — are the same ones that stop
+    the publisher, so returning quietly reported the projection as current on exactly
+    the failure this check exists to catch, and emitted no line for the JSON finding
+    parser to see either. An unreadable source is not evidence of a current projection.
     """
     path = _sqlite_path()
     if path is None or not path.exists():
@@ -204,8 +210,14 @@ def _check_host_projection_is_current() -> bool:
     published = ProjectionReader(projection_dir_for(path)).read().projection
     try:
         expected = ProjectionPublisher(path, projection_dir_for(path)).build().generation
-    except sqlite3.Error:
-        return True
+    except sqlite3.Error as exc:
+        typer.secho(
+            f"FAIL  Host projection: could not read the source generation from {path} ({exc}). "
+            "Whether the projection is current is unknown, so every Claude Code hook reading a "
+            "DB-home setting without Django may be serving values this generation did not produce.",
+            fg=typer.colors.RED,
+        )
+        return False
     if published is not None and published.generation == expected:
         typer.secho(
             f"OK    Host projection: current at generation {expected}",

--- a/src/teatree/cli/doctor/plugin_repair.py
+++ b/src/teatree/cli/doctor/plugin_repair.py
@@ -1,15 +1,17 @@
 """Plugin marketplace + registration repair helpers used by `t3 doctor check`.
 
-Split out of ``teatree.cli.doctor`` (souliane/teatree#1270). These helpers
-auto-repair the Claude plugin registration (`known_marketplaces.json`,
-`installed_plugins.json`, `enabledPlugins` in `settings.json`) on every
-`t3 doctor check`. Kept private — re-exported from ``teatree.cli.doctor``
-for backward compatibility with existing test imports.
+Split out of ``teatree.cli.doctor`` (souliane/teatree#1270). These helpers repair
+the Claude plugin registration (`known_marketplaces.json`, `installed_plugins.json`,
+`enabledPlugins` in `settings.json`), and they WRITE only under ``--repair``: a plain
+`t3 doctor check` reports the drift and touches nothing, as ``--repair``'s own help
+text promises. Kept private — re-exported from ``teatree.cli.doctor`` for backward
+compatibility with existing test imports.
 """
 
 import json
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 import typer
@@ -17,13 +19,24 @@ import typer
 _CLAUDE_PLUGIN_ID = "t3@souliane"
 
 
-def _read_json_safe(path: Path) -> dict:
+class UnparsableJson:
+    """Sentinel: the file exists but is not readable JSON, so its content is UNKNOWN.
+
+    Distinct from the empty dict an ABSENT file yields. Collapsing the two let a
+    momentarily-unparsable ``~/.claude/settings.json`` (Claude Code mid-write, a
+    truncated write, a trailing comma the operator just typed) read as "no keys set",
+    so the repair below rewrote the operator's whole configuration — permissions,
+    hooks, env, statusLine — as a one-key file.
+    """
+
+
+def _read_json_safe(path: Path) -> "dict | type[UnparsableJson]":
     if not path.is_file():
         return {}
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
-        return {}
+        return UnparsableJson
 
 
 def _resolve_main_clone() -> Path | None:
@@ -50,28 +63,56 @@ def _resolve_main_clone() -> Path | None:
     return repo
 
 
-def _repair_marketplace_json(plugins_dir: Path, target: str, now: str) -> bool:
+@dataclass(frozen=True, slots=True)
+class RegistrationOutcome:
+    """What one registration artifact needed, and whether this run wrote it.
+
+    An empty *detail* means the artifact already names the expected clone. A detail
+    with ``written=False`` is drift this run deliberately did not touch — either
+    because ``--repair`` was not given, or because the file could not be read and
+    writing it would replace its whole content.
+    """
+
+    detail: str = ""
+    written: bool = False
+
+
+def _unreadable(path: Path) -> RegistrationOutcome:
+    return RegistrationOutcome(f"{path} is not readable JSON — refusing to write over it")
+
+
+def _repair_marketplace_json(plugins_dir: Path, target: str, now: str, *, repair: bool = False) -> RegistrationOutcome:
+    """Reconcile the marketplace registration against *target*; write only under *repair*."""
     path = plugins_dir / "known_marketplaces.json"
     data = _read_json_safe(path)
+    if not isinstance(data, dict):
+        return _unreadable(path)
     mp_name = _CLAUDE_PLUGIN_ID.split("@", 1)[1]
     if data.get(mp_name, {}).get("installLocation") == target:
-        return False
+        return RegistrationOutcome()
+    if not repair:
+        return RegistrationOutcome(f"{path} does not install {mp_name} from {target}")
     data[mp_name] = {
         "source": {"source": "directory", "path": target},
         "installLocation": target,
         "lastUpdated": now,
     }
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    return True
+    return RegistrationOutcome(f"repaired {path}", written=True)
 
 
-def _repair_installed_plugins(plugins_dir: Path, target: str, now: str) -> bool:
+def _repair_installed_plugins(plugins_dir: Path, target: str, now: str, *, repair: bool = False) -> RegistrationOutcome:
+    """Reconcile the installed-plugins entry against *target*; write only under *repair*."""
     path = plugins_dir / "installed_plugins.json"
     data = _read_json_safe(path)
+    if not isinstance(data, dict):
+        return _unreadable(path)
     plugins = data.setdefault("plugins", {})
     entries = plugins.get(_CLAUDE_PLUGIN_ID, [])
     if entries and entries[0].get("installPath") == target:
-        return False
+        return RegistrationOutcome()
+    if not repair:
+        return RegistrationOutcome(f"{path} does not install {_CLAUDE_PLUGIN_ID} from {target}")
     data.setdefault("version", 2)
     plugins[_CLAUDE_PLUGIN_ID] = [
         {
@@ -84,34 +125,45 @@ def _repair_installed_plugins(plugins_dir: Path, target: str, now: str) -> bool:
     ]
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    return True
+    return RegistrationOutcome(f"repaired {path}", written=True)
 
 
-def _repair_enabled_plugins() -> bool:
+def _repair_enabled_plugins(*, repair: bool = False) -> RegistrationOutcome:
+    """Reconcile ``enabledPlugins`` in the operator's own ``~/.claude/settings.json``.
+
+    The riskiest of the three: that file also carries permissions, hooks, env and the
+    statusLine block, and it is the operator's, not teatree's. An unparsable read is
+    reported and never written over — a ``{}`` stand-in would have replaced the whole
+    file with a single ``enabledPlugins`` key.
+    """
     settings_path = Path.home() / ".claude" / "settings.json"
     resolved = settings_path.resolve() if settings_path.is_file() else settings_path
     data = _read_json_safe(resolved)
+    if not isinstance(data, dict):
+        return _unreadable(resolved)
     enabled = data.setdefault("enabledPlugins", {})
     if enabled.get(_CLAUDE_PLUGIN_ID) is True:
-        return False
+        return RegistrationOutcome()
+    if not repair:
+        return RegistrationOutcome(f"{resolved} does not enable {_CLAUDE_PLUGIN_ID}")
     enabled[_CLAUDE_PLUGIN_ID] = True
     resolved.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    return True
+    return RegistrationOutcome(f"repaired {resolved}", written=True)
 
 
-def _ensure_plugin_registered() -> bool:
-    """Verify and auto-repair t3 plugin registration.
+def _ensure_plugin_registered(*, repair: bool = False) -> bool:
+    """Verify t3 plugin registration, repairing it only under *repair*.
 
     Called at every ``t3 doctor check`` (and thus every Claude session start).
     Best-effort — never fails the check if the repo or filesystem is unavailable.
     """
     try:
-        return _do_ensure_plugin_registered()
+        return _do_ensure_plugin_registered(repair=repair)
     except OSError:
         return True
 
 
-def _do_ensure_plugin_registered() -> bool:
+def _do_ensure_plugin_registered(*, repair: bool = False) -> bool:
     repo = _resolve_main_clone()
     if not repo:
         return True
@@ -122,10 +174,16 @@ def _do_ensure_plugin_registered() -> bool:
     now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.000Z")
     plugins_dir = Path.home() / ".claude" / "plugins"
 
-    repaired = _repair_marketplace_json(plugins_dir, target, now)
-    repaired = _repair_installed_plugins(plugins_dir, target, now) or repaired
-    repaired = _repair_enabled_plugins() or repaired
-
-    if repaired:
-        typer.echo(f"OK    Auto-repaired {_CLAUDE_PLUGIN_ID} plugin → {target}")
+    outcomes = [
+        _repair_marketplace_json(plugins_dir, target, now, repair=repair),
+        _repair_installed_plugins(plugins_dir, target, now, repair=repair),
+        _repair_enabled_plugins(repair=repair),
+    ]
+    if any(outcome.written for outcome in outcomes):
+        typer.echo(f"OK    Repaired {_CLAUDE_PLUGIN_ID} plugin registration → {target}")
+    untouched = [outcome.detail for outcome in outcomes if outcome.detail and not outcome.written]
+    for detail in untouched:
+        typer.echo(f"WARN  Plugin registration: {detail}")
+    if untouched and not repair:
+        typer.echo(f"WARN  Plugin registration: `t3 doctor check --repair` points {_CLAUDE_PLUGIN_ID} at {target}")
     return True

--- a/src/teatree/core/factory/chokepoint_registry.py
+++ b/src/teatree/core/factory/chokepoint_registry.py
@@ -155,6 +155,12 @@ MERGE_KEYSTONE = GuardedChokepoint(
             purpose="A clean recorded merge-quality verdict covers the shipped head (north-star PR-4).",
         ),
         GateSpec(
+            name="ticket_scoped_gates",
+            callable_path="teatree.core.merge.ticket_gates.assert_ticket_scoped_gates",
+            purpose="The anti-vacuity attestation and rubric done-gate, resolved by PR identity so the "
+            "no-CLEAR merge paths are graded by the settings the operator enabled (#1829/#2241).",
+        ),
+        GateSpec(
             name="not_draft",
             callable_path="teatree.core.merge.execution.assert_not_draft",
             purpose="The PR/MR is not in draft state at the live head (§17.4.3 step 4).",

--- a/src/teatree/core/gates/merge_quality_gate.py
+++ b/src/teatree/core/gates/merge_quality_gate.py
@@ -39,12 +39,11 @@ from typing import TYPE_CHECKING, cast
 from teatree.config import get_effective_settings
 from teatree.core.gates.plan_currency_gate import latest_plan_artifact
 from teatree.core.merge.errors import MergePreconditionError
+from teatree.core.merge.ticket_resolution import resolve_gated_ticket
 from teatree.core.models.critic_dispatch import CriticDispatch
 from teatree.core.models.critic_finding import CriticFinding, CriticFindingSpec
 from teatree.core.models.critic_verdict import CriticVerdict
 from teatree.core.models.directive import Directive
-from teatree.core.models.merge_clear import MergeClear
-from teatree.core.models.pull_request import PullRequest
 from teatree.core.review.critic_rubric import _MERGE_TRANSITION, item_for, llm_items
 
 if TYPE_CHECKING:
@@ -264,37 +263,17 @@ def check_merge_quality_verdict(ticket: "Ticket", head_sha: str) -> None:
         raise MergeQualityVerdictError(msg)
 
 
-def _resolve_gated_ticket(*, slug: str, pr_id: int) -> "Ticket | None":
-    """The ticket whose merge quality is gated, or ``None`` when nothing is gated.
-
-    Resolved from the PR ledger ``(repo, iid)`` FIRST (case-insensitive — GitHub
-    slugs are case-insensitive, so a ``Owner/Repo`` row must still match an
-    ``owner/repo`` merge). When the PR ledger has no matching row (never recorded,
-    or mis-cased before this fix), fall back to the ``MergeClear`` for the same
-    ``(slug, pr_id)`` — the CLEAR carries the ticket FK at merge time and is the
-    reliable handle. This closes the silent-bypass: a directive PR whose PR-ledger
-    row is missing or mis-cased no longer skips the PR-4 gate, because its CLEAR's
-    ticket still resolves and the (fail-closed) gate runs.
-    """
-    pr = PullRequest.objects.filter(repo__iexact=slug, iid=str(pr_id)).select_related("ticket").order_by("-id").first()
-    if pr is not None and pr.ticket is not None:
-        return pr.ticket
-    clear = MergeClear.objects.filter(slug__iexact=slug, pr_id=pr_id).select_related("ticket").order_by("-id").first()
-    if clear is not None and clear.ticket is not None:
-        return clear.ticket
-    return None
-
-
 def assert_merge_quality_verdict(*, slug: str, pr_id: int, head_sha: str) -> None:
     """The ``execute_bound_merge`` chokepoint entry — resolve the ticket then run the gate.
 
     Resolves the gated ticket from the PR ``(repo, iid)`` ledger (case-insensitive)
-    OR the ``MergeClear`` for the same ``(slug, pr_id)`` (:func:`_resolve_gated_ticket`),
+    OR the ``MergeClear`` for the same ``(slug, pr_id)``
+    (:func:`~teatree.core.merge.ticket_resolution.resolve_gated_ticket`),
     so a missing/mis-cased PR row can no longer silently skip the gate. A genuinely
     unresolvable ticket (no PR row, no CLEAR) is a no-op (nothing to gate); a resolved
     directive ticket runs the fail-closed gate.
     """
-    ticket = _resolve_gated_ticket(slug=slug, pr_id=pr_id)
+    ticket = resolve_gated_ticket(slug=slug, pr_id=pr_id)
     if ticket is None:
         return
     check_merge_quality_verdict(ticket, head_sha)

--- a/src/teatree/core/management/commands/notify.py
+++ b/src/teatree/core/management/commands/notify.py
@@ -108,7 +108,7 @@ class Command(TyperCommand):
         idempotency_key: Annotated[
             str,
             typer.Option("--idempotency-key", help="Required dedupe key (the helper enforces it)."),
-        ],
+        ] = "",
         user_id: Annotated[
             str,
             typer.Option("--user-id", help="Slack user id to DM (defaults to the configured user)."),
@@ -164,11 +164,11 @@ class Command(TyperCommand):
         channel: Annotated[
             str,
             typer.Option("--channel", help="Destination: the user's own DM (→bot) or a colleague/channel (→xoxp)."),
-        ],
+        ] = "",
         text: Annotated[
             str,
             typer.Option("--text", help="Slack mrkdwn body. Use ``-`` to read the body from stdin."),
-        ],
+        ] = "",
         thread_ts: Annotated[
             str,
             typer.Option("--thread-ts", help="Thread ``ts`` to reply into (omit to post a new top-level message)."),
@@ -179,6 +179,9 @@ class Command(TyperCommand):
         ] = "",
     ) -> str:
         """Post to a destination, token chosen by it: self-DM→bot, colleague/channel→xoxp (exit 0 on ``ok``)."""
+        if not channel.strip():
+            self.stderr.write("--channel must not be empty")
+            raise SystemExit(2)
         body = sys.stdin.read() if text == "-" else text
         if not body.strip():
             self.stderr.write("--text must not be empty")
@@ -210,21 +213,27 @@ class Command(TyperCommand):
         channel: Annotated[
             str,
             typer.Option("--channel", help="Destination the message is in: self-DM (bot) or colleague/channel (xoxp)."),
-        ],
+        ] = "",
         ts: Annotated[
             str,
             typer.Option("--ts", help="Timestamp ``ts`` of the message to react to."),
-        ],
+        ] = "",
         emoji: Annotated[
             str,
             typer.Option("--emoji", help="Emoji name (with or without surrounding colons)."),
-        ],
+        ] = "",
         overlay: Annotated[
             str,
             typer.Option("--overlay", help="Set T3_OVERLAY_NAME for the call (per-overlay credentials)."),
         ] = "",
     ) -> str:
         """React on a destination, token chosen by it: self-DM→bot, colleague/channel→xoxp (exit 0 on ``ok``)."""
+        if not channel.strip():
+            self.stderr.write("--channel must not be empty")
+            raise SystemExit(2)
+        if not ts.strip():
+            self.stderr.write("--ts must not be empty")
+            raise SystemExit(2)
         name = emoji.strip().strip(":")
         if not name:
             self.stderr.write("--emoji must not be empty")

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -22,7 +22,8 @@ from teatree.core.management.commands._sweep_commands import SweepCommands
 from teatree.core.management.commands._ticket_show import TicketShowCommands
 from teatree.core.management.commands._transition_names import ALLOWED_TRANSITIONS, TRANSITION_HELP
 from teatree.core.management.commands._transition_refusals import review_context_refusal
-from teatree.core.merge import MergePreconditionError, resolve_host_kind, resolve_pr_repo_slug
+from teatree.core.merge import MergePreconditionError, normalize_repo_slug, resolve_host_kind, resolve_pr_repo_slug
+from teatree.core.merge.pr_slug_resolution import _reconcile_slug_against_reviewed_sha
 from teatree.core.models import ClearIssuanceError, ClearRequest, MergeClear, ReviewVerdict, Ticket
 from teatree.core.models.errors import InvalidTransitionError
 from teatree.core.models.external_delivery import refresh_external_delivery_if_active
@@ -68,6 +69,37 @@ class E2EBypassResult(TypedDict, total=False):
     ticket_id: int
     head_sha: str
     approver: str
+
+
+def _verdict_slug(request: ClearRequest, resolved_slug: str) -> str:
+    """The repo the MERGE will bind to, so the by-product verdict is keyed where the gate reads it.
+
+    ``resolve_pr_repo_slug`` is only half of what the keystone does: it then runs
+    ``_reconcile_slug_against_reviewed_sha``, which recovers the real repo when the
+    initial slug's PR does not carry the reviewed SHA. Issuance skipping that half is
+    the #1335 trap in its most durable form — a CLEAR for a downstream overlay's PR
+    records its verdict under the running clone's ``origin``, the merge queries the
+    recovered repo, finds nothing, and the CLEAR is unmergeable for its whole life
+    with re-issuing reproducing the same wrong slug.
+
+    The reconcile is skipped for an ``owner/repo``-shaped CLEAR slug, which
+    ``resolve_pr_repo_slug`` returns unchanged and which no fallback could have
+    mis-resolved — so an ordinary CLEAR pays no forge read. A reconcile that refuses
+    (a genuinely moved head, an offline forge) keeps the initial slug: issuance must
+    not become STRICTER than the merge gate it feeds, and the merge's own SHA bind
+    still refuses a moved head.
+    """
+    if normalize_repo_slug(request.slug):
+        return resolved_slug
+    try:
+        return _reconcile_slug_against_reviewed_sha(
+            initial_slug=resolved_slug,
+            pr_id=request.pr_id,
+            reviewed_sha=request.reviewed_sha.strip().lower(),
+            host_kind=request.host_kind,
+        )
+    except MergePreconditionError:
+        return resolved_slug
 
 
 # The 10-mixin base list is a django-typer requirement, not a composition-bar
@@ -134,7 +166,7 @@ class Command(
         reason: Annotated[
             str,
             typer.Option(help="Why this UI-visible ticket may ship without a local-stack E2E (#88)."),
-        ],
+        ] = "",
         by: Annotated[
             str,
             typer.Option(help="Who is recording the override (audit trail)."),
@@ -174,11 +206,11 @@ class Command(
                 "--approver",
                 help="Human user id authorising the bypass; a maker/coding-agent/loop id is refused (#1967).",
             ),
-        ],
+        ] = "",
         head_sha: Annotated[
             str,
             typer.Option("--head-sha", help="Full 40-char hex SHA of the reviewed tree the bypass authorises."),
-        ],
+        ] = "",
     ) -> "E2EBypassResult":
         """Record a single-use user bypass of the mandatory-E2E gate (#1967).
 
@@ -192,6 +224,9 @@ class Command(
         """
         from teatree.core.models.e2e_bypass import E2EBypassApproval, E2EBypassApprovalError  # noqa: PLC0415 — lazy ORM
 
+        if not approver.strip() or not head_sha.strip():
+            self.stderr.write("  e2e-bypass refused: --approver and --head-sha are both required.")
+            raise SystemExit(1)
         ticket = self._resolve_ticket(ticket_id)
         try:
             approval = E2EBypassApproval.record(ticket=ticket, head_sha=head_sha, approver_id=approver)
@@ -374,6 +409,7 @@ class Command(
         try:
             verdict_slug = resolve_pr_repo_slug(request)
             request = dataclasses.replace(request, host_kind=resolve_host_kind(request, repo_slug=verdict_slug))
+            verdict_slug = _verdict_slug(request, verdict_slug)
             with transaction.atomic():
                 clear = MergeClear.issue(request)
                 # Record the durable read-side sibling (a merge-safe judgment by
@@ -402,9 +438,10 @@ class Command(
         # ``--ticket-id`` is optional and no caller passes it, so a CLEAR is routinely
         # born with no ticket for the merge keystone to advance. The PR knows its own
         # ticket — adopt it AFTER issuance, so the issuance contract sees exactly the
-        # inputs the caller supplied.
+        # inputs the caller supplied. Keyed on verdict_slug for the same reason the
+        # verdict is: ``clear.slug`` is a workstream name that matches no PR row.
         if resolved_ticket is None:
-            resolved_ticket = clear.adopt_owning_ticket()
+            resolved_ticket = clear.adopt_owning_ticket(verdict_slug)
         self.stdout.write(
             f"  issued CLEAR {clear.pk} for {clear.slug}#{clear.pr_id}@{clear.reviewed_sha[:8]} on {clear.host_kind}"
         )

--- a/src/teatree/core/merge/authorization.py
+++ b/src/teatree/core/merge/authorization.py
@@ -13,7 +13,7 @@ from teatree.core.merge.ci_rollup import CodeHostQuery
 from teatree.core.merge.errors import MergePreconditionError
 from teatree.core.merge.substrate_standing import resolve_overlay_by_repo_identity, substrate_standing_authorization
 from teatree.core.models.mr_review_lock import MRReviewLock
-from teatree.core.models.review_verdict import HeadVerdictState, ReviewVerdict
+from teatree.core.models.review_verdict import HeadVerdictState, ReviewVerdict, normalize_reviewer_identity
 from teatree.core.review.author_trust import AuthorSubject, AutonomyGate, TrustVerdict, decide_author_trust
 from teatree.utils.pr_ref import PrRef
 
@@ -132,10 +132,17 @@ def _assert_reviewer_independent(clear: "MergeClear", *, executing_loop_identity
     path in ``ticket.py``) would otherwise smuggle a self-attesting maker through
     the equality check, so the issue-time and merge-time gates re-check identically
     and cannot drift apart (codex #1282 finding 1 / #1283).
+
+    Both identities are compared through :func:`normalize_reviewer_identity` — the
+    same canonicalization ``ReviewVerdict`` keys its uniqueness on. A raw comparison
+    let ``"Worker-Alpha"`` (or an inner double space) slip past an executing loop
+    identity of ``worker-alpha``, so the loop about to execute the merge had
+    self-issued its own clearance: exactly the self-attestation §17.8 clause 3
+    forbids.
     """
     from teatree.core.models.merge_clear import is_non_reviewer_role  # noqa: PLC0415 — deferred: ORM/app-registry
 
-    if clear.reviewer_identity.strip() == executing_loop_identity.strip():
+    if normalize_reviewer_identity(clear.reviewer_identity) == normalize_reviewer_identity(executing_loop_identity):
         msg = (
             f"MergeClear reviewer_identity ({clear.reviewer_identity!r}) equals the "
             f"executing loop identity — a CLEAR must be issued by an independent "
@@ -359,7 +366,10 @@ def _assert_anti_vacuity(clear: "MergeClear", head_sha: str) -> None:
 
     NO-OP when ``require_anti_vacuity_attestation`` is off (opt-in default) or
     the CLEAR carries no ticket (the attestation lives on the ticket's durable
-    ``extra``). The :class:`AntiVacuityAttestationError` raised on a block is
+    ``extra``). A ticketless CLEAR is not thereby ungated: the same gate runs by PR
+    identity in :func:`assert_ticket_scoped_gates` at the shared merge chokepoint,
+    which is where a resolvable-nowhere ticket is REFUSED rather than skipped. The
+    :class:`AntiVacuityAttestationError` raised on a block is
     re-wrapped as a :class:`MergePreconditionError` so the merge command's
     single re-escalation path surfaces it (the loop never self-issues a
     replacement CLEAR).
@@ -382,7 +392,9 @@ def _assert_rubric_satisfied(clear: "MergeClear", head_sha: str) -> None:
     """Refuse a merge whose CLEAR ticket's rubric is not fully PASS at ``head_sha`` (#2241).
 
     NO-OP when ``require_rubric_verification`` is off (opt-in default) or the CLEAR
-    carries no ticket (the rubric is FK'd to the ticket). The
+    carries no ticket (the rubric is FK'd to the ticket) — a ticketless CLEAR is
+    graded instead by PR identity in :func:`assert_ticket_scoped_gates` at the shared
+    merge chokepoint, which REFUSES when the ticket resolves nowhere. The
     :class:`RubricNotSatisfiedError` raised on a block is re-wrapped as a
     :class:`MergePreconditionError` so the merge command's single re-escalation
     path surfaces it (the loop never self-issues a replacement CLEAR). Sibling of

--- a/src/teatree/core/merge/authorization.py
+++ b/src/teatree/core/merge/authorization.py
@@ -12,8 +12,9 @@ from typing import TYPE_CHECKING
 from teatree.core.merge.ci_rollup import CodeHostQuery
 from teatree.core.merge.errors import MergePreconditionError
 from teatree.core.merge.substrate_standing import resolve_overlay_by_repo_identity, substrate_standing_authorization
+from teatree.core.models.merge_clear import normalize_reviewer_identity
 from teatree.core.models.mr_review_lock import MRReviewLock
-from teatree.core.models.review_verdict import HeadVerdictState, ReviewVerdict, normalize_reviewer_identity
+from teatree.core.models.review_verdict import HeadVerdictState, ReviewVerdict
 from teatree.core.review.author_trust import AuthorSubject, AutonomyGate, TrustVerdict, decide_author_trust
 from teatree.utils.pr_ref import PrRef
 

--- a/src/teatree/core/merge/ci_rollup.py
+++ b/src/teatree/core/merge/ci_rollup.py
@@ -184,11 +184,19 @@ def attach_touched_paths(clear: object, query: CodeHostQuery) -> None:
     """Populate ``clear.touched_paths`` from the forge's live changed-file list.
 
     A non-``MergeClear`` *clear* (the gate handles that refusal) is a no-op. When the
-    changed-path list cannot be read to completion — a forge error (exception) or the
-    ``CHANGED_PATHS_UNAVAILABLE`` sentinel from a truncated/paginated diff — the diff
-    can no longer be PROVEN non-substrate, so ``substrate_paths_indeterminate`` is set
-    and ``is_substrate()`` fails CLOSED (holds the merge). A complete list populates
-    ``touched_paths`` for the path detector and clears the indeterminate flag.
+    changed-path list cannot be read to completion — a forge error (exception), the
+    ``CHANGED_PATHS_UNAVAILABLE`` sentinel from a truncated/paginated diff, or an EMPTY
+    list — the diff can no longer be PROVEN non-substrate, so
+    ``substrate_paths_indeterminate`` is set and ``is_substrate()`` fails CLOSED (holds
+    the merge). A complete list populates ``touched_paths`` for the path detector and
+    clears the indeterminate flag.
+
+    An empty list is a read failure, not a confirmed non-substrate diff: a real open PR
+    always changes at least one file, so ``[]`` means the fetch returned nothing usable
+    (a rate-limited 200 with an empty array, a response-shape change, a token whose
+    scope yields no files). The solo sibling
+    (:func:`~teatree.loop.scanners.pr_sweep_substrate.pr_diff_is_substrate`) already
+    holds on it; both paths read the same rule so they cannot disagree on one diff.
     """
     if not isinstance(clear, MergeClear):
         return
@@ -202,9 +210,9 @@ def attach_touched_paths(clear: object, query: CodeHostQuery) -> None:
         )
         clear.substrate_paths_indeterminate = True
         return
-    if changed_paths_unavailable(paths):
+    if not paths or changed_paths_unavailable(paths):
         logger.warning(
-            "ci_rollup: changed-paths list truncated/unavailable for %s#%s — holding as substrate (fail closed)",
+            "ci_rollup: empty/truncated changed-paths list for %s#%s — holding as substrate (fail closed)",
             query.ref.slug,
             query.ref.pr_id,
         )

--- a/src/teatree/core/merge/execution.py
+++ b/src/teatree/core/merge/execution.py
@@ -131,11 +131,9 @@ def assert_merge_preconditions(
     slug, pr_id = ref.slug, ref.pr_id
 
     # Attach the live diff paths so the substrate authorization guard can detect
-    # a mislabeled substrate diff (path-based classifier — invariant 4). A forge
-    # error degrades to no paths: the path detector only WIDENS substrate over the
-    # recorded ``blast_class``, never narrows it, so a missing diff never weakens
-    # the label-based gate. Set BEFORE the authorize call so the substrate branch
-    # reads it.
+    # a mislabeled substrate diff (path-based classifier — invariant 4). A diff
+    # that cannot be read to completion holds as substrate rather than merging
+    # unclassified. Set BEFORE the authorize call so the substrate branch reads it.
     attach_touched_paths(clear, query)
 
     authorized_clear = _assert_clear_authorized(

--- a/src/teatree/core/merge/execution.py
+++ b/src/teatree/core/merge/execution.py
@@ -40,6 +40,7 @@ from teatree.core.merge.merge_response import _raise_bound_merge_failure
 from teatree.core.merge.post_hook import MergeAuditAuthorizers, record_merge_and_advance
 from teatree.core.merge.pr_slug_resolution import _reconcile_slug_against_reviewed_sha, resolve_pr_repo_slug
 from teatree.core.merge.sha_bind import verify_sha_bound
+from teatree.core.merge.ticket_gates import assert_ticket_scoped_gates
 from teatree.project import find_project_root
 from teatree.utils.pr_ref import PrRef
 
@@ -308,12 +309,15 @@ def execute_bound_merge(
     hook idempotently instead of re-issuing the (then-405-bricking) merge.
     A policy refusal (not-mergeable / required-checks / 405 / 422) and a
     head-moved are NOT transient — they raise on the first attempt. Before the
-    retry loop, five gates run — the single chokepoint BOTH merge paths cross
+    retry loop, six gates run — the single chokepoint BOTH merge paths cross
     (the keystone via ``assert_merge_preconditions`` AND the solo-overlay bypass
     via ``merge_pr_squash_bound`` with NO preconditions run): ``assert_review_verdict_gate``
     (#2829), ``assert_no_active_review_lock`` (#1405), ``assert_merge_quality_verdict``
     (north-star PR-4 — a directive keystone / opted-in ordinary ticket needs a clean
-    recorded merge-quality verdict at the shipped head), and the #18 not-draft +
+    recorded merge-quality verdict at the shipped head), ``assert_ticket_scoped_gates``
+    (the anti-vacuity attestation + rubric done-gate, resolved by PR identity so the
+    no-CLEAR paths are graded by the settings the operator enabled instead of merging
+    past them silently), and the #18 not-draft +
     FAILED-live-CI floor. The latter re-reads the forge's LIVE state at the merge
     chokepoint so a green→red / open→draft flip in the TOCTOU window between a
     caller's snapshot and this PUT is refused here — the solo lane had NO such
@@ -347,6 +351,10 @@ def execute_bound_merge(
     from teatree.core.gates import merge_quality_gate  # noqa: PLC0415 avoids a core.merge/core.gates cycle
 
     merge_quality_gate.assert_merge_quality_verdict(slug=slug, pr_id=pr_id, head_sha=expected_head_oid)
+    # The two ticket-scoped gates, by PR identity rather than through a CLEAR — so the
+    # no-CLEAR paths that reach this chokepoint are graded by the settings the operator
+    # turned on, instead of merging past them silently.
+    assert_ticket_scoped_gates(slug=slug, pr_id=pr_id, head_sha=expected_head_oid)
     assert_not_draft(query)
     assert_ci_not_failed(query)
     for attempt in range(MERGE_TRANSIENT_ATTEMPTS):

--- a/src/teatree/core/merge/post_hook.py
+++ b/src/teatree/core/merge/post_hook.py
@@ -8,7 +8,6 @@ atomic DB write. :func:`record_merge_and_advance` is what
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 from django.apps import apps
 from django.db import transaction
@@ -16,9 +15,8 @@ from django.utils import timezone
 from django_fsm import TransitionNotAllowed
 
 from teatree.core.merge.errors import MergePreconditionError, MergeReplayError
-
-if TYPE_CHECKING:
-    from teatree.core.models import MergeClear
+from teatree.core.merge.pr_slug_resolution import normalize_repo_slug, resolved_repo_slug
+from teatree.core.models import MergeClear
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +36,7 @@ class MergeAuditAuthorizers:
     standing_delegation_by: str = ""
 
 
-def _supersede_siblings(locked: "MergeClear", *, repo_slug: str) -> None:
+def _supersede_siblings(locked: MergeClear, *, repo_slug: str) -> None:
     """§15: consume every sibling unconsumed CLEAR for the SAME repo's PR.
 
     A re-review at a moved head issues a fresh CLEAR at the new SHA, leaving the
@@ -57,12 +55,6 @@ def _supersede_siblings(locked: "MergeClear", *, repo_slug: str) -> None:
     An ``owner/repo``-shaped slug is already repo-scoped and keeps the plain
     case-insensitive match a forge slug's case-insensitivity requires.
     """
-    from teatree.core.merge.pr_slug_resolution import (  # noqa: PLC0415 — deferred: core.merge package cycle
-        normalize_repo_slug,
-        resolved_repo_slug,
-    )
-    from teatree.core.models import MergeClear  # noqa: PLC0415 — deferred: ORM import needs the app registry
-
     siblings = (
         MergeClear.objects.filter(slug__iexact=locked.slug, pr_id=locked.pr_id, consumed_at__isnull=True)
         .exclude(pk=locked.pk)
@@ -131,7 +123,6 @@ def record_merge_and_advance(
     idempotent DB write retries).
     """
     from teatree.core.modelkit.db_retry import retry_on_locked  # noqa: PLC0415 — deferred: call-time import, kept lazy
-    from teatree.core.models import MergeClear  # noqa: PLC0415 — deferred: ORM import needs the app registry
 
     stamps = authorizers or MergeAuditAuthorizers()
     if not isinstance(clear, MergeClear):  # pragma: no cover - guarded by caller

--- a/src/teatree/core/merge/post_hook.py
+++ b/src/teatree/core/merge/post_hook.py
@@ -8,6 +8,7 @@ atomic DB write. :func:`record_merge_and_advance` is what
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from django.apps import apps
 from django.db import transaction
@@ -15,6 +16,9 @@ from django.utils import timezone
 from django_fsm import TransitionNotAllowed
 
 from teatree.core.merge.errors import MergePreconditionError, MergeReplayError
+
+if TYPE_CHECKING:
+    from teatree.core.models import MergeClear
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +36,54 @@ class MergeAuditAuthorizers:
 
     expedited_by: str = ""
     standing_delegation_by: str = ""
+
+
+def _supersede_siblings(locked: "MergeClear", *, repo_slug: str) -> None:
+    """§15: consume every sibling unconsumed CLEAR for the SAME repo's PR.
+
+    A re-review at a moved head issues a fresh CLEAR at the new SHA, leaving the
+    older one unconsumed; once THIS merge consumes one, its siblings are no longer a
+    stalled merge, so they are consumed in the caller's atomic block under the row
+    lock (a single serialized UPDATE) rather than left to ratchet S4 hard-red forever.
+
+    The scope is the REPO, never the stored ``slug`` alone. A ticketless CLEAR's slug
+    is a workstream name (``merge-candidate-working-repos``) that several repos share,
+    so keying on ``(slug, pr_id)`` let a merge in one repo stamp another repo's live,
+    independently-reviewed CLEAR for its own PR #42 as consumed — that CLEAR then
+    refuses its merge as "already consumed" and owes a fresh cold review for work
+    that never merged. So a workstream-slug sibling is superseded only when it
+    resolves to the same repo this merge landed in, and when the merge-time repo is
+    unknown (a legacy caller passing no ``repo_slug``) nothing is superseded at all.
+    An ``owner/repo``-shaped slug is already repo-scoped and keeps the plain
+    case-insensitive match a forge slug's case-insensitivity requires.
+    """
+    from teatree.core.merge.pr_slug_resolution import (  # noqa: PLC0415 — deferred: core.merge package cycle
+        normalize_repo_slug,
+        resolved_repo_slug,
+    )
+    from teatree.core.models import MergeClear  # noqa: PLC0415 — deferred: ORM import needs the app registry
+
+    siblings = (
+        MergeClear.objects.filter(slug__iexact=locked.slug, pr_id=locked.pr_id, consumed_at__isnull=True)
+        .exclude(pk=locked.pk)
+        .select_related("ticket")
+    )
+    if normalize_repo_slug(locked.slug):
+        superseded = [sibling.pk for sibling in siblings]
+    elif repo_slug:
+        superseded = [
+            sibling.pk for sibling in siblings if resolved_repo_slug(sibling).casefold() == repo_slug.casefold()
+        ]
+    else:
+        logger.warning(
+            "merge keystone: %s#%s carries a workstream slug and no merge-time repo — "
+            "skipping the §15 sibling supersede rather than risk consuming another repo's live CLEAR",
+            locked.slug,
+            locked.pr_id,
+        )
+        return
+    if superseded:
+        MergeClear.objects.filter(pk__in=superseded).update(consumed_at=locked.consumed_at)
 
 
 def record_merge_and_advance(
@@ -113,24 +165,11 @@ def record_merge_and_advance(
                 repo_slug=repo_slug,
                 standing_delegation_by=stamps.standing_delegation_by,
             )
-            # §15: supersede every sibling unconsumed CLEAR for the same PR —
-            # re-review at a moved head issues a fresh CLEAR at the new SHA,
-            # leaving the older one unconsumed. Once THIS merge consumes one, its
-            # siblings are no longer a stalled merge, so consume them in the same
-            # atomic block (single serialized UPDATE) under the row lock. The slug
-            # is matched case-INSENSITIVELY (``slug__iexact``): a forge slug is
-            # case-insensitive, so a sibling CLEAR recorded with a differently-cased
-            # ``owner/Repo`` must NOT survive to keep ratcheting the S4 hard-red gate
-            # forever (the rest of the pipeline resolves slugs with ``__iexact``).
-            MergeClear.objects.filter(
-                slug__iexact=locked.slug,
-                pr_id=locked.pr_id,
-                consumed_at__isnull=True,
-            ).exclude(pk=locked.pk).update(consumed_at=locked.consumed_at)
+            _supersede_siblings(locked, repo_slug=repo_slug)
             # The forge merge already landed, so the PR row is MERGED and a ticketless
             # CLEAR (``--ticket-id`` is optional, and the loop never passed one) can
             # recover from the PR the FSM it otherwise has nothing to advance.
-            ticket = locked.record_merged_pull_request()
+            ticket = locked.record_merged_pull_request(repo_slug)
             if ticket is None:
                 # #3840: the merge landed, the CLEAR is consumed and the audit is written,
                 # but no FSM advanced. Returning "" quietly made that indistinguishable from

--- a/src/teatree/core/merge/ticket_gates.py
+++ b/src/teatree/core/merge/ticket_gates.py
@@ -1,0 +1,69 @@
+"""The two ticket-scoped merge gates, run by PR identity at the shared chokepoint.
+
+The anti-vacuity attestation (#1829) and the rubric done-gate (#2241) are recorded on
+the TICKET, and their CLEAR-taking twins in :mod:`authorization` therefore only ever
+ran on the keystone path. The solo-overlay bypass and the uv-audit raw fallback reach
+the forge through :func:`~teatree.core.merge.execution.execute_bound_merge` with no
+CLEAR at all, so they merged ungraded by both — on installs that had turned the
+settings ON, with nothing telling the operator the gate had not run. Resolving the
+ticket from the PR identity instead makes both gates reachable from the one chokepoint
+every merge path crosses.
+"""
+
+from teatree.core.merge.errors import MergePreconditionError
+from teatree.core.merge.substrate_standing import resolve_overlay_by_repo_identity
+
+
+def assert_ticket_scoped_gates(*, slug: str, pr_id: int, head_sha: str) -> None:
+    """Run the anti-vacuity + rubric gates at the SHARED merge chokepoint, by PR identity.
+
+    The ticket is resolved through the SAME
+    :func:`~teatree.core.gates.merge_quality_gate._resolve_gated_ticket` the sibling
+    quality gate already calls at this chokepoint (PR ledger first, CLEAR second, both
+    case-insensitive) — a second resolver here is how the four-way slug divergence got
+    built, so there is deliberately only one.
+
+    An unresolvable ticket while either setting is IN FORCE REFUSES the merge. Skipping
+    is the shape the operator cannot see: they turn the setting on, nothing resolves a
+    ticket, and the gate they enabled grades nothing while every signal reads healthy.
+    An ungradable subject is not evidence that the subject is satisfied. With both
+    settings off (the shipped default) an unresolvable ticket is a plain no-op, so
+    nothing that merges today stops merging.
+    """
+    from teatree.core.gates import merge_quality_gate  # noqa: PLC0415 avoids a core.merge/core.gates cycle
+    from teatree.core.gates.anti_vacuity_gate import (  # noqa: PLC0415 — deferred: call-time import, kept lazy
+        AntiVacuityAttestationError,
+        anti_vacuity_required,
+        check_anti_vacuity_attestation,
+    )
+    from teatree.core.gates.rubric_gate import (  # noqa: PLC0415 — deferred: call-time import, kept lazy
+        RubricNotSatisfiedError,
+        check_rubric_satisfied,
+        rubric_gate_required,
+    )
+
+    ticket = merge_quality_gate._resolve_gated_ticket(slug=slug, pr_id=pr_id)  # noqa: SLF001 — one resolver, not two
+    if ticket is None:
+        overlay = resolve_overlay_by_repo_identity(slug, fallback="") or None
+        required = [
+            name
+            for name, in_force in (
+                ("require_anti_vacuity_attestation", anti_vacuity_required(overlay)),
+                ("require_rubric_verification", rubric_gate_required(overlay)),
+            )
+            if in_force
+        ]
+        if required:
+            msg = (
+                f"{' and '.join(required)} enabled but no owning ticket resolves for {slug}#{pr_id} — "
+                f"both are recorded on the ticket, so the gate cannot be evaluated and the merge is "
+                f"refused rather than merged silently ungraded. Link the PR to its ticket "
+                f"(`t3 <overlay> ticket backfill-clears`, or re-issue the CLEAR with `--ticket-id <id>`)."
+            )
+            raise MergePreconditionError(msg)
+        return
+    try:
+        check_anti_vacuity_attestation(ticket, head_sha, transition="merge")
+        check_rubric_satisfied(ticket, head_sha, transition="merge")
+    except (AntiVacuityAttestationError, RubricNotSatisfiedError) as exc:
+        raise MergePreconditionError(str(exc)) from exc

--- a/src/teatree/core/merge/ticket_gates.py
+++ b/src/teatree/core/merge/ticket_gates.py
@@ -10,12 +10,9 @@ ticket from the PR identity instead makes both gates reachable from the one chok
 every merge path crosses.
 """
 
-from teatree.core.gates.anti_vacuity_gate import (
-    AntiVacuityAttestationError,
-    anti_vacuity_required,
-    check_anti_vacuity_attestation,
-)
-from teatree.core.gates.rubric_gate import RubricNotSatisfiedError, check_rubric_satisfied, rubric_gate_required
+from teatree.core.gates import anti_vacuity_gate, rubric_gate
+from teatree.core.gates.anti_vacuity_gate import AntiVacuityAttestationError
+from teatree.core.gates.rubric_gate import RubricNotSatisfiedError
 from teatree.core.merge.errors import MergePreconditionError
 from teatree.core.merge.substrate_standing import resolve_overlay_by_repo_identity
 from teatree.core.merge.ticket_resolution import resolve_gated_ticket
@@ -43,8 +40,8 @@ def assert_ticket_scoped_gates(*, slug: str, pr_id: int, head_sha: str) -> None:
         required = [
             name
             for name, in_force in (
-                ("require_anti_vacuity_attestation", anti_vacuity_required(overlay)),
-                ("require_rubric_verification", rubric_gate_required(overlay)),
+                ("require_anti_vacuity_attestation", anti_vacuity_gate.anti_vacuity_required(overlay)),
+                ("require_rubric_verification", rubric_gate.rubric_gate_required(overlay)),
             )
             if in_force
         ]
@@ -58,7 +55,7 @@ def assert_ticket_scoped_gates(*, slug: str, pr_id: int, head_sha: str) -> None:
             raise MergePreconditionError(msg)
         return
     try:
-        check_anti_vacuity_attestation(ticket, head_sha, transition="merge")
-        check_rubric_satisfied(ticket, head_sha, transition="merge")
+        anti_vacuity_gate.check_anti_vacuity_attestation(ticket, head_sha, transition="merge")
+        rubric_gate.check_rubric_satisfied(ticket, head_sha, transition="merge")
     except (AntiVacuityAttestationError, RubricNotSatisfiedError) as exc:
         raise MergePreconditionError(str(exc)) from exc

--- a/src/teatree/core/merge/ticket_gates.py
+++ b/src/teatree/core/merge/ticket_gates.py
@@ -10,15 +10,22 @@ ticket from the PR identity instead makes both gates reachable from the one chok
 every merge path crosses.
 """
 
+from teatree.core.gates.anti_vacuity_gate import (
+    AntiVacuityAttestationError,
+    anti_vacuity_required,
+    check_anti_vacuity_attestation,
+)
+from teatree.core.gates.rubric_gate import RubricNotSatisfiedError, check_rubric_satisfied, rubric_gate_required
 from teatree.core.merge.errors import MergePreconditionError
 from teatree.core.merge.substrate_standing import resolve_overlay_by_repo_identity
+from teatree.core.merge.ticket_resolution import resolve_gated_ticket
 
 
 def assert_ticket_scoped_gates(*, slug: str, pr_id: int, head_sha: str) -> None:
     """Run the anti-vacuity + rubric gates at the SHARED merge chokepoint, by PR identity.
 
     The ticket is resolved through the SAME
-    :func:`~teatree.core.gates.merge_quality_gate._resolve_gated_ticket` the sibling
+    :func:`~teatree.core.merge.ticket_resolution.resolve_gated_ticket` the sibling
     quality gate already calls at this chokepoint (PR ledger first, CLEAR second, both
     case-insensitive) — a second resolver here is how the four-way slug divergence got
     built, so there is deliberately only one.
@@ -30,19 +37,7 @@ def assert_ticket_scoped_gates(*, slug: str, pr_id: int, head_sha: str) -> None:
     settings off (the shipped default) an unresolvable ticket is a plain no-op, so
     nothing that merges today stops merging.
     """
-    from teatree.core.gates import merge_quality_gate  # noqa: PLC0415 avoids a core.merge/core.gates cycle
-    from teatree.core.gates.anti_vacuity_gate import (  # noqa: PLC0415 — deferred: call-time import, kept lazy
-        AntiVacuityAttestationError,
-        anti_vacuity_required,
-        check_anti_vacuity_attestation,
-    )
-    from teatree.core.gates.rubric_gate import (  # noqa: PLC0415 — deferred: call-time import, kept lazy
-        RubricNotSatisfiedError,
-        check_rubric_satisfied,
-        rubric_gate_required,
-    )
-
-    ticket = merge_quality_gate._resolve_gated_ticket(slug=slug, pr_id=pr_id)  # noqa: SLF001 — one resolver, not two
+    ticket = resolve_gated_ticket(slug=slug, pr_id=pr_id)
     if ticket is None:
         overlay = resolve_overlay_by_repo_identity(slug, fallback="") or None
         required = [

--- a/src/teatree/core/merge/ticket_resolution.py
+++ b/src/teatree/core/merge/ticket_resolution.py
@@ -1,0 +1,39 @@
+"""Resolve the ticket a PR/MR belongs to — the one answer every merge-time gate reads.
+
+A merge-time gate whose subject is recorded on the TICKET (merge quality, the
+anti-vacuity attestation, the rubric done-gate) holds only a ``(slug, pr_id)`` pair
+at the chokepoint, so each needs the same PR→ticket lookup. Keeping that lookup in
+one leaf — dependent on ``core.models`` alone — is what lets every caller import it
+at module level: the resolver used to live beside the merge-quality gate, whose own
+``core.review`` imports make it unreachable from inside ``core.merge`` without a
+deferred import, and a second copy of the lookup is how the slug divergence this
+package just unified got built in the first place.
+"""
+
+from typing import TYPE_CHECKING
+
+from teatree.core.models import MergeClear, PullRequest
+
+if TYPE_CHECKING:
+    from teatree.core.models import Ticket
+
+
+def resolve_gated_ticket(*, slug: str, pr_id: int) -> "Ticket | None":
+    """The ticket whose merge is gated, or ``None`` when nothing is gated.
+
+    Resolved from the PR ledger ``(repo, iid)`` FIRST (case-insensitive — GitHub
+    slugs are case-insensitive, so a ``Owner/Repo`` row must still match an
+    ``owner/repo`` merge). When the PR ledger has no matching row (never recorded,
+    or mis-cased before this fix), fall back to the ``MergeClear`` for the same
+    ``(slug, pr_id)`` — the CLEAR carries the ticket FK at merge time and is the
+    reliable handle. This closes the silent-bypass: a directive PR whose PR-ledger
+    row is missing or mis-cased no longer skips the PR-4 gate, because its CLEAR's
+    ticket still resolves and the (fail-closed) gate runs.
+    """
+    pr = PullRequest.objects.filter(repo__iexact=slug, iid=str(pr_id)).select_related("ticket").order_by("-id").first()
+    if pr is not None and pr.ticket is not None:
+        return pr.ticket
+    clear = MergeClear.objects.filter(slug__iexact=slug, pr_id=pr_id).select_related("ticket").order_by("-id").first()
+    if clear is not None and clear.ticket is not None:
+        return clear.ticket
+    return None

--- a/src/teatree/core/migrations/0001_squashed_0030.py
+++ b/src/teatree/core/migrations/0001_squashed_0030.py
@@ -584,7 +584,7 @@ def backward(apps, schema_editor) -> None:
 
 # --- ported verbatim from 0030_review_verdict_reviewer_identity_normalized — _normalize + _backfill_and_dedup ---
 def _normalize(identity: str) -> str:
-    # Frozen snapshot of teatree.core.models.review_verdict.normalize_reviewer_identity:
+    # Frozen snapshot of teatree.core.models.merge_clear.normalize_reviewer_identity:
     # strip + collapse internal whitespace runs + casefold. Duplicated here on
     # purpose — a migration is a point-in-time transform and must not drift with
     # the live function.

--- a/src/teatree/core/migrations/0030_review_verdict_reviewer_identity_normalized.py
+++ b/src/teatree/core/migrations/0030_review_verdict_reviewer_identity_normalized.py
@@ -17,7 +17,7 @@ from django.db import migrations, models
 
 
 def _normalize(identity: str) -> str:
-    # Frozen snapshot of teatree.core.models.review_verdict.normalize_reviewer_identity:
+    # Frozen snapshot of teatree.core.models.merge_clear.normalize_reviewer_identity:
     # strip + collapse internal whitespace runs + casefold. Duplicated here on
     # purpose — a migration is a point-in-time transform and must not drift with
     # the live function.

--- a/src/teatree/core/models/__init__.py
+++ b/src/teatree/core/models/__init__.py
@@ -72,7 +72,13 @@ from teatree.core.models.loop_preset import Mode, ModeManager, ModeOverride, Mod
 from teatree.core.models.loop_schedule import ModeSchedule, ModeScheduleSlot
 from teatree.core.models.loop_state import LoopState, LoopStateManager, LoopStatus
 from teatree.core.models.mechanism_sketch import MechanismSketch, MechanismSketchError
-from teatree.core.models.merge_clear import ClearIssuanceError, ClearRequest, MergeAudit, MergeClear
+from teatree.core.models.merge_clear import (
+    ClearIssuanceError,
+    ClearRequest,
+    MergeAudit,
+    MergeClear,
+    normalize_reviewer_identity,
+)
 from teatree.core.models.mergeable_notified import MergeableNotified
 from teatree.core.models.mr_review_lock import DEFAULT_LOCK_TTL, MRReviewLock
 from teatree.core.models.on_behalf_approval import OnBehalfApproval, OnBehalfApprovalError, OnBehalfAudit
@@ -104,13 +110,7 @@ from teatree.core.models.review_assignment import ReviewAssignment, ReviewIntent
 from teatree.core.models.review_backend_cooldown import ReviewBackendCooldown
 from teatree.core.models.review_evidence import ReviewEvidence, ReviewEvidenceError
 from teatree.core.models.review_request_post import ReviewRequestPost
-from teatree.core.models.review_verdict import (
-    Finding,
-    ReviewVerdict,
-    ReviewVerdictError,
-    Severity,
-    normalize_reviewer_identity,
-)
+from teatree.core.models.review_verdict import Finding, ReviewVerdict, ReviewVerdictError, Severity
 from teatree.core.models.rubric import Rubric, RubricCriterion, RubricError
 from teatree.core.models.scanned_broadcast import BroadcastObservation, ScannedBroadcast
 from teatree.core.models.scanned_failed_e2e import ScannedFailedE2E

--- a/src/teatree/core/models/merge_clear.py
+++ b/src/teatree/core/models/merge_clear.py
@@ -332,7 +332,11 @@ class MergeClear(models.Model):
         if not reviewer:
             msg = "reviewer_identity is required and must be non-empty (§17.4.2)"
             raise ClearIssuanceError(msg)
-        if reviewer == request.executing_loop_identity.strip():
+        from teatree.core.models.review_verdict import (  # noqa: PLC0415 — deferred: review_verdict imports this module
+            normalize_reviewer_identity,
+        )
+
+        if normalize_reviewer_identity(reviewer) == normalize_reviewer_identity(request.executing_loop_identity):
             msg = (
                 f"reviewer_identity {reviewer!r} equals the executing loop identity "
                 f"({request.executing_loop_identity!r}) — a CLEAR must be issued by an independent "
@@ -465,22 +469,34 @@ class MergeClear(models.Model):
             )
             raise ClearIssuanceError(msg)
 
-    def record_merged_pull_request(self) -> "Ticket | None":
+    def record_merged_pull_request(self, repo_slug: str = "") -> "Ticket | None":
         """Bind a landed merge to the PR-side records; return the ticket the FSM must advance.
 
         The merge keystone is the authoritative moment the PR became merged — the
         open-PR-only reconciler that used to be ``PullRequest.mark_merged``'s sole
         caller can never observe a PR that merged between two of its ticks.
-        """
-        PullRequest.objects.record_forge_merge(slug=self.slug, pr_id=self.pr_id)
-        return self.adopt_owning_ticket()
 
-    def adopt_owning_ticket(self) -> "Ticket | None":
+        *repo_slug* is the real ``owner/repo`` the caller merged against; see
+        :meth:`adopt_owning_ticket` for why :attr:`slug` is not it.
+        """
+        PullRequest.objects.record_forge_merge(slug=repo_slug or self.slug, pr_id=self.pr_id)
+        return self.adopt_owning_ticket(repo_slug)
+
+    def adopt_owning_ticket(self, repo_slug: str = "") -> "Ticket | None":
         """Persist the PR's owning ticket onto a ticketless CLEAR; return the ticket adopted.
 
         ``--ticket-id`` is optional on ``ticket clear`` and the loop never passed one,
         so a CLEAR is routinely born with no ticket and the merge keystone then has no
         FSM to advance. The PR itself knows its ticket, so recover the link from there.
+
+        *repo_slug* is the real ``owner/repo`` the caller resolved for this PR, and it
+        is what the lookup is keyed on. :attr:`slug` is a WORKSTREAM name on exactly the
+        ticketless CLEARs this method exists for, so keying on it matched no
+        ``PullRequest`` row and adoption silently never happened for them — the board
+        never moved and the log said only "merged but resolved no owning ticket". The
+        caller supplies the slug rather than this model re-deriving it: the merge
+        keystone already reconciled the authoritative one, and ``core.models`` may not
+        depend on the ``core.merge`` resolver that would re-derive it (tach).
 
         Adoption is bookkeeping, never authorisation: the merge gates that read
         ``clear.ticket`` (anti-vacuity, rubric) run BEFORE the merge, so adopting
@@ -488,7 +504,7 @@ class MergeClear(models.Model):
         """
         if self.ticket is not None:
             return self.ticket
-        ticket = PullRequest.objects.owning_ticket(slug=self.slug, pr_id=self.pr_id)
+        ticket = PullRequest.objects.owning_ticket(slug=repo_slug or self.slug, pr_id=self.pr_id)
         if ticket is None:
             return None
         self.ticket = ticket

--- a/src/teatree/core/models/merge_clear.py
+++ b/src/teatree/core/models/merge_clear.py
@@ -147,6 +147,27 @@ def is_non_reviewer_role(identity: str) -> bool:
     return bool(parts & _COMPONENT_ROLE_WORDS)
 
 
+def normalize_reviewer_identity(identity: str) -> str:
+    """The canonical, idempotency-keyed form of a free-text reviewer identity (F8).
+
+    The recorded ``reviewer_identity`` is free text — 187 distinct values on the
+    live box, with the SAME logical reviewer spelled many ways ("Codex", "codex ",
+    "codex"). That made "has this sha been reviewed by this identity?" unanswerable
+    by query and let the dispatcher re-review one sha 17 times. The normalized form
+    collapses the case-and-whitespace noise only — ``strip`` + internal-whitespace
+    runs to one space + ``casefold`` — so equivalent spellings key to ONE row while
+    genuinely distinct identities stay distinct (no role-prefix stripping, which
+    would over-merge two real reviewers). It is the canonical key at every boundary:
+    the ``ReviewVerdict`` write, its uniqueness constraint, and the maker≠checker
+    comparison at CLEAR issuance and at merge time.
+
+    It sits beside :func:`is_non_reviewer_role` rather than next to ``ReviewVerdict``
+    because CLEAR issuance validates through it and ``review_verdict`` imports this
+    module — the reviewer-identity primitives are the shared lower layer.
+    """
+    return " ".join(identity.split()).casefold()
+
+
 def is_commit_sha(value: str) -> bool:
     """True iff ``value`` is a full 40-char hex commit SHA (§17.4.2, #1162).
 
@@ -332,10 +353,6 @@ class MergeClear(models.Model):
         if not reviewer:
             msg = "reviewer_identity is required and must be non-empty (§17.4.2)"
             raise ClearIssuanceError(msg)
-        from teatree.core.models.review_verdict import (  # noqa: PLC0415 — deferred: review_verdict imports this module
-            normalize_reviewer_identity,
-        )
-
         if normalize_reviewer_identity(reviewer) == normalize_reviewer_identity(request.executing_loop_identity):
             msg = (
                 f"reviewer_identity {reviewer!r} equals the executing loop identity "

--- a/src/teatree/core/models/review_verdict.py
+++ b/src/teatree/core/models/review_verdict.py
@@ -34,25 +34,15 @@ from django.utils import timezone
 
 from teatree.core.models.auto_review_dispatch import AutoReviewDispatch
 from teatree.core.models.codex_review_marker import CodexReviewMarker
-from teatree.core.models.merge_clear import SHA_FULL_LEN, MergeClear, is_commit_sha, is_non_reviewer_role
+from teatree.core.models.merge_clear import (
+    SHA_FULL_LEN,
+    MergeClear,
+    is_commit_sha,
+    is_non_reviewer_role,
+    normalize_reviewer_identity,
+)
 from teatree.core.models.mr_review_lock import MRReviewLock
 from teatree.core.models.ticket import Ticket
-
-
-def normalize_reviewer_identity(identity: str) -> str:
-    """The canonical, idempotency-keyed form of a free-text reviewer identity (F8).
-
-    The recorded ``reviewer_identity`` is free text — 187 distinct values on the
-    live box, with the SAME logical reviewer spelled many ways ("Codex", "codex ",
-    "codex"). That made "has this sha been reviewed by this identity?" unanswerable
-    by query and let the dispatcher re-review one sha 17 times. The normalized form
-    collapses the case-and-whitespace noise only — ``strip`` + internal-whitespace
-    runs to one space + ``casefold`` — so equivalent spellings key to ONE row while
-    genuinely distinct identities stay distinct (no role-prefix stripping, which
-    would over-merge two real reviewers). It is the canonical key at both boundaries:
-    the record write and the uniqueness constraint.
-    """
-    return " ".join(identity.split()).casefold()
 
 
 class ReviewVerdictError(ValueError):

--- a/src/teatree/core/models/review_verdict.py
+++ b/src/teatree/core/models/review_verdict.py
@@ -137,7 +137,18 @@ class ReviewVerdictManager(models.Manager["ReviewVerdict"]):
     """Read surface for the recorded-verdict lookup (``review status``)."""
 
     def for_pr(self, slug: str, pr_id: int) -> "models.QuerySet[ReviewVerdict]":
-        return self.filter(slug=slug.strip(), pr_id=pr_id)
+        """Every recorded verdict for *slug*``#``*pr_id*, matched case-INSENSITIVELY.
+
+        A forge slug is case-insensitive, so a verdict recorded under ``Owner/Repo``
+        vouches for the same PR the merge gate resolves as ``owner/repo``. Matching
+        exactly made such a verdict invisible to
+        :func:`~teatree.core.merge.authorization.assert_review_verdict_gate`, which
+        then refused the merge permanently while ``review status`` still showed the
+        merge_safe verdict. Every sibling resolver in the subsystem — the
+        ``PullRequest`` lookup, the §15 sibling supersede, the merge-quality ticket
+        resolver — reads ``__iexact`` for the same reason.
+        """
+        return self.filter(slug__iexact=slug.strip(), pr_id=pr_id)
 
     def latest_for_pr(self, slug: str, pr_id: int) -> "ReviewVerdict | None":
         """The most recently recorded verdict for a PR, regardless of SHA.

--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -110,7 +110,7 @@ class Task(models.Model):
 
     def save(self, *args: object, **kwargs: object) -> None:
         if self._state.adding and self.execution_target == self.ExecutionTarget.HEADLESS:
-            self._default_loop_dispatched_to_interactive()
+            self._route_loop_dispatched_lane()
         super().save(*args, **kwargs)  # type: ignore[arg-type]
 
     def display_subject(self) -> str:
@@ -143,11 +143,11 @@ class Task(models.Model):
 
         Pure registry membership (``SUBAGENT_BY_PHASE``). Whether such a task
         runs in-session or headless is the ``agent_runtime`` setting's call,
-        resolved by ``headless_dispatch.runs_in_session``: under ``interactive``
-        (default) it is dispatched per-phase by the in-session ``/loop`` slot
-        (``loop_dispatch claim-next`` → the ``Agent`` tool); under a headless
-        runtime it runs via ``agents/headless.py``. A pair with no registered
-        agent is free-form headless work and always runs headless.
+        resolved by ``headless_dispatch.runs_in_session``: under the SHIPPED
+        ``headless`` runtime it runs via ``agents/headless.py``; only under
+        ``interactive`` is it dispatched per-phase by the in-session ``/loop``
+        slot (``loop_dispatch claim-next`` → the ``Agent`` tool). A pair with no
+        registered agent is free-form headless work and always runs headless.
         """
         from teatree.core.modelkit.phases import subagent_for_phase  # noqa: PLC0415 — deferred: call-time import
 
@@ -175,17 +175,19 @@ class Task(models.Model):
             role_phase |= Q(ticket__role=role, phase__in=phase_spellings(phase))
         return role_phase & not_under_external_delivery_q()
 
-    def _default_loop_dispatched_to_interactive(self) -> None:
-        """Route a freshly-created loop-dispatched phase task to INTERACTIVE.
+    def _route_loop_dispatched_lane(self) -> None:
+        """Route a freshly-created loop-dispatched phase task to its configured lane.
 
-        The single chokepoint for "phase tasks default to interactive": when the
-        ``agent_runtime`` setting selects ``interactive`` the loop
-        is their sole dispatcher, so every ``schedule_*`` / scanner / CLI creation
-        site inherits the rule here without each having to know it. Under
-        ``agent_runtime=headless`` the row is left HEADLESS so the headless lane
-        takes it. Only an insert-time HEADLESS row is touched; an explicit
-        ``route_to_interactive`` / ``route_to_headless`` after creation goes
-        through ``_route`` (not an insert) and is never overridden here.
+        The single chokepoint for which lane a phase task lands in, so every
+        ``schedule_*`` / scanner / CLI creation site inherits the rule here without
+        each having to know it. Under the SHIPPED ``agent_runtime=headless`` the row
+        is left HEADLESS and the headless lane takes it — that is what a freshly
+        created phase task gets on every shipped install, and this method is a no-op
+        for it. Only an ``interactive`` runtime re-targets the row to INTERACTIVE, for
+        the in-session ``/loop`` slot to dispatch per-phase. Only an insert-time
+        HEADLESS row is touched; an explicit ``route_to_interactive`` /
+        ``route_to_headless`` after creation goes through ``_route`` (not an insert)
+        and is never overridden here.
 
         Mirrors ``headless_dispatch.runs_in_session`` (the predicate the signal /
         drain / refusal gates share). It is inlined here rather than called because

--- a/src/teatree/utils/singleton.py
+++ b/src/teatree/utils/singleton.py
@@ -2,13 +2,16 @@
 
 One teatree instance shares one SQLite DB and one queue of background
 tasks. Two concurrent ``t3 <overlay> worker`` invocations would compete
-for the same rows and double-execute side effects; two concurrent
-``t3 slack listen`` processes would double-ack every Slack event; and N
-concurrent ``t3 loop tick`` processes (one per open Claude Code session,
-each registered by the session-start hook's ``CronCreate``) would race
-on scanner state, the statusline file, and per-row dispatch dedup. Each
-of these wraps its main loop with :func:`singleton` so a second
-invocation refuses to start while the first is alive.
+for the same rows and double-execute side effects, and two concurrent
+``t3 slack listen`` processes would double-ack every Slack event. Those
+are the entry points that wrap their main loop with :func:`singleton`,
+so a second invocation refuses to start while the first is alive.
+
+``t3 loop tick`` is NOT one of them. N concurrent ticks (one per open
+Claude Code session, each registered by the session-start hook's
+``CronCreate``) are held apart by the DB ``loop-tick`` ``LoopLease``
+compare-and-swap; no flock wraps the tick, so an audit of tick
+concurrency reads that lease and never a lock file.
 
 The guard is a non-blocking ``fcntl.flock``. It is kernel-enforced:
 crash-safe (the lock releases when the holder's process dies, with no

--- a/tests/_forge_stub.py
+++ b/tests/_forge_stub.py
@@ -1,0 +1,16 @@
+"""Shared test-infra helper: the changed-files answer every merge-path ``gh`` stub owes.
+
+The substrate detector reads the PR's changed paths at the merge chokepoint and holds
+the merge when that list comes back empty — a real open PR always changes at least one
+file, so ``[]`` is a failed read, not a proven non-substrate diff. A stub whose
+fall-through returns an empty body therefore turns every merge test into a substrate
+hold. Route the fall-through through :func:`changed_files_stdout` so the rule lives in
+one place instead of once per stub.
+"""
+
+_CHANGED_FILES_ENDPOINT = "/files"
+
+
+def changed_files_stdout(joined_argv: str, *, otherwise: str = "") -> str:
+    """One changed path when *joined_argv* is the changed-files read, else *otherwise*."""
+    return "README.md\n" if _CHANGED_FILES_ENDPOINT in joined_argv else otherwise

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -120,11 +120,10 @@
 # PullRequest` — the merge-landed ledger write needs the app registry, same as every
 # other ORM read in this file's group.
 "src/teatree/core/merge/execution.py" = 3
-# souliane/teatree#3840: the keystone post hook moved to its own module and took its two
-# call-time ORM imports with it — the retry helper and the `MergeClear` the atomic block
-# re-reads under the row lock. Same edges, new home; the pair below is execution.py's old
-# 4 split, not a new one.
-"src/teatree/core/merge/post_hook.py" = 2
+# souliane/teatree#3840: the keystone post hook moved to its own module and took its
+# call-time ORM imports with it. Only the retry helper is left deferred — `MergeClear`
+# is now a module-level import, the same edge `ci_rollup` already declares.
+"src/teatree/core/merge/post_hook.py" = 1
 # substrate_standing defers `from teatree.core.overlay_loader import infer_overlay_for_url`
 # so resolving a repo's owning overlay stays a call-time read of the live overlay
 # registry — the edge moved here verbatim from merge/authorization.py (#3648).

--- a/tests/teatree_cli/doctor/test_checks_db_integrity.py
+++ b/tests/teatree_cli/doctor/test_checks_db_integrity.py
@@ -334,3 +334,18 @@ class TestTheHostProjectionIsCurrent:
             assert _check_host_projection_is_current() is False
 
         assert "nothing published" in capsys.readouterr().out
+
+    def test_an_unreadable_source_fails_loud(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # The fault that makes the source unreadable is the same one that stops the
+        # publisher, so a quiet pass reported the projection current on exactly the
+        # failure this check exists to catch — and emitted no line for the JSON parser.
+        db = self._projectable(_sound_db(tmp_path / "db.sqlite3"), 5)
+        ProjectionPublisher(db, db.parent).publish()
+
+        with (
+            _database_config(db, SQLITE_BOUNDARY_ENGINE),
+            patch.object(ProjectionPublisher, "build", side_effect=sqlite3.OperationalError("database is locked")),
+        ):
+            assert _check_host_projection_is_current() is False
+
+        assert "could not read the source generation" in capsys.readouterr().out

--- a/tests/teatree_cli/doctor/test_plain_run_is_non_mutating.py
+++ b/tests/teatree_cli/doctor/test_plain_run_is_non_mutating.py
@@ -1,0 +1,112 @@
+"""A plain ``t3 doctor check`` leaves the operator's settings file alone.
+
+``--repair``'s promise is that a plain run reports drift and writes nothing, and the
+plugin-registration pass is the one finaliser that WRITES — it used to rewrite
+``~/.claude/settings.json`` on every session start. The switch enforcing that promise is
+a single ``repair=repair`` at ``run_doctor_checks``'s call to the advisory finalisers, so
+it is asserted here by its effect on a drifted settings file rather than by the flag's
+value: flipping that one keyword to ``True`` restores the rewrite, and only a file-level
+assertion notices.
+
+The paired ``--repair`` case is the control — without it a test that never writes under
+either flag would pass on a harness that cannot write at all.
+"""
+
+import contextlib
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import teatree.cli.doctor.app as doctor_app_mod
+from teatree.cli.doctor.app import run_doctor_checks
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+_PLUGIN_ID = "t3@souliane"
+_FINALISERS = "_run_advisory_finalisers"
+
+#: The four checks ``run_doctor_checks`` imports inside its own body, patched where the
+#: function binds them (they are not attributes of the doctor app module).
+_DEFERRED_CALLS = (
+    "teatree.core.gates.schema_guard.doctor_check_self_db_migrations",
+    "teatree.cli.doctor.self_heal.run_self_heal_checks",
+    "teatree.cli.update._collect_repos",
+    "teatree.core.gates.clone_guard.doctor_check_clone_currency",
+)
+
+#: Names the aggregate references that are not checks — its own deferred imports of
+#: ``django``/``teatree.core``, the exception it catches, and its output builtins.
+_NOT_A_CHECK = frozenset({"django", "teatree.core", "ImportError", "typer", "echo", "all"})
+
+
+@contextlib.contextmanager
+def _aggregate_reduced_to_its_finalisers() -> Iterator[None]:
+    """Stub every check ``run_doctor_checks`` calls except the advisory finalisers.
+
+    The aggregate probes MCP, Slack and the forge and re-points the running install as
+    it goes, so it can neither run for real under test nor have its forty-odd checks
+    enumerated by hand without rotting. Reading the names off the function's own code
+    object keeps the isolation exact as checks come and go.
+    """
+    with contextlib.ExitStack() as stack:
+        for name in run_doctor_checks.__code__.co_names:
+            if name != _FINALISERS and callable(getattr(doctor_app_mod, name, None)):
+                stack.enter_context(mock.patch.object(doctor_app_mod, name, return_value=True))
+        for target in _DEFERRED_CALLS:
+            stack.enter_context(mock.patch(target, return_value=True))
+        yield
+
+
+@pytest.fixture
+def drifted_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An operator home whose ``settings.json`` does not yet enable the t3 plugin."""
+    clone = tmp_path / "clone"
+    clone.mkdir()
+    (clone / "pyproject.toml").write_text('[project]\nname = "teatree"\n', encoding="utf-8")
+    monkeypatch.setenv("T3_REPO", str(clone))
+
+    home = tmp_path / "home"
+    (home / ".claude" / "plugins").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+
+    settings = home / ".claude" / "settings.json"
+    settings.write_text(json.dumps({"permissions": {"allow": ["Bash(git status)"]}}, indent=2) + "\n", encoding="utf-8")
+    return settings
+
+
+class TestPlainRunNeverWritesTheOperatorsSettings:
+    def test_a_plain_run_leaves_the_drifted_file_byte_identical(self, drifted_settings: Path) -> None:
+        before = drifted_settings.read_bytes()
+
+        with _aggregate_reduced_to_its_finalisers():
+            run_doctor_checks(repair=False)
+
+        assert drifted_settings.read_bytes() == before, (
+            "a plain `t3 doctor check` must report the plugin-registration drift and write "
+            "nothing — the operator's settings file was rewritten"
+        )
+
+    def test_a_repair_run_does_write_it(self, drifted_settings: Path) -> None:
+        with _aggregate_reduced_to_its_finalisers():
+            run_doctor_checks(repair=True)
+
+        written = json.loads(drifted_settings.read_text(encoding="utf-8"))
+        assert written["enabledPlugins"][_PLUGIN_ID] is True
+        assert written["permissions"] == {"allow": ["Bash(git status)"]}
+
+    def test_the_isolation_accounts_for_every_name_the_aggregate_calls(self) -> None:
+        # A check added with a deferred import would otherwise run for real here — against
+        # the operator's own machine — and only show up as a slow, occasionally-mutating test.
+        deferred = {target.rsplit(".", 1)[-1] for target in _DEFERRED_CALLS}
+        deferred |= {target.rsplit(".", 1)[0] for target in _DEFERRED_CALLS}
+        unaccounted = (
+            {name for name in run_doctor_checks.__code__.co_names if not callable(getattr(doctor_app_mod, name, None))}
+            - _NOT_A_CHECK
+            - deferred
+        )
+
+        assert not unaccounted, f"add these to _DEFERRED_CALLS (or _NOT_A_CHECK): {sorted(unaccounted)}"

--- a/tests/teatree_cli/doctor/test_plugin_repair.py
+++ b/tests/teatree_cli/doctor/test_plugin_repair.py
@@ -1,0 +1,112 @@
+"""The plugin-registration pass writes only under ``--repair``, and never over an unreadable file.
+
+Two faults met here. It mutated on EVERY `t3 doctor check` — which the SessionStart
+hook runs — contradicting ``--repair``'s own promise that a plain run never mutates.
+And its JSON read degraded an unparsable file to ``{}``, so a momentarily-broken
+``~/.claude/settings.json`` was replaced wholesale by a one-key file, destroying the
+operator's permissions, hooks, env and statusLine block.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from teatree.cli.doctor.plugin_repair import (
+    _CLAUDE_PLUGIN_ID,
+    UnparsableJson,
+    _do_ensure_plugin_registered,
+    _read_json_safe,
+    _repair_enabled_plugins,
+)
+
+_FULL_SETTINGS = {
+    "permissions": {"allow": ["Bash(git status)"]},
+    "hooks": {"SessionStart": []},
+    "statusLine": {"type": "command", "command": "/usr/local/bin/t3-statusline"},
+}
+
+
+class TestReadJsonSafeSeparatesAbsentFromUnparsable:
+    def test_absent_file_is_an_empty_mapping(self, tmp_path: Path) -> None:
+        assert _read_json_safe(tmp_path / "nothing.json") == {}
+
+    def test_unparsable_file_is_the_sentinel(self, tmp_path: Path) -> None:
+        path = tmp_path / "settings.json"
+        path.write_text('{"permissions": {,}', encoding="utf-8")
+        assert _read_json_safe(path) is UnparsableJson
+
+    def test_readable_file_is_its_content(self, tmp_path: Path) -> None:
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps(_FULL_SETTINGS), encoding="utf-8")
+        assert _read_json_safe(path) == _FULL_SETTINGS
+
+
+class TestEnabledPluginsIsNotWrittenBlind:
+    @staticmethod
+    def _settings_at(home: Path, content: str) -> Path:
+        path = home / ".claude" / "settings.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_a_plain_run_reports_drift_and_writes_nothing(self, tmp_path: Path) -> None:
+        path = self._settings_at(tmp_path, json.dumps(_FULL_SETTINGS))
+        with patch("teatree.cli.doctor.plugin_repair.Path.home", return_value=tmp_path):
+            outcome = _repair_enabled_plugins()
+        assert outcome.written is False
+        assert _CLAUDE_PLUGIN_ID in outcome.detail
+        assert json.loads(path.read_text(encoding="utf-8")) == _FULL_SETTINGS
+
+    def test_repair_enables_the_plugin_and_keeps_every_other_key(self, tmp_path: Path) -> None:
+        path = self._settings_at(tmp_path, json.dumps(_FULL_SETTINGS))
+        with patch("teatree.cli.doctor.plugin_repair.Path.home", return_value=tmp_path):
+            outcome = _repair_enabled_plugins(repair=True)
+        assert outcome.written is True
+        written = json.loads(path.read_text(encoding="utf-8"))
+        assert written["enabledPlugins"][_CLAUDE_PLUGIN_ID] is True
+        assert written["permissions"] == _FULL_SETTINGS["permissions"]
+        assert written["statusLine"] == _FULL_SETTINGS["statusLine"]
+
+    def test_an_unparsable_settings_file_is_never_written_over(self, tmp_path: Path) -> None:
+        broken = '{"permissions": {"allow": ["Bash(git status)"],}'
+        path = self._settings_at(tmp_path, broken)
+        with patch("teatree.cli.doctor.plugin_repair.Path.home", return_value=tmp_path):
+            outcome = _repair_enabled_plugins(repair=True)
+        assert outcome.written is False
+        assert "not readable JSON" in outcome.detail
+        assert path.read_text(encoding="utf-8") == broken
+
+
+class TestTheRegistrationPassHonoursRepair:
+    def test_a_plain_run_writes_no_registration_file(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        home = tmp_path / "home"
+        (home / ".claude" / "plugins").mkdir(parents=True)
+        clone = tmp_path / "clone"
+        clone.mkdir()
+        with (
+            patch("teatree.cli.doctor.plugin_repair.Path.home", return_value=home),
+            patch("teatree.cli.doctor.plugin_repair._resolve_main_clone", return_value=clone),
+        ):
+            assert _do_ensure_plugin_registered() is True
+
+        assert not list((home / ".claude" / "plugins").iterdir())
+        assert not (home / ".claude" / "settings.json").exists()
+        assert "--repair" in capsys.readouterr().out
+
+    def test_repair_writes_all_three(self, tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        (home / ".claude" / "plugins").mkdir(parents=True)
+        clone = tmp_path / "clone"
+        clone.mkdir()
+        with (
+            patch("teatree.cli.doctor.plugin_repair.Path.home", return_value=home),
+            patch("teatree.cli.doctor.plugin_repair._resolve_main_clone", return_value=clone),
+        ):
+            assert _do_ensure_plugin_registered(repair=True) is True
+
+        plugins = home / ".claude" / "plugins"
+        assert (plugins / "known_marketplaces.json").is_file()
+        assert (plugins / "installed_plugins.json").is_file()
+        assert (home / ".claude" / "settings.json").is_file()

--- a/tests/teatree_core/factory/test_chokepoint_registry.py
+++ b/tests/teatree_core/factory/test_chokepoint_registry.py
@@ -35,6 +35,7 @@ _EXPECTED_MERGE_GATES = frozenset(
         "review_verdict",
         "no_active_review_lock",
         "merge_quality",
+        "ticket_scoped_gates",
         "not_draft",
         "ci_verdict",
     },

--- a/tests/teatree_core/gates/test_merge_quality_gate.py
+++ b/tests/teatree_core/gates/test_merge_quality_gate.py
@@ -51,6 +51,7 @@ from teatree.core.models import (
 from teatree.core.models.mechanism_sketch import MechanismSketch
 from teatree.core.models.plan_adequacy import all_negated_adequacy
 from teatree.core.models.review_verdict import ReviewVerdict
+from tests._forge_stub import changed_files_stdout
 
 _FORTY_HEX = "a" * 40
 _OTHER_HEX = "b" * 40
@@ -327,7 +328,7 @@ def _gh_green(argv: list[str]) -> tuple[int, str, str]:
             return (0, out, "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "merged0deadbeef"}', "")
-    return (0, "", "")
+    return (0, changed_files_stdout(joined), "")
 
 
 def _keystone_fixtures(ticket: Ticket) -> MergeClear:

--- a/tests/teatree_core/management/commands/test_clear_verdict_slug.py
+++ b/tests/teatree_core/management/commands/test_clear_verdict_slug.py
@@ -7,11 +7,15 @@ the merge queried the recovered repo — a CLEAR unmergeable for its whole life,
 re-issuing reproducing the same wrong slug.
 """
 
+from typing import cast
 from unittest.mock import patch
 
-from teatree.core.management.commands.ticket import _verdict_slug
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.core.management.commands.ticket import ClearIssueResult, _verdict_slug
 from teatree.core.merge.errors import MergePreconditionError
-from teatree.core.models import ClearRequest
+from teatree.core.models import ClearRequest, MergeClear, ReviewVerdict
 
 _SHA = "b" * 40
 _RECONCILE = "teatree.core.management.commands.ticket._reconcile_slug_against_reviewed_sha"
@@ -47,3 +51,75 @@ class TestVerdictSlug:
         # own SHA bind still refuses a genuinely moved head.
         with patch(_RECONCILE, side_effect=MergePreconditionError("head moved")):
             assert _verdict_slug(_request("merge-candidate-working-repos"), "souliane/teatree") == "souliane/teatree"
+
+
+_PR_ID = 159
+_CLONE_ORIGIN = "souliane/teatree"
+_RECOVERED = "downstream-org/downstream-overlay"
+_STALE_SHA = "c" * 40
+_WORKSTREAM_SLUG = "merge-candidate-working-repos"
+
+
+def _gh_head_by_repo(argv: list[str]) -> tuple[int, str, str]:
+    """A ``gh`` stub whose PR #159 carries the reviewed SHA only in ``_RECOVERED``.
+
+    The clone-origin repo exposes an unrelated same-numbered PR at ``_STALE_SHA``,
+    which is the #1335 shape: the initially-resolved repo answers, just about the
+    wrong PR.
+    """
+    joined = " ".join(argv)
+    return (0, _SHA if _RECOVERED in joined else _STALE_SHA, "")
+
+
+class TestClearCommandReconcilesTheVerdictSlug(TestCase):
+    """``ticket clear`` — not just the helper — keys the verdict where the merge reads it.
+
+    ``_verdict_slug`` is only a fix if issuance calls it: dropping the one call site
+    reverts #1335 whole, leaving the by-product verdict under the clone's ``origin``
+    while the merge gate queries the recovered repo. So the binding is asserted end to
+    end through ``call_command``, with only the ``gh`` subprocess and the overlay-registry
+    enumeration (both machine-dependent) stubbed.
+    """
+
+    def _issue_clear(self) -> ClearIssueResult:
+        with (
+            patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_head_by_repo),
+            patch(
+                "teatree.core.merge.pr_slug_resolution._iter_candidate_repo_slugs",
+                return_value=[_CLONE_ORIGIN, _RECOVERED],
+            ),
+            patch(
+                "teatree.core.management.commands.ticket.resolve_pr_repo_slug",
+                return_value=_CLONE_ORIGIN,
+            ),
+        ):
+            return cast(
+                "ClearIssueResult",
+                call_command(
+                    "ticket",
+                    "clear",
+                    _PR_ID,
+                    _WORKSTREAM_SLUG,
+                    reviewed_sha=_SHA,
+                    reviewer_identity="cold-reviewer",
+                    forge="github",
+                    blast_class="docs",
+                ),
+            )
+
+    def test_the_recorded_verdict_is_keyed_to_the_repo_the_merge_binds(self) -> None:
+        result = self._issue_clear()
+
+        assert result.get("issued") is True, result
+        verdict = ReviewVerdict.objects.get(pr_id=_PR_ID)
+        assert verdict.slug == _RECOVERED, (
+            f"the CLEAR's by-product verdict must be keyed under the reconciled repo the merge "
+            f"gate queries, not the initially-resolved {_CLONE_ORIGIN!r}; got {verdict.slug!r}"
+        )
+
+    def test_the_clear_row_keeps_the_workstream_slug_it_was_issued_with(self) -> None:
+        # The reconcile targets the verdict key alone — the CLEAR itself still records
+        # the workstream slug the orchestrator issued it under.
+        self._issue_clear()
+
+        assert MergeClear.objects.get(pr_id=_PR_ID).slug == _WORKSTREAM_SLUG

--- a/tests/teatree_core/management/commands/test_clear_verdict_slug.py
+++ b/tests/teatree_core/management/commands/test_clear_verdict_slug.py
@@ -1,0 +1,49 @@
+"""The CLEAR's by-product verdict is keyed where the MERGE will look for it.
+
+``resolve_pr_repo_slug`` is only half of the keystone's resolution; the other half is
+the #1335 cross-repo reconcile. Issuance ran only the first half, so a CLEAR for a
+downstream overlay's PR recorded its verdict under the running clone's ``origin`` while
+the merge queried the recovered repo — a CLEAR unmergeable for its whole life, with
+re-issuing reproducing the same wrong slug.
+"""
+
+from unittest.mock import patch
+
+from teatree.core.management.commands.ticket import _verdict_slug
+from teatree.core.merge.errors import MergePreconditionError
+from teatree.core.models import ClearRequest
+
+_SHA = "b" * 40
+_RECONCILE = "teatree.core.management.commands.ticket._reconcile_slug_against_reviewed_sha"
+
+
+def _request(slug: str) -> ClearRequest:
+    return ClearRequest(
+        pr_id=159,
+        slug=slug,
+        reviewed_sha=_SHA,
+        reviewer_identity="cold-reviewer",
+        gh_verify_result="green",
+        blast_class="logic",
+        host_kind="github",
+    )
+
+
+class TestVerdictSlug:
+    def test_an_owner_repo_clear_slug_never_probes_the_forge(self) -> None:
+        with patch(_RECONCILE) as reconcile:
+            assert _verdict_slug(_request("souliane/teatree"), "souliane/teatree") == "souliane/teatree"
+        reconcile.assert_not_called()
+
+    def test_a_workstream_slug_is_reconciled_to_the_repo_the_merge_binds(self) -> None:
+        with patch(_RECONCILE, return_value="downstream-org/overlay") as reconcile:
+            resolved = _verdict_slug(_request("merge-candidate-working-repos"), "souliane/teatree")
+        assert resolved == "downstream-org/overlay"
+        assert reconcile.call_args.kwargs["initial_slug"] == "souliane/teatree"
+        assert reconcile.call_args.kwargs["reviewed_sha"] == _SHA
+
+    def test_a_refused_reconcile_keeps_the_initial_slug(self) -> None:
+        # Issuance must never become STRICTER than the merge gate it feeds; the merge's
+        # own SHA bind still refuses a genuinely moved head.
+        with patch(_RECONCILE, side_effect=MergePreconditionError("head moved")):
+            assert _verdict_slug(_request("merge-candidate-working-repos"), "souliane/teatree") == "souliane/teatree"

--- a/tests/teatree_core/management/commands/test_required_options_reach_call_command.py
+++ b/tests/teatree_core/management/commands/test_required_options_reach_call_command.py
@@ -1,0 +1,54 @@
+"""Gate commands must be invocable through ``call_command`` with plain kwargs.
+
+An ``Annotated[str, typer.Option(...)]`` parameter with no default raises
+``Missing parameter`` under ``call_command`` even when the caller passes the kwarg, so
+every in-process caller had to hand-roll raw argv. These are the gate commands an
+in-process caller reaches for; each takes a default plus a runtime non-blank check.
+"""
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.core.models import Ticket
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+
+class TestNotifyAcceptsKwargs(TestCase):
+    def test_send_reaches_the_idempotency_key_check_via_kwargs(self) -> None:
+        with pytest.raises(SystemExit) as exit_info:
+            call_command("notify", "send", "a body", idempotency_key="")
+        assert exit_info.value.code == 2
+
+    def test_post_reaches_the_channel_check_via_kwargs(self) -> None:
+        with pytest.raises(SystemExit) as exit_info:
+            call_command("notify", "post", channel="", text="hello")
+        assert exit_info.value.code == 2
+
+    def test_react_reaches_the_ts_check_via_kwargs(self) -> None:
+        with pytest.raises(SystemExit) as exit_info:
+            call_command("notify", "react", channel="C1", ts="", emoji="eyes")
+        assert exit_info.value.code == 2
+
+
+class TestTicketGateCommandsAcceptKwargs(TestCase):
+    def _ticket(self) -> Ticket:
+        return Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+
+    def test_dod_override_refuses_a_blank_reason_via_kwargs(self) -> None:
+        with pytest.raises(SystemExit) as exit_info:
+            call_command("ticket", "dod-override", self._ticket().pk, reason="  ")
+        assert exit_info.value.code == 1
+
+    def test_dod_override_records_via_kwargs(self) -> None:
+        ticket = self._ticket()
+        call_command("ticket", "dod-override", ticket.pk, reason="non-UI ticket")
+        ticket.refresh_from_db()
+        assert ticket.extra["dod_e2e_override"]["reason"] == "non-UI ticket"
+
+    def test_e2e_bypass_refuses_a_missing_approver_via_kwargs(self) -> None:
+        with pytest.raises(SystemExit) as exit_info:
+            call_command("ticket", "e2e-bypass", self._ticket().pk, approver="", head_sha="a" * 40)
+        assert exit_info.value.code == 1

--- a/tests/teatree_core/management_commands/test_notify.py
+++ b/tests/teatree_core/management_commands/test_notify.py
@@ -11,8 +11,7 @@ import os
 from io import StringIO
 from unittest.mock import MagicMock, patch
 
-import pytest
-from django.core.management import CommandError, call_command
+from django.core.management import call_command
 from django.test import TestCase
 
 from teatree.core.models import BotPing
@@ -154,8 +153,11 @@ class TestNotifySendSubcommand(TestCase):
         assert "no_messaging_backend" in message
 
     def test_missing_idempotency_key_is_required(self) -> None:
-        with pytest.raises((SystemExit, CommandError)):
-            _call("notify", "send", "body", "--user-id", "U_ME", "--kind", "info")
+        # The option carries a default so `call_command` kwargs reach the body, so an
+        # OMITTED key is refused by the same runtime check a blank one hits, not by
+        # typer's missing-parameter error.
+        _out, code = _call("notify", "send", "body", "--user-id", "U_ME", "--kind", "info")
+        assert code == 2
 
     def test_blank_idempotency_key_exits_two(self) -> None:
         _out, code = _call(

--- a/tests/teatree_core/merge/test_authorization_gates.py
+++ b/tests/teatree_core/merge/test_authorization_gates.py
@@ -95,6 +95,19 @@ class TestReviewerIndependentFacet(TestCase):
         with pytest.raises(MergePreconditionError, match="non-reviewer role"):
             _assert_reviewer_independent(clear, executing_loop_identity="merge-loop")
 
+    def test_reviewer_differing_only_in_case_is_refused(self) -> None:
+        # The identity is free text; ``ReviewVerdict`` canonicalizes case + whitespace,
+        # so a raw comparison let a loop self-issue its own clearance under another
+        # spelling of its own name.
+        clear = _clear(reviewer_identity="Worker-Alpha")
+        with pytest.raises(MergePreconditionError, match="equals the executing loop"):
+            _assert_reviewer_independent(clear, executing_loop_identity="worker-alpha")
+
+    def test_reviewer_differing_only_in_inner_whitespace_is_refused(self) -> None:
+        clear = _clear(reviewer_identity="worker  alpha")
+        with pytest.raises(MergePreconditionError, match="equals the executing loop"):
+            _assert_reviewer_independent(clear, executing_loop_identity="worker alpha")
+
     def test_independent_reviewer_passes(self) -> None:
         _assert_reviewer_independent(_clear(), executing_loop_identity="merge-loop")
 

--- a/tests/teatree_core/merge/test_ci_rollup.py
+++ b/tests/teatree_core/merge/test_ci_rollup.py
@@ -832,6 +832,14 @@ class TestAttachTouchedPaths:
         assert clear.substrate_paths_indeterminate is True
         assert clear.is_substrate() is True
 
+    def test_empty_path_list_holds_as_substrate(self) -> None:
+        # A real open PR always changes >=1 file, so `[]` is a failed read rather than a
+        # confirmed non-substrate diff — the rule ``pr_diff_is_substrate`` already applies.
+        clear = self._logic_clear()
+        attach_touched_paths(clear, _StubQuery([]))
+        assert clear.substrate_paths_indeterminate is True
+        assert clear.is_substrate() is True
+
 
 class TestExpectedRequiredContextsFloor(TestCase):
     """The operator floor fails a DETERMINATE-EMPTY required set closed (Medium finding)."""

--- a/tests/teatree_core/merge/test_host_kind.py
+++ b/tests/teatree_core/merge/test_host_kind.py
@@ -82,7 +82,9 @@ class _GitLabApiStub:
 
     def get_json_paginated(self, endpoint: str) -> list[dict[str, object]]:
         self.calls.append(endpoint)
-        return []
+        # A real open MR always carries at least one diff, so an empty list is a failed
+        # read the substrate gate holds on — scripted here rather than left blank.
+        return [{"new_path": "README.md"}] if "/diffs" in endpoint else []
 
     def put_response(
         self,

--- a/tests/teatree_core/merge/test_slug_scoped_gates.py
+++ b/tests/teatree_core/merge/test_slug_scoped_gates.py
@@ -152,20 +152,25 @@ class TestTicketScopedGatesAtTheSharedChokepoint(TestCase):
         PullRequestFactory(ticket=ticket, repo=_REPO, iid="9003")
         with (
             patch("teatree.core.gates.anti_vacuity_gate.anti_vacuity_required", return_value=True),
-            pytest.raises(MergePreconditionError),
+            pytest.raises(MergePreconditionError, match="require_anti_vacuity_attestation"),
         ):
             assert_ticket_scoped_gates(slug=_REPO, pr_id=9003, head_sha=_SHA)
 
     def test_bound_merge_runs_the_ticket_scoped_gates(self) -> None:
-        """The solo-overlay bypass reaches the forge with no CLEAR — the gate must still fire."""
+        """The solo-overlay bypass reaches the forge with no CLEAR — the gate must still fire.
+
+        The refusal is matched on the ATTESTATION message, not merely on the error type:
+        the not-draft and CI floors below also refuse on an unreachable forge, so a
+        type-only assertion would pass with this gate deleted.
+        """
         ticket = TicketFactory()
         PullRequestFactory(ticket=ticket, repo=_REPO, iid="9004")
         with (
-            patch("teatree.core.merge.authorization.assert_merge_provenance_trusted"),
+            patch("teatree.core.merge.execution.assert_merge_provenance_trusted"),
             patch("teatree.core.merge.execution.assert_review_verdict_gate"),
             patch("teatree.core.merge.execution.assert_no_active_review_lock"),
             patch("teatree.core.gates.merge_quality_gate.assert_merge_quality_verdict"),
             patch("teatree.core.gates.anti_vacuity_gate.anti_vacuity_required", return_value=True),
-            pytest.raises(MergePreconditionError),
+            pytest.raises(MergePreconditionError, match="require_anti_vacuity_attestation"),
         ):
             execute_bound_merge(ref=PrRef(slug=_REPO, pr_id=9004), expected_head_oid=_SHA)

--- a/tests/teatree_core/merge/test_slug_scoped_gates.py
+++ b/tests/teatree_core/merge/test_slug_scoped_gates.py
@@ -1,0 +1,171 @@
+"""The repo-slug boundary the merge gates join on, and the parity between the two merge paths.
+
+A PR's repo slug has several resolutions across the subsystem, and every finding
+pinned here is one place a join was keyed on the WRONG one — a workstream slug that
+matches no PR row, or a case-sensitive match against a case-insensitive forge slug.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.merge.authorization import assert_review_verdict_gate
+from teatree.core.merge.errors import MergePreconditionError
+from teatree.core.merge.execution import execute_bound_merge
+from teatree.core.merge.post_hook import _supersede_siblings
+from teatree.core.merge.ticket_gates import assert_ticket_scoped_gates
+from teatree.core.models import MergeClear, PullRequest, ReviewVerdict
+from teatree.utils.pr_ref import PrRef
+from tests.factories import MergeClearFactory, PullRequestFactory, TicketFactory
+
+_SHA = "a" * 40
+_REPO = "souliane/teatree"
+_WORKSTREAM = "merge-candidate-working-repos"
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+
+class TestReviewVerdictSlugIsCaseInsensitive(TestCase):
+    """A verdict recorded under a differently-cased slug still vouches for the same PR."""
+
+    def test_verdict_recorded_under_other_casing_is_found(self) -> None:
+        ReviewVerdict.record(
+            pr_id=77,
+            slug="Souliane/Teatree",
+            reviewed_sha=_SHA,
+            verdict=ReviewVerdict.Verdict.MERGE_SAFE,
+            reviewer_identity="cold-reviewer",
+        )
+        found = list(ReviewVerdict.objects.for_pr(_REPO, 77))
+        assert [verdict.slug for verdict in found] == ["Souliane/Teatree"]
+
+    def test_merge_gate_reads_the_other_cased_verdict(self) -> None:
+        ReviewVerdict.record(
+            pr_id=78,
+            slug="SOULIANE/TEATREE",
+            reviewed_sha=_SHA,
+            verdict=ReviewVerdict.Verdict.MERGE_SAFE,
+            reviewer_identity="cold-reviewer",
+        )
+        assert_review_verdict_gate(slug=_REPO, pr_id=78, head_sha=_SHA)
+
+
+class TestClearAdoptsItsTicketByRepoSlug(TestCase):
+    """A ticketless CLEAR's workstream slug matches no PR row — the caller supplies the repo."""
+
+    def test_workstream_slug_alone_adopts_nothing(self) -> None:
+        ticket = TicketFactory()
+        PullRequestFactory(ticket=ticket, repo=_REPO, iid="4242")
+        clear = MergeClearFactory(ticket=None, slug=_WORKSTREAM, pr_id=4242)
+        assert clear.adopt_owning_ticket() is None
+
+    def test_repo_slug_adopts_the_prs_ticket(self) -> None:
+        ticket = TicketFactory()
+        PullRequestFactory(ticket=ticket, repo=_REPO, iid="4243")
+        clear = MergeClearFactory(ticket=None, slug=_WORKSTREAM, pr_id=4243)
+        assert clear.adopt_owning_ticket(_REPO) == ticket
+        clear.refresh_from_db()
+        assert clear.ticket == ticket
+
+    def test_landed_merge_records_the_pr_under_the_repo_slug(self) -> None:
+        ticket = TicketFactory()
+        pr = PullRequestFactory(ticket=ticket, repo=_REPO, iid="4244", state=PullRequest.State.OPEN)
+        clear = MergeClearFactory(ticket=None, slug=_WORKSTREAM, pr_id=4244)
+        assert clear.record_merged_pull_request(_REPO) == ticket
+        pr.refresh_from_db()
+        assert pr.state == PullRequest.State.MERGED
+
+
+class TestSiblingSupersedeIsRepoScoped(TestCase):
+    """A workstream slug is shared across repos, so it can never scope the §15 supersede."""
+
+    _issue = 0
+
+    def _clear_for(self, *, repo: str, pr_id: int) -> "MergeClear":
+        """A ticketless-shaped CLEAR whose repo is knowable only through its ticket's issue URL."""
+        TestSiblingSupersedeIsRepoScoped._issue += 1
+        ticket = TicketFactory(issue_url=f"https://github.com/{repo}/issues/{self._issue}")
+        return MergeClearFactory.create(ticket=ticket, slug=_WORKSTREAM, pr_id=pr_id)
+
+    def test_another_repos_live_clear_survives(self) -> None:
+        merged = self._clear_for(repo=_REPO, pr_id=42)
+        other = self._clear_for(repo="souliane/other-repo", pr_id=42)
+        merged.consumed_at = merged.issued_at
+        merged.save(update_fields=["consumed_at"])
+
+        _supersede_siblings(merged, repo_slug=_REPO)
+
+        other.refresh_from_db()
+        assert other.consumed_at is None
+
+    def test_same_repos_stale_sibling_is_consumed(self) -> None:
+        merged = self._clear_for(repo=_REPO, pr_id=43)
+        stale = self._clear_for(repo=_REPO, pr_id=43)
+        merged.consumed_at = merged.issued_at
+        merged.save(update_fields=["consumed_at"])
+
+        _supersede_siblings(merged, repo_slug=_REPO)
+
+        stale.refresh_from_db()
+        assert stale.consumed_at == merged.consumed_at
+
+    def test_owner_repo_slug_supersedes_without_a_merge_time_repo(self) -> None:
+        merged = MergeClearFactory(slug=_REPO, pr_id=44)
+        stale = MergeClearFactory(slug="Souliane/Teatree", pr_id=44)
+        merged.consumed_at = merged.issued_at
+        merged.save(update_fields=["consumed_at"])
+
+        _supersede_siblings(merged, repo_slug="")
+
+        stale.refresh_from_db()
+        assert stale.consumed_at == merged.consumed_at
+
+    def test_unknown_merge_time_repo_supersedes_nothing(self) -> None:
+        merged = self._clear_for(repo=_REPO, pr_id=45)
+        sibling = self._clear_for(repo=_REPO, pr_id=45)
+        merged.consumed_at = merged.issued_at
+        merged.save(update_fields=["consumed_at"])
+
+        _supersede_siblings(merged, repo_slug="")
+
+        sibling.refresh_from_db()
+        assert sibling.consumed_at is None
+
+
+class TestTicketScopedGatesAtTheSharedChokepoint(TestCase):
+    """Both merge paths cross ``execute_bound_merge``; the ticket-scoped gates must run there."""
+
+    def test_unresolvable_ticket_is_a_no_op_with_both_settings_off(self) -> None:
+        assert_ticket_scoped_gates(slug=_REPO, pr_id=9001, head_sha=_SHA)
+
+    def test_unresolvable_ticket_refuses_while_a_setting_is_in_force(self) -> None:
+        with (
+            patch("teatree.core.gates.anti_vacuity_gate.anti_vacuity_required", return_value=True),
+            pytest.raises(MergePreconditionError, match="no owning ticket resolves"),
+        ):
+            assert_ticket_scoped_gates(slug=_REPO, pr_id=9002, head_sha=_SHA)
+
+    def test_resolved_ticket_without_an_attestation_is_refused(self) -> None:
+        ticket = TicketFactory()
+        PullRequestFactory(ticket=ticket, repo=_REPO, iid="9003")
+        with (
+            patch("teatree.core.gates.anti_vacuity_gate.anti_vacuity_required", return_value=True),
+            pytest.raises(MergePreconditionError),
+        ):
+            assert_ticket_scoped_gates(slug=_REPO, pr_id=9003, head_sha=_SHA)
+
+    def test_bound_merge_runs_the_ticket_scoped_gates(self) -> None:
+        """The solo-overlay bypass reaches the forge with no CLEAR — the gate must still fire."""
+        ticket = TicketFactory()
+        PullRequestFactory(ticket=ticket, repo=_REPO, iid="9004")
+        with (
+            patch("teatree.core.merge.authorization.assert_merge_provenance_trusted"),
+            patch("teatree.core.merge.execution.assert_review_verdict_gate"),
+            patch("teatree.core.merge.execution.assert_no_active_review_lock"),
+            patch("teatree.core.gates.merge_quality_gate.assert_merge_quality_verdict"),
+            patch("teatree.core.gates.anti_vacuity_gate.anti_vacuity_required", return_value=True),
+            pytest.raises(MergePreconditionError),
+        ):
+            execute_bound_merge(ref=PrRef(slug=_REPO, pr_id=9004), expected_head_oid=_SHA)

--- a/tests/teatree_core/test_clear_issuance_and_human_substrate.py
+++ b/tests/teatree_core/test_clear_issuance_and_human_substrate.py
@@ -44,6 +44,7 @@ from teatree.core.models import (
     Ticket,
 )
 from teatree.utils.pr_ref import PrRef
+from tests._forge_stub import changed_files_stdout
 from tests.teatree_core.conftest import seed_merge_safe_verdict
 
 
@@ -125,7 +126,7 @@ def _gh_stub(argv: list[str]) -> tuple[int, str, str]:
         return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "landed00deadbeef"}', "")
-    return (0, "", "")
+    return (0, changed_files_stdout(joined), "")
 
 
 class TestClearIssuanceSeam(TestCase):
@@ -1448,20 +1449,21 @@ class TestClearCanonicalizesVerdictSlug(TestCase):
             state=Ticket.State.IN_REVIEW,
             issue_url="https://github.com/souliane/teatree/issues/859",
         )
-        result = cast(
-            "dict[str, object]",
-            call_command(
-                "ticket",
-                "clear",
-                "859",
-                "teatree",
-                reviewed_sha=_SHA,
-                reviewer_identity="cold-reviewer",
-                gh_verify_result="green",
-                blast_class="docs",
-                ticket_id=int(ticket.pk),
-            ),
-        )
+        with patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_stub):
+            result = cast(
+                "dict[str, object]",
+                call_command(
+                    "ticket",
+                    "clear",
+                    "859",
+                    "teatree",
+                    reviewed_sha=_SHA,
+                    reviewer_identity="cold-reviewer",
+                    gh_verify_result="green",
+                    blast_class="docs",
+                    ticket_id=int(ticket.pk),
+                ),
+            )
         assert result["issued"]
         clear = MergeClear.objects.get(pk=result["clear_id"])
         assert clear.slug == "teatree"
@@ -1514,20 +1516,21 @@ class TestClearCanonicalizesVerdictSlug(TestCase):
             state=Ticket.State.IN_REVIEW,
             issue_url="https://github.com/souliane/teatree/issues/859",
         )
-        result = cast(
-            "dict[str, object]",
-            call_command(
-                "ticket",
-                "clear",
-                "859",
-                "  fix/clear-slug  ",
-                reviewed_sha=_SHA,
-                reviewer_identity="cold-reviewer",
-                gh_verify_result="green",
-                blast_class="docs",
-                ticket_id=int(ticket.pk),
-            ),
-        )
+        with patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_stub):
+            result = cast(
+                "dict[str, object]",
+                call_command(
+                    "ticket",
+                    "clear",
+                    "859",
+                    "  fix/clear-slug  ",
+                    reviewed_sha=_SHA,
+                    reviewer_identity="cold-reviewer",
+                    gh_verify_result="green",
+                    blast_class="docs",
+                    ticket_id=int(ticket.pk),
+                ),
+            )
         assert result["issued"]
         clear = MergeClear.objects.get(pk=result["clear_id"])
         assert clear.slug == "fix/clear-slug"
@@ -1599,9 +1602,12 @@ class TestClearResolvesVerdictSlugBeforeIssuing(TestCase):
 
     def test_clone_origin_fallback_still_issues_and_records_verdict(self) -> None:
         """The happy twin: a resolvable clone origin issues the CLEAR and records the verdict under it."""
-        with patch(
-            "teatree.core.merge.pr_slug_resolution._project_repo_slug",
-            return_value="souliane/teatree",
+        with (
+            patch(
+                "teatree.core.merge.pr_slug_resolution._project_repo_slug",
+                return_value="souliane/teatree",
+            ),
+            patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_stub),
         ):
             result = cast(
                 "dict[str, object]",

--- a/tests/teatree_core/test_is_non_reviewer_role.py
+++ b/tests/teatree_core/test_is_non_reviewer_role.py
@@ -16,6 +16,7 @@ from django.test import TestCase
 from teatree.core.merge import MergePreconditionError, merge_ticket_pr
 from teatree.core.models import MergeClear, Ticket
 from teatree.core.models.merge_clear import ClearIssuanceError, ClearRequest, is_non_reviewer_role
+from tests._forge_stub import changed_files_stdout
 from tests.teatree_core.conftest import seed_merge_safe_verdict
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -46,9 +47,7 @@ def _gh_stub(argv: list[str]) -> tuple[int, str, str]:
         return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "landed00deadbeef"}', "")
-    # A real open PR always changes >=1 file, so an empty list is a failed read
-    # the substrate gate holds on.
-    return (0, "README.md\n" if "/files" in joined else "", "")
+    return (0, changed_files_stdout(joined), "")
 
 
 class TestIsNonReviewerRoleUnit(TestCase):

--- a/tests/teatree_core/test_is_non_reviewer_role.py
+++ b/tests/teatree_core/test_is_non_reviewer_role.py
@@ -46,7 +46,9 @@ def _gh_stub(argv: list[str]) -> tuple[int, str, str]:
         return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "landed00deadbeef"}', "")
-    return (0, "", "")
+    # A real open PR always changes >=1 file, so an empty list is a failed read
+    # the substrate gate holds on.
+    return (0, "README.md\n" if "/files" in joined else "", "")
 
 
 class TestIsNonReviewerRoleUnit(TestCase):
@@ -112,6 +114,23 @@ class TestIssueTimeMergeLoopBlockedIntegration(TestCase):
                     reviewed_sha=_SHA,
                     reviewer_identity="merge-loop",
                     executing_loop_identity="other-loop",
+                    gh_verify_result="green",
+                    blast_class="logic",
+                )
+            )
+        assert MergeClear.objects.count() == 0
+
+    def test_issue_with_differently_cased_executing_loop_raises(self) -> None:
+        # Issue-time and merge-time canonicalize the identity identically, so a
+        # re-spelling of the executor's own name cannot self-issue a clearance.
+        with pytest.raises(ClearIssuanceError, match="equals the executing loop identity"):
+            MergeClear.issue(
+                ClearRequest(
+                    pr_id=1602,
+                    slug="souliane/teatree",
+                    reviewed_sha=_SHA,
+                    reviewer_identity="Worker-Alpha",
+                    executing_loop_identity="worker-alpha",
                     gh_verify_result="green",
                     blast_class="logic",
                 )

--- a/tests/teatree_core/test_lifecycle_reviewer_attestation.py
+++ b/tests/teatree_core/test_lifecycle_reviewer_attestation.py
@@ -19,6 +19,7 @@ from django.test import TestCase
 
 from teatree.core.management.commands.lifecycle import ReviewerAttestationError
 from teatree.core.models import MergeClear, Session, Ticket
+from tests._forge_stub import changed_files_stdout
 from tests.teatree_core.conftest import seed_merge_safe_verdict
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -106,7 +107,7 @@ class TestTicketMergeKeystoneCli(TestCase):
             return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
         if "pulls" in joined and "merge" in joined:
             return (0, '{"sha": "landed00"}', "")
-        return (0, "", "")
+        return (0, changed_files_stdout(joined), "")
 
     def test_ticket_merge_advances_in_review_to_merged(self) -> None:
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)

--- a/tests/teatree_core/test_merge_candidate_working_repos.py
+++ b/tests/teatree_core/test_merge_candidate_working_repos.py
@@ -36,6 +36,7 @@ from teatree.config import OverlayEntry
 from teatree.core.merge import MergePreconditionError, merge_ticket_pr, pr_slug_resolution
 from teatree.core.models import MergeClear
 from teatree.core.overlay import OverlayBase, OverlayReview
+from tests._forge_stub import changed_files_stdout
 from tests.teatree_core.conftest import seed_merge_safe_verdict
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -155,7 +156,7 @@ def _gh_keyed_by_repo(calls: list[list[str]], right_repo: str):
             return (0, '{"state": "OPEN", "mergeCommit": null}', "")
         if "pulls" in joined and "merge" in joined:
             return (0, '{"sha": "merged0deadbeef"}', "")
-        return (0, "", "")
+        return (0, changed_files_stdout(joined), "")
 
     return _gh
 
@@ -254,7 +255,7 @@ class TestWorkingRepoCandidateEnumeration(TestCase):
                 return (0, "false", "")
             if "statusCheckRollup" in joined:
                 return (0, _GREEN, "")
-            return (0, "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with (
             patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_all_wrong),

--- a/tests/teatree_core/test_merge_clear_verdict_must_be_merge_safe.py
+++ b/tests/teatree_core/test_merge_clear_verdict_must_be_merge_safe.py
@@ -60,7 +60,9 @@ def _gh_stub_live_green(argv: list[str]) -> tuple[int, str, str]:
         return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "landed00deadbeef"}', "")
-    return (0, "", "")
+    # A real open PR always changes >=1 file, so an empty list is a failed read
+    # the substrate gate holds on.
+    return (0, "README.md\n" if "/files" in joined else "", "")
 
 
 class TestNonGreenVerdictNeverIssuable(TestCase):

--- a/tests/teatree_core/test_merge_clear_verdict_must_be_merge_safe.py
+++ b/tests/teatree_core/test_merge_clear_verdict_must_be_merge_safe.py
@@ -23,6 +23,7 @@ from django.test import TestCase
 
 from teatree.core.merge import MergePreconditionError, merge_ticket_pr
 from teatree.core.models import MergeAudit, MergeClear
+from tests._forge_stub import changed_files_stdout
 from tests.factories import _FORTY_HEX, MergeClearFactory, TicketFactory
 from tests.teatree_core.conftest import seed_merge_safe_verdict
 
@@ -60,9 +61,7 @@ def _gh_stub_live_green(argv: list[str]) -> tuple[int, str, str]:
         return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "landed00deadbeef"}', "")
-    # A real open PR always changes >=1 file, so an empty list is a failed read
-    # the substrate gate holds on.
-    return (0, "README.md\n" if "/files" in joined else "", "")
+    return (0, changed_files_stdout(joined), "")
 
 
 class TestNonGreenVerdictNeverIssuable(TestCase):

--- a/tests/teatree_core/test_merge_execution.py
+++ b/tests/teatree_core/test_merge_execution.py
@@ -34,6 +34,7 @@ from teatree.core.merge import (
 )
 from teatree.core.models import ClearRequest, MergeAudit, MergeClear, PullRequest, Session, Ticket, Worktree
 from teatree.utils.pr_ref import PrRef
+from tests._forge_stub import changed_files_stdout
 from tests.teatree_core.conftest import CommandOverlay
 
 _GIT = shutil.which("git") or "git"
@@ -180,7 +181,7 @@ class _GhStub:
         if "pulls" in joined and "merge" in joined:
             moved = "Head branch was modified. Review and try the merge again. (409)"
             return (1, "", moved) if self.merge_rc != 0 else (0, '{"sha": "merged0deadbeef"}', "")
-        return (0, "", "")
+        return (0, changed_files_stdout(joined), "")
 
 
 def _run(clear: MergeClear, stub: _GhStub, identity: str = "merge-loop") -> MergeOutcome:
@@ -382,9 +383,10 @@ class TestMergeExecutionEdgeCases(TestCase):
         clear = _clear(ticket)
 
         def _no_head(argv: list[str]) -> tuple[int, str, str]:
-            if "headRefOid" in " ".join(argv):
+            joined = " ".join(argv)
+            if "headRefOid" in joined:
                 return (1, "", "boom")
-            return (0, "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with (
             patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_no_head),
@@ -402,7 +404,7 @@ class TestMergeExecutionEdgeCases(TestCase):
                 return probe
             if "pulls" in joined and "merge" in joined:
                 return (1, "", "500 Internal Server Error")
-            return (0, "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with (
             patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_merge_500),
@@ -506,7 +508,7 @@ class TestMergeExecutionEdgeCases(TestCase):
                 return (0, "false", "")
             if "statusCheckRollup" in joined:
                 return (1, "", "api error")
-            return (0, "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with (
             patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_rollup_rc1),
@@ -579,7 +581,7 @@ class TestMergeExecutionEdgeCases(TestCase):
                 return probe
             if "pulls" in joined and "merge" in joined:
                 return (0, "not-json-at-all", "")
-            return (0, "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_bad_merge_json):
             outcome = merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
@@ -648,7 +650,7 @@ class _LostPostHookGhStub:
             return (0, self._merge_state_payload(), "")
         if "pulls" in joined and "merge" in joined:
             return self._do_merge()
-        return (0, "", "")
+        return (0, changed_files_stdout(joined), "")
 
 
 class TestLostPostHookRecoverable(TestCase):
@@ -719,7 +721,7 @@ class TestLostPostHookRecoverable(TestCase):
                 return (0, _GREEN, "")
             if "state,mergeCommit" in joined:
                 return (0, '{"state": "MERGED", "mergeCommit": {"oid": "othermerge0"}}', "")
-            return (0, "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with (
             patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_merged_other_head),
@@ -744,7 +746,7 @@ class TestLostPostHookRecoverable(TestCase):
                 return probe
             if "state,mergeCommit" in joined:
                 return (0, '{"state": "MERGED", "mergeCommit": null}', "")
-            return (0, "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_merged_no_commit):
             outcome = merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
@@ -1131,7 +1133,7 @@ class _TransientThenSuccessGhStub:
                 return (1, "", "unexpected end of JSON input")
             self.merged = True
             return (0, '{"sha": "merged0deadbeef"}', "")
-        return (0, "", "")
+        return (0, changed_files_stdout(joined), "")
 
 
 class TestTransientMergeRetry(TestCase):
@@ -1198,7 +1200,7 @@ class TestTransientMergeRetry(TestCase):
             if "pulls" in joined and "merge" in joined:
                 attempts["merge"] += 1
                 return (1, "", "Pull Request is not mergeable (405)")
-            return (0, "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with (
             patch("teatree.core.merge.execution.time.sleep") as sleep,
@@ -1225,7 +1227,7 @@ class TestTransientMergeRetry(TestCase):
             if "pulls" in joined and "merge" in joined:
                 attempts["merge"] += 1
                 return (1, "", "Head branch was modified. Review and try the merge again. (409)")
-            return (0, "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with (
             patch("teatree.core.merge.execution.time.sleep"),
@@ -1258,7 +1260,7 @@ class TestTransientMergeRetry(TestCase):
                 # The merge lands at GitHub but the response is truncated.
                 state["merged"] = True
                 return (1, "", "unexpected end of JSON input")
-            return (0, "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with (
             patch("teatree.core.merge.execution.time.sleep"),
@@ -1296,7 +1298,7 @@ class TestTransientMergeRetry(TestCase):
             if "pulls" in joined and "merge" in joined:
                 attempts["merge"] += 1
                 return (1, "", "")
-            return (0, "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with (
             patch("teatree.core.merge.execution.time.sleep"),

--- a/tests/teatree_core/test_merge_execution_author_gate.py
+++ b/tests/teatree_core/test_merge_execution_author_gate.py
@@ -26,6 +26,7 @@ from teatree.core.merge.execution import execute_bound_merge, merge_ticket_pr
 from teatree.core.models import MergeClear, Ticket, TrustedIdentity
 from teatree.core.review import author_trust
 from teatree.utils.pr_ref import PrRef
+from tests._forge_stub import changed_files_stdout
 from tests.teatree_core.conftest import CommandOverlay, seed_merge_safe_verdict
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -84,7 +85,7 @@ class _GhStub:
                 return (0, out, "")
         if "pulls" in joined and "merge" in joined:
             return (0, '{"sha": "merged0deadbeef"}', "")
-        return (0, "", "")
+        return (0, changed_files_stdout(joined), "")
 
     @property
     def attempted_merge(self) -> bool:

--- a/tests/teatree_core/test_merge_execution_cross_repo.py
+++ b/tests/teatree_core/test_merge_execution_cross_repo.py
@@ -31,6 +31,7 @@ from teatree.core.merge import MergePreconditionError, merge_ticket_pr, resolve_
 from teatree.core.merge.authorization import assert_review_verdict_gate
 from teatree.core.merge.pr_slug_resolution import _reconcile_slug_against_reviewed_sha
 from teatree.core.models import MergeAudit, MergeClear, ReviewVerdict, Ticket
+from tests._forge_stub import changed_files_stdout
 from tests.teatree_core.conftest import seed_merge_safe_verdict
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -109,9 +110,7 @@ def _gh_keyed_by_repo(calls: list[list[str]], right_repo: str = _OVERLAY_REPO):
             return (0, '{"state": "OPEN", "mergeCommit": null}', "")
         if "pulls" in joined and "merge" in joined:
             return (0, '{"sha": "merged0deadbeef"}', "")
-        # A real open PR always changes >=1 file, so an empty list is a failed read
-        # the substrate gate holds on.
-        return (0, "README.md\n" if "/files" in joined else "", "")
+        return (0, changed_files_stdout(joined), "")
 
     return _gh
 
@@ -201,9 +200,7 @@ class TestCrossRepoCandidateProbe(TestCase):
                 return (0, "false", "")
             if "statusCheckRollup" in joined:
                 return (0, _GREEN, "")
-            # A real open PR always changes >=1 file, so an empty list is a failed read
-            # the substrate gate holds on.
-            return (0, "README.md\n" if "/files" in joined else "", "")
+            return (0, changed_files_stdout(joined), "")
 
         def _remote_slug_for_path(repo: str = ".", remote: str = "origin") -> str:
             del remote
@@ -267,9 +264,7 @@ class TestCrossRepoCandidateProbe(TestCase):
                 return (0, '{"state": "OPEN", "mergeCommit": null}', "")
             if "pulls" in joined and "merge" in joined:
                 return (0, '{"sha": "merged0deadbeef"}', "")
-            # A real open PR always changes >=1 file, so an empty list is a failed read
-            # the substrate gate holds on.
-            return (0, "README.md\n" if "/files" in joined else "", "")
+            return (0, changed_files_stdout(joined), "")
 
         def _remote_slug_for_path(repo: str = ".", remote: str = "origin") -> str:
             del remote
@@ -381,7 +376,11 @@ class TestUrlFormCrossRepoClearVerdictStaysConsistent(TestCase):
         )
         # The CLEAR slug is a bare workstream name; the real repo (Y) is resolved
         # from the ticket issue_url, NOT the running clone's origin (X).
-        with patch("teatree.core.merge.pr_slug_resolution._project_repo_slug", return_value=_CLONE_ORIGIN):
+        issue_calls: list[list[str]] = []
+        with (
+            patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_keyed_by_repo(issue_calls)),
+            patch("teatree.core.merge.pr_slug_resolution._project_repo_slug", return_value=_CLONE_ORIGIN),
+        ):
             issued = cast(
                 "dict[str, object]",
                 call_command(
@@ -421,17 +420,21 @@ class TestTicketlessWorkstreamCrossRepoClearFailsClosed(TestCase):
 
     A TICKETLESS CLEAR with a workstream slug for a PR that lives in a downstream
     overlay repo resolves (``resolve_pr_repo_slug``) only to the running clone's
-    ``origin`` (X) — the real repo (Y) is discoverable solely by the forge-probing
-    ``_reconcile_slug_against_reviewed_sha`` at merge time. So the by-product
-    verdict is recorded under X while the #2829 gate looks it up under the
-    reconciled Y — a miss. Closing this consistently would need the forge probe to
-    run at CLEAR-issue time (coupling issuance to forge connectivity and breaking
-    the forge-free clear contract), so it is out of the tactical scope. It fails
-    CLOSED (a refusal, never a silent mismerge), which this pins.
+    ``origin`` (X). Issuance now runs the same forge-probing
+    ``_reconcile_slug_against_reviewed_sha`` the merge runs, so the two agree
+    whenever the probe can SEE the real repo (Y) — but the probe enumerates
+    candidates from the overlays discoverable in the issuing process, and here that
+    set is empty. So the by-product verdict is recorded under X while the #2829 gate
+    looks it up under the Y the merge-time probe recovers — a miss. That residual
+    window fails CLOSED (a refusal, never a silent mismerge), which this pins.
     """
 
     def test_cross_repo_merge_refuses_when_verdict_is_under_clone_origin(self) -> None:
-        with patch("teatree.core.merge.pr_slug_resolution._project_repo_slug", return_value=_CLONE_ORIGIN):
+        issue_calls: list[list[str]] = []
+        with (
+            patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_keyed_by_repo(issue_calls)),
+            patch("teatree.core.merge.pr_slug_resolution._project_repo_slug", return_value=_CLONE_ORIGIN),
+        ):
             issued = cast(
                 "dict[str, object]",
                 call_command(

--- a/tests/teatree_core/test_merge_execution_cross_repo.py
+++ b/tests/teatree_core/test_merge_execution_cross_repo.py
@@ -109,7 +109,9 @@ def _gh_keyed_by_repo(calls: list[list[str]], right_repo: str = _OVERLAY_REPO):
             return (0, '{"state": "OPEN", "mergeCommit": null}', "")
         if "pulls" in joined and "merge" in joined:
             return (0, '{"sha": "merged0deadbeef"}', "")
-        return (0, "", "")
+        # A real open PR always changes >=1 file, so an empty list is a failed read
+        # the substrate gate holds on.
+        return (0, "README.md\n" if "/files" in joined else "", "")
 
     return _gh
 
@@ -199,7 +201,9 @@ class TestCrossRepoCandidateProbe(TestCase):
                 return (0, "false", "")
             if "statusCheckRollup" in joined:
                 return (0, _GREEN, "")
-            return (0, "", "")
+            # A real open PR always changes >=1 file, so an empty list is a failed read
+            # the substrate gate holds on.
+            return (0, "README.md\n" if "/files" in joined else "", "")
 
         def _remote_slug_for_path(repo: str = ".", remote: str = "origin") -> str:
             del remote
@@ -263,7 +267,9 @@ class TestCrossRepoCandidateProbe(TestCase):
                 return (0, '{"state": "OPEN", "mergeCommit": null}', "")
             if "pulls" in joined and "merge" in joined:
                 return (0, '{"sha": "merged0deadbeef"}', "")
-            return (0, "", "")
+            # A real open PR always changes >=1 file, so an empty list is a failed read
+            # the substrate gate holds on.
+            return (0, "README.md\n" if "/files" in joined else "", "")
 
         def _remote_slug_for_path(repo: str = ".", remote: str = "origin") -> str:
             del remote

--- a/tests/teatree_core/test_merge_execution_gitlab.py
+++ b/tests/teatree_core/test_merge_execution_gitlab.py
@@ -151,7 +151,9 @@ class _GitLabApiStub:
 
     def get_json_paginated(self, endpoint: str) -> list[dict[str, object]]:
         self.calls.append(endpoint)
-        return []
+        # A real open MR always changes >=1 file, so an empty diff is a failed read
+        # the substrate gate holds on.
+        return [{"new_path": "README.md"}] if "/diffs" in endpoint else []
 
     def put_response(
         self,

--- a/tests/teatree_core/test_merge_expedite_waiver.py
+++ b/tests/teatree_core/test_merge_expedite_waiver.py
@@ -29,6 +29,7 @@ from teatree.core.models import (
     ReviewVerdictError,
     Ticket,
 )
+from tests._forge_stub import changed_files_stdout
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
@@ -83,9 +84,7 @@ class _GhStub:
             return (0, self.checks, "")
         if "pulls" in joined and "merge" in joined:
             return (0, '{"sha": "expedited0merged"}', "")
-        # A real open PR always changes >=1 file, so an empty list is a failed read
-        # the substrate gate holds on.
-        return (0, "README.md\n" if "/files" in joined else "", "")
+        return (0, changed_files_stdout(joined), "")
 
 
 def _pending_stub() -> _GhStub:

--- a/tests/teatree_core/test_merge_expedite_waiver.py
+++ b/tests/teatree_core/test_merge_expedite_waiver.py
@@ -83,7 +83,9 @@ class _GhStub:
             return (0, self.checks, "")
         if "pulls" in joined and "merge" in joined:
             return (0, '{"sha": "expedited0merged"}', "")
-        return (0, "", "")
+        # A real open PR always changes >=1 file, so an empty list is a failed read
+        # the substrate gate holds on.
+        return (0, "README.md\n" if "/files" in joined else "", "")
 
 
 def _pending_stub() -> _GhStub:

--- a/tests/teatree_core/test_merge_head_guard.py
+++ b/tests/teatree_core/test_merge_head_guard.py
@@ -26,6 +26,7 @@ from django.test import TestCase
 from teatree.core.merge import merge_ticket_pr, restore_caller_branch
 from teatree.core.merge.head_guard import _capture_head, _restore_head
 from teatree.core.models import MergeClear, Ticket
+from tests._forge_stub import changed_files_stdout
 from tests.teatree_core.conftest import seed_merge_safe_verdict
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -126,7 +127,7 @@ def _gh_ok(argv: list[str]) -> tuple[int, str, str]:
         return (0, '{"state": "OPEN", "mergeCommit": null}', "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "merged0deadbeef"}', "")
-    return (0, "", "")
+    return (0, changed_files_stdout(joined), "")
 
 
 class TestMergeKeystoneRestoresCallerBranch(TestCase):

--- a/tests/teatree_core/test_merge_repo_resolution.py
+++ b/tests/teatree_core/test_merge_repo_resolution.py
@@ -115,7 +115,9 @@ class TestMergeUsesResolvedRepo(TestCase):
                 return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
             if "pulls" in joined and "merge" in joined:
                 return (0, '{"sha": "merged0deadbeef"}', "")
-            return (0, "", "")
+            # A real open PR always changes >=1 file, so an empty list is a failed read
+            # the substrate gate holds on.
+            return (0, "README.md\n" if "/files" in joined else "", "")
 
         with (
             patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh),
@@ -215,7 +217,9 @@ class TestOverlayRepoDiffersFromCloneOrigin(TestCase):
                 return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
             if "pulls" in joined and "merge" in joined:
                 return (0, '{"sha": "merged0deadbeef"}', "")
-            return (0, "", "")
+            # A real open PR always changes >=1 file, so an empty list is a failed read
+            # the substrate gate holds on.
+            return (0, "README.md\n" if "/files" in joined else "", "")
 
         return _gh
 

--- a/tests/teatree_core/test_merge_repo_resolution.py
+++ b/tests/teatree_core/test_merge_repo_resolution.py
@@ -29,6 +29,7 @@ from teatree.core.merge import (
     resolve_pr_repo_slug,
 )
 from teatree.core.models import MergeClear, Ticket
+from tests._forge_stub import changed_files_stdout
 from tests.teatree_core.conftest import seed_merge_safe_verdict
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -115,9 +116,7 @@ class TestMergeUsesResolvedRepo(TestCase):
                 return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
             if "pulls" in joined and "merge" in joined:
                 return (0, '{"sha": "merged0deadbeef"}', "")
-            # A real open PR always changes >=1 file, so an empty list is a failed read
-            # the substrate gate holds on.
-            return (0, "README.md\n" if "/files" in joined else "", "")
+            return (0, changed_files_stdout(joined), "")
 
         with (
             patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh),
@@ -217,9 +216,7 @@ class TestOverlayRepoDiffersFromCloneOrigin(TestCase):
                 return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
             if "pulls" in joined and "merge" in joined:
                 return (0, '{"sha": "merged0deadbeef"}', "")
-            # A real open PR always changes >=1 file, so an empty list is a failed read
-            # the substrate gate holds on.
-            return (0, "README.md\n" if "/files" in joined else "", "")
+            return (0, changed_files_stdout(joined), "")
 
         return _gh
 

--- a/tests/teatree_core/test_merge_review_lock_gate.py
+++ b/tests/teatree_core/test_merge_review_lock_gate.py
@@ -21,6 +21,7 @@ from django.test import TestCase
 
 from teatree.core.merge import MergeOutcome, MergePreconditionError, merge_ticket_pr
 from teatree.core.models import MergeAudit, MergeClear, MRReviewLock, ReviewVerdict, Ticket
+from tests._forge_stub import changed_files_stdout
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
@@ -69,7 +70,7 @@ def _gh_green(argv: list[str]) -> tuple[int, str, str]:
             return (0, out, "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "merged0deadbeef"}', "")
-    return (0, "", "")
+    return (0, changed_files_stdout(joined), "")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/teatree_core/test_merge_verdict_gate.py
+++ b/tests/teatree_core/test_merge_verdict_gate.py
@@ -30,6 +30,7 @@ from teatree.core.models.review_verdict import HeadVerdictState, ReviewVerdict
 from teatree.loop.scanners.pr_sweep import PrSummary, PrSweepScanner
 from teatree.loop.scanners.pr_sweep_adapters import NullMergeNotifier
 from teatree.loop.scanners.pr_sweep_decision import has_independent_cold_review
+from tests._forge_stub import changed_files_stdout
 from tests.teatree_loop.test_pr_sweep_scanner import FakeKeystone, FakePrApiClient
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -93,7 +94,7 @@ def _gh_green(argv: list[str]) -> tuple[int, str, str]:
             return (0, out, "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "merged0deadbeef"}', "")
-    return (0, "", "")
+    return (0, changed_files_stdout(joined), "")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/teatree_core/test_schema_guard.py
+++ b/tests/teatree_core/test_schema_guard.py
@@ -234,6 +234,12 @@ class BehindSelfDbReportingTest(TransactionTestCase):
 # single-core that exceeds the global 60s ``pytest-timeout`` under maximum
 # parallel contention. Scoped 240s bump for the genuinely-slow migrations; the
 # global 60s stays as the hang-detector everywhere else (#1189).
+def _forge_offline(argv: list[str]) -> tuple[int, str, str]:
+    """Every forge read fails — the repo-reconcile probe falls back to its initial slug."""
+    del argv
+    return (1, "", "forge unreachable")
+
+
 @pytest.mark.timeout(240)
 class BehindSelfDbSelfHealsTest(TransactionTestCase):
     """The sanctioned commands that cannot move off ``default`` (#2915).
@@ -252,18 +258,21 @@ class BehindSelfDbSelfHealsTest(TransactionTestCase):
         self.addCleanup(_migrate_core_forward)
 
     def test_ticket_clear_command_proceeds_past_schema_gate(self) -> None:
-        result = cast(
-            "dict[str, object]",
-            call_command(
-                "ticket",
-                "clear",
-                866,
-                "statusline-stale-wakeup",
-                reviewed_sha="29f0a77a4fd03bd281b23e53cfc47ea9a928620b",
-                reviewer_identity="coldrev-866",
-                blast_class="logic",
-            ),
-        )
+        # A workstream-slug CLEAR probes the forge to reconcile its repo. This case is
+        # about the schema gate, so answer that probe offline instead of shelling out.
+        with patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_forge_offline):
+            result = cast(
+                "dict[str, object]",
+                call_command(
+                    "ticket",
+                    "clear",
+                    866,
+                    "statusline-stale-wakeup",
+                    reviewed_sha="29f0a77a4fd03bd281b23e53cfc47ea9a928620b",
+                    reviewer_identity="coldrev-866",
+                    blast_class="logic",
+                ),
+            )
         # The clear proceeds past the schema gate; whatever its outcome, it
         # is never the unapplied-migration refusal that #2006 eliminates.
         assert "unapplied migration" not in str(result.get("error", ""))

--- a/tests/teatree_core/test_task_lane_routing.py
+++ b/tests/teatree_core/test_task_lane_routing.py
@@ -1,0 +1,39 @@
+"""A freshly created loop-dispatched phase task lands in the runtime's own lane.
+
+The save-time hook was named ``_default_loop_dispatched_to_interactive`` and its
+docstring called itself "the single chokepoint for phase tasks default to interactive".
+Both were stale: the shipped ``agent_runtime`` is ``headless``, so the hook is a no-op
+on every shipped install and a reader concluded the opposite of what happens.
+"""
+
+import pytest
+from django.test import TestCase
+
+from teatree.config import AgentRuntime, get_effective_settings
+from teatree.core.modelkit.phases import SUBAGENT_BY_PHASE
+from teatree.core.models import Task
+from tests.factories import SessionFactory, TicketFactory
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+_ROLE, _PHASE = next(iter(SUBAGENT_BY_PHASE))
+
+
+class TestLoopDispatchedLaneRouting(TestCase):
+    def _phase_task(self) -> Task:
+        ticket = TicketFactory.create(role=_ROLE)
+        return Task.objects.create(
+            ticket=ticket,
+            session=SessionFactory.create(ticket=ticket),
+            phase=_PHASE,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+        )
+
+    def test_the_shipped_runtime_leaves_a_phase_task_headless(self) -> None:
+        assert get_effective_settings().agent_runtime is AgentRuntime.HEADLESS, "control: shipped default"
+        assert self._phase_task().execution_target == Task.ExecutionTarget.HEADLESS
+
+    def test_the_hook_is_named_for_the_lane_it_routes(self) -> None:
+        assert hasattr(Task, "_route_loop_dispatched_lane")
+        assert not hasattr(Task, "_default_loop_dispatched_to_interactive")

--- a/tests/teatree_utils/test_singleton_documents_its_own_call_sites.py
+++ b/tests/teatree_utils/test_singleton_documents_its_own_call_sites.py
@@ -1,0 +1,40 @@
+"""The module docstring must name only entry points that actually take the flock.
+
+An operator auditing concurrency reads this docstring and stops there. Naming an
+entry point that never calls :func:`singleton` tells them a guard exists where none
+does — the same "absent signal read as a definite verdict" shape, at the doc layer.
+"""
+
+import ast
+from pathlib import Path
+
+from teatree.utils import singleton
+
+_SRC = Path(singleton.__file__).resolve().parents[1]
+
+
+def _modules_calling_singleton() -> set[str]:
+    """Every module under ``src/teatree`` with a call to ``singleton(...)``."""
+    callers: set[str] = set()
+    for path in _SRC.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "singleton":
+                callers.add(path.name)
+    return callers
+
+
+class TestDocstringMatchesCallSites:
+    def test_loop_tick_is_not_claimed_to_be_flock_wrapped(self) -> None:
+        doc = singleton.__doc__ or ""
+        tick_paragraph = doc[doc.index("loop tick") :]
+        assert "LoopLease" in tick_paragraph
+        assert "wraps its main loop" not in tick_paragraph
+
+    def test_no_tick_module_actually_takes_the_flock(self) -> None:
+        assert not {name for name in _modules_calling_singleton() if "tick" in name}
+
+    def test_the_documented_flock_holders_do_call_it(self) -> None:
+        callers = _modules_calling_singleton()
+        assert "listen.py" in callers
+        assert "overlay.py" in callers


### PR DESCRIPTION
fix(core): key the merge joins on the repo slug, gate both merge paths, stop doctor mutating on a plain run

## What
fix(core): key the merge joins on the repo slug, gate both merge paths, stop doctor mutating on a plain run

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.