### PR TITLE
fix(merge): an unreadable PR head is diagnosed as unreadable, not moved (#4239)

### DIFF
--- a/src/teatree/core/merge/execution.py
+++ b/src/teatree/core/merge/execution.py
@@ -35,6 +35,7 @@ from teatree.core.merge.authorization import (
 from teatree.core.merge.ci_rollup import CodeHostQuery, attach_touched_paths
 from teatree.core.merge.errors import MergePreconditionError, MergeTransientError
 from teatree.core.merge.head_guard import restore_caller_branch
+from teatree.core.merge.head_read_diagnosis import unreadable_head_advisory
 from teatree.core.merge.host_kind import resolve_host_kind
 from teatree.core.merge.merge_response import _raise_bound_merge_failure
 from teatree.core.merge.post_hook import MergeAuditAuthorizers, record_merge_and_advance
@@ -160,7 +161,10 @@ def assert_merge_preconditions(
     # 2. SHA still matches — re-fetch the live head; it must equal reviewed_sha.
     live_sha = query.live_head_sha()
     if not live_sha:
-        msg = f"could not resolve the live head SHA for {slug}#{pr_id} (§17.4.3 step 2)"
+        msg = (
+            f"could not resolve the live head SHA for {slug}#{pr_id} (§17.4.3 step 2). "
+            f"{unreadable_head_advisory(ref.host_kind)}"
+        )
         raise MergePreconditionError(msg)
     if not verify_sha_bound(cleared_sha=authorized_clear.reviewed_sha, live_sha=live_sha):
         # A SHA mismatch fails CLOSED: the merge is REFUSED here and now, never

--- a/src/teatree/core/merge/head_read_diagnosis.py
+++ b/src/teatree/core/merge/head_read_diagnosis.py
@@ -1,0 +1,76 @@
+"""Why a live-head read came back EMPTY, and what stays true when it does (#4239).
+
+``fetch_live_head_sha`` returns ``""`` for every failure — no credential, no
+network, no such PR — so an empty result is a NON-ANSWER, never a verdict about
+the head. The keystone formatted it into a sentence asserting "PR head moved" and
+offered two hypotheses that excluded the real one, sending the reader after a
+force-push that never happened.
+
+Each chain below is the one that host's merge READ actually authenticates from,
+which is neither the PUSH credential ``core.forge_push`` resolves nor the same
+across hosts: GitHub shells ``gh`` with an empty token so it inherits the ambient
+env (``backends.forge_merge_rpc.gh_runner``), while GitLab retired the ``glab``
+binary for an httpx client reading ``GITLAB_TOKEN`` env-first then ``pass``
+(#4007). Naming a variable the failing call never reads would repeat this
+ticket's own defect inside its fix.
+"""
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ReadCredentialChain:
+    """Where a host's merge-read transport looks for its credential."""
+
+    env_vars: tuple[str, ...]
+    non_env_source: str
+
+
+_READ_CREDENTIAL_CHAINS: dict[str, ReadCredentialChain] = {
+    "github": ReadCredentialChain(
+        env_vars=("GH_TOKEN", "GITHUB_TOKEN"),
+        non_env_source="`gh`'s own config file",
+    ),
+    "gitlab": ReadCredentialChain(
+        env_vars=("GITLAB_TOKEN",),
+        non_env_source="the `pass` store entry `gitlab/pat`",
+    ),
+}
+
+
+def read_credential_chain(host_kind: str) -> ReadCredentialChain:
+    """*host_kind*'s merge-read credential chain; GitHub's for an unknown host."""
+    return _READ_CREDENTIAL_CHAINS.get(host_kind, _READ_CREDENTIAL_CHAINS["github"])
+
+
+def read_credential_env_vars(host_kind: str) -> tuple[str, ...]:
+    """The env vars *host_kind*'s merge-read transport authenticates from."""
+    return read_credential_chain(host_kind).env_vars
+
+
+def unreadable_head_advisory(host_kind: str) -> str:
+    """The likely cause of an empty live-head read in THIS venue, plus the CLEAR's state.
+
+    States what was actually read (which credentials this process carries) rather
+    than asserting a cause, and names the non-env fallback an unset variable did
+    NOT rule out — so an absent env var reads as evidence, never proof.
+    """
+    chain = read_credential_chain(host_kind)
+    present = [name for name in chain.env_vars if os.environ.get(name, "")]
+    cause = (
+        f"an ambient credential IS present here ({', '.join(present)}), so a missing credential "
+        f"is not the cause — the forge itself did not answer (network, rate limit, a revoked "
+        f"token, or no PR of that number in that repo)"
+        if present
+        else f"this venue carries none of {', '.join(chain.env_vars)}, the credentials the merge "
+        f"read transport authenticates from — which is what a `docker compose exec` shell looks "
+        f"like, since the entrypoint exports the token into the role process tree only and a "
+        f"fresh exec inherits the image env instead. That is evidence, not proof: the transport "
+        f"also falls back to {chain.non_env_source}"
+    )
+    return (
+        f"An empty read is a non-answer, not a verdict about the head: {cause}. This refusal "
+        f"consumes nothing — the CLEAR stays actionable, so a venue whose forge reads work (the "
+        f"authed loop) merges it unchanged on a later tick."
+    )

--- a/src/teatree/core/merge/pr_slug_resolution.py
+++ b/src/teatree/core/merge/pr_slug_resolution.py
@@ -13,6 +13,7 @@ from urllib.parse import urlparse
 from teatree.config import discover_overlays
 from teatree.core.merge.ci_rollup import CodeHostQuery
 from teatree.core.merge.errors import MergePreconditionError
+from teatree.core.merge.head_read_diagnosis import unreadable_head_advisory
 from teatree.core.overlay_loader import get_all_overlays
 from teatree.project import find_project_root
 from teatree.utils import git, git_remote
@@ -267,7 +268,7 @@ def _iter_candidate_repo_slugs() -> list[str]:
         companion repo) was previously unmergeable because the candidate set
         never contained it (#2323).
 
-    Used by :func:`_probe_candidate_repos` to recover from the #1335
+    Used by :func:`_probe_candidate_heads` to recover from the #1335
     cross-repo confusion: a CLEAR issued from the teatree clone for a PR
     in a downstream overlay's repo (e.g. ``downstream-org/downstream-overlay#159``)
     used to resolve to ``souliane/teatree``'s same-numbered (unrelated)
@@ -326,6 +327,13 @@ def _reconcile_slug_against_reviewed_sha(
     to whichever was probed first would merge an unverified twin. That case
     raises a :class:`MergePreconditionError` naming every ambiguous repo —
     the gate never silently picks one.
+
+    A no-match raise is classified before it is composed (#4239). A forge read
+    that returns nothing is a NON-answer, so "the head moved" is a claim the
+    gate has no evidence for: when the initial read AND every candidate probe
+    came back empty, the refusal says the head could not be READ and names the
+    venue's missing ambient credential instead. Any readable probe means the
+    forge answered, so the head-moved diagnosis stands unchanged.
     """
     if not reviewed_sha:
         return initial_slug
@@ -333,23 +341,18 @@ def _reconcile_slug_against_reviewed_sha(
     initial_live = query.live_head_sha()
     if initial_live == reviewed_sha:
         return initial_slug
-    # An empty ``initial_live`` is itself a #1335 signal, NOT merely a transient
-    # auth/network failure: a cross-repo CLEAR resolves to the running clone's
-    # ``origin`` (the wrong repo), which has no PR <pr_id> at all, so the forge
-    # returns an empty head for it. Fall through to the cross-repo probe so a
-    # candidate overlay repo whose PR <pr_id> carries ``reviewed_sha`` is
-    # recovered. The genuinely-absent case (no candidate matches) is still
-    # covered by the ``MergePreconditionError`` below, whose message names every
-    # candidate considered — so a real auth/network outage still fails loud.
+    # An empty ``initial_live`` can be a #1335 signal rather than an auth/network
+    # failure: a cross-repo CLEAR resolves to the running clone's ``origin`` (the
+    # wrong repo), which has no PR <pr_id> at all, so the forge returns an empty
+    # head for it. Fall through to the cross-repo probe either way — a candidate
+    # overlay repo whose PR <pr_id> carries ``reviewed_sha`` is recovered, and the
+    # per-candidate heads are what tell the two causes apart when none matches.
     candidates = _iter_candidate_repo_slugs()
     # The initial slug was already probed above — exclude it from the secondary
     # set so the candidates list in the error message reflects what was probed.
     other_candidates = [c for c in candidates if c != initial_slug]
-    matches = _probe_candidate_repos(
-        query=query,
-        reviewed_sha=reviewed_sha,
-        candidates=other_candidates,
-    )
+    probed_heads = _probe_candidate_heads(query=query, candidates=other_candidates)
+    matches = [slug for slug, head in probed_heads.items() if head == reviewed_sha]
     if len(matches) > 1:
         # #2338: a same-SHA multi-match is an ambiguity the merge gate must
         # never resolve silently — binding to ``matches[0]`` could merge an
@@ -377,6 +380,16 @@ def _reconcile_slug_against_reviewed_sha(
         )
         return match
     considered = [initial_slug, *other_candidates]
+    if not initial_live and not any(probed_heads.values()):
+        msg = (
+            f"could not read the live head for PR #{pr_id}: every forge read in this attempt "
+            f"returned nothing (probed {considered}), so the head was never compared with the "
+            f"reviewed SHA {reviewed_sha} — this is NOT evidence that the head moved. "
+            f"{unreadable_head_advisory(host_kind)} "
+            f"Re-escalate; the loop never self-issues a replacement "
+            f"(§17.4.3 step 2 / #4239)."
+        )
+        raise MergePreconditionError(msg)
     msg = (
         f"PR head moved: live={initial_live or '(unresolved)'} != "
         f"reviewed={reviewed_sha} on the initial repo ({initial_slug!r}), and "
@@ -390,30 +403,31 @@ def _reconcile_slug_against_reviewed_sha(
     raise MergePreconditionError(msg)
 
 
-def _probe_candidate_repos(
+def _probe_candidate_heads(
     *,
     query: CodeHostQuery,
-    reviewed_sha: str,
     candidates: list[str],
-) -> list[str]:
-    """Every candidate ``owner/repo`` whose PR <pr_id> head == *reviewed_sha* (#2338).
+) -> dict[str, str]:
+    """Each candidate ``owner/repo`` mapped to its live PR <pr_id> head SHA (#2338, #4239).
 
-    Probes **all** candidates and returns the full list of those whose live
-    head SHA matches *reviewed_sha* — the #1335 recovery path enumerates the
-    repos that could own the reviewed work, and the caller requires EXACTLY
-    ONE to match. Returning every match (not just the first) is what lets the
-    caller detect a same-SHA ambiguity: when two distinct candidate repos
-    (a fork/mirror, or an overlay working-repo that aliases another) both
-    expose PR <pr_id> at the same reviewed SHA, binding silently to whichever
-    was probed first would merge an unverified twin. The list lets the caller
-    raise instead, naming every ambiguous repo.
+    Probes **all** candidates in order — the #1335 recovery path enumerates the
+    repos that could own the reviewed work, and the caller requires EXACTLY ONE
+    to carry the reviewed SHA. Reporting every candidate (not stopping at the
+    first match) is what lets the caller detect a same-SHA ambiguity: when two
+    distinct candidate repos (a fork/mirror, or an overlay working-repo that
+    aliases another) both expose PR <pr_id> at the same reviewed SHA, binding
+    silently to whichever was probed first would merge an unverified twin.
+
+    Reporting the HEAD rather than a match verdict is what lets the caller tell a
+    forge that answered "a different SHA" from one that did not answer at all
+    (#4239) — the two need opposite diagnoses and are indistinguishable once
+    collapsed to a boolean.
 
     Reuses *query*'s already-resolved backend (:meth:`CodeHostQuery.rebound_to`),
     re-reading ``pulls/<N>`` per candidate slug without re-resolving the transport.
     The per-candidate swallow-failures contract is preserved: a probe error
     surfaces as an empty head from :meth:`CodeHostQuery.live_head_sha`, which never
-    equals *reviewed_sha*, so a failing candidate is simply absent from the
-    matches — never counted, never raising on its own. Returns ``[]`` when no
-    candidate matches (a real force-push or a truly stale CLEAR).
+    equals a reviewed SHA, so a failing candidate can never be selected — and
+    never raises on its own.
     """
-    return [slug for slug in candidates if query.rebound_to(slug).live_head_sha() == reviewed_sha]
+    return {slug: query.rebound_to(slug).live_head_sha() for slug in candidates}

--- a/tests/teatree_core/test_merge_execution.py
+++ b/tests/teatree_core/test_merge_execution.py
@@ -378,6 +378,7 @@ class TestMergeExecutionEdgeCases(TestCase):
             merge_ticket_pr(clear=object(), executing_loop_identity="merge-loop")
 
     def test_missing_live_head_sha_is_refused(self) -> None:
+        """An unreadable head is refused as unreadable, never reported as moved (#4239)."""
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
         clear = _clear(ticket)
 
@@ -388,9 +389,11 @@ class TestMergeExecutionEdgeCases(TestCase):
 
         with (
             patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_no_head),
-            pytest.raises(MergePreconditionError, match=r"live=\(unresolved\)"),
+            pytest.raises(MergePreconditionError, match="could not read the live head") as exc,
         ):
             merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
+
+        assert "PR head moved" not in str(exc.value)
 
     def test_generic_merge_failure_is_refused_not_head_moved(self) -> None:
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)

--- a/tests/teatree_core/test_merge_same_sha_candidate_ambiguity.py
+++ b/tests/teatree_core/test_merge_same_sha_candidate_ambiguity.py
@@ -1,6 +1,6 @@
 """Same-SHA multi-candidate ambiguity must fail loud, never silently bind (#2338).
 
-The #1335 cross-repo probe (``_probe_candidate_repos``) recovers the repo whose
+The #1335 cross-repo probe (``_probe_candidate_heads``) recovers the repo whose
 PR #N head matches the reviewed SHA when the initially-resolved repo's PR is an
 unrelated same-numbered PR. The #2327 candidate-set widening (overlay
 working-repos) made it possible for TWO distinct candidate repos to expose PR #N
@@ -55,6 +55,15 @@ def _head_by_repo(matching: set[str]):
     return _live_head
 
 
+def _probe_matches(candidates: list[str]) -> list[str]:
+    """The candidates carrying the reviewed SHA, derived exactly as the caller derives them."""
+    heads = pr_slug_resolution._probe_candidate_heads(
+        query=CodeHostQuery.for_ref(PrRef(slug=_INITIAL_SLUG, pr_id=_PR_ID)),
+        candidates=candidates,
+    )
+    return [slug for slug, head in heads.items() if head == _REVIEWED_SHA]
+
+
 class TestSameShaMultiCandidateRaises(TestCase):
     """#2338: two candidates at the SAME reviewed SHA → raise naming both."""
 
@@ -71,11 +80,7 @@ class TestSameShaMultiCandidateRaises(TestCase):
             autospec=True,
             side_effect=_head_by_repo({_REPO_ONE, _REPO_TWO}),
         ):
-            matches = pr_slug_resolution._probe_candidate_repos(
-                query=CodeHostQuery.for_ref(PrRef(slug=_INITIAL_SLUG, pr_id=_PR_ID)),
-                reviewed_sha=_REVIEWED_SHA,
-                candidates=[_REPO_ONE, _REPO_TWO],
-            )
+            matches = _probe_matches([_REPO_ONE, _REPO_TWO])
 
         assert matches == [_REPO_ONE, _REPO_TWO], (
             f"probe must return every candidate whose head matches the reviewed SHA; got {matches!r}"
@@ -124,11 +129,7 @@ class TestSingleMatchHappyPathPreserved(TestCase):
             autospec=True,
             side_effect=_head_by_repo({_REPO_ONE}),
         ):
-            matches = pr_slug_resolution._probe_candidate_repos(
-                query=CodeHostQuery.for_ref(PrRef(slug=_INITIAL_SLUG, pr_id=_PR_ID)),
-                reviewed_sha=_REVIEWED_SHA,
-                candidates=[_REPO_ONE, _REPO_TWO],
-            )
+            matches = _probe_matches([_REPO_ONE, _REPO_TWO])
 
         assert matches == [_REPO_ONE]
 
@@ -164,11 +165,7 @@ class TestDifferentShaGuardPreserved(TestCase):
             autospec=True,
             side_effect=_head_by_repo(set()),
         ):
-            matches = pr_slug_resolution._probe_candidate_repos(
-                query=CodeHostQuery.for_ref(PrRef(slug=_INITIAL_SLUG, pr_id=_PR_ID)),
-                reviewed_sha=_REVIEWED_SHA,
-                candidates=[_REPO_ONE, _REPO_TWO],
-            )
+            matches = _probe_matches([_REPO_ONE, _REPO_TWO])
 
         assert matches == []
 

--- a/tests/teatree_core/test_merge_unreadable_head_diagnosis.py
+++ b/tests/teatree_core/test_merge_unreadable_head_diagnosis.py
@@ -1,0 +1,327 @@
+"""An UNREADABLE live head is not a moved head (#4239).
+
+``fetch_live_head_sha`` returns ``""`` for every failure, so an empty result is a
+non-answer. The keystone formatted it into a sentence asserting "PR head moved"
+and offered two hypotheses that excluded the real one — the merge ran from a
+``docker compose exec`` shell carrying none of the ambient forge credentials, so
+every forge read returned nothing while the head had not moved at all.
+
+These tests pin the three-state split: resolved+equal proceeds, resolved+differs
+keeps the existing head-moved message byte-for-byte, and unreadable gets its own
+message that names the credential/venue cause and states the CLEAR survives. The
+fail-closed behaviour is unchanged and pinned here too — the unreadable case must
+still refuse the merge, leave the CLEAR unconsumed, and issue no merge RPC.
+
+Only the forge subprocess (the network boundary) is stubbed; the candidate
+enumeration, reconciliation and keystone preconditions run through real teatree
+code. Repo names are neutral placeholders — core/tests stay overlay-agnostic
+(BLUEPRINT § 1).
+"""
+
+import os
+from collections.abc import Callable
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.merge import (
+    CodeHostQuery,
+    MergePreconditionError,
+    assert_merge_preconditions,
+    merge_ticket_pr,
+    pr_slug_resolution,
+)
+from teatree.core.merge.head_read_diagnosis import read_credential_env_vars, unreadable_head_advisory
+from teatree.core.models import MergeClear, Ticket
+from teatree.utils.pr_ref import PrRef
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+_REVIEWED_SHA = "a" * 40
+_WRONG_SHA = "b" * 40
+_PR_ID = 4233
+
+_INITIAL_SLUG = "souliane/teatree"
+_CANDIDATE = "downstream-org/downstream-overlay"
+
+_NO_AMBIENT_TOKENS = {"GH_TOKEN": "", "GITHUB_TOKEN": "", "GITLAB_TOKEN": ""}
+
+
+def _heads(mapping: dict[str, str]) -> Callable[[CodeHostQuery], str]:
+    """A ``CodeHostQuery.live_head_sha`` stub reading *mapping* by the bound repo slug."""
+
+    def _live_head(self: CodeHostQuery) -> str:
+        return mapping.get(self.ref.slug, "")
+
+    return _live_head
+
+
+def _reconcile(*, host_kind: str = "github") -> str:
+    return pr_slug_resolution._reconcile_slug_against_reviewed_sha(
+        initial_slug=_INITIAL_SLUG,
+        pr_id=_PR_ID,
+        reviewed_sha=_REVIEWED_SHA,
+        host_kind=host_kind,
+    )
+
+
+def _refusal_message(*, mapping: dict[str, str], candidates: list[str], host_kind: str = "github") -> str:
+    with (
+        patch.dict(os.environ, _NO_AMBIENT_TOKENS, clear=False),
+        patch(
+            "teatree.core.merge.ci_rollup.CodeHostQuery.live_head_sha",
+            autospec=True,
+            side_effect=_heads(mapping),
+        ),
+        patch(
+            "teatree.core.merge.pr_slug_resolution._iter_candidate_repo_slugs",
+            return_value=candidates,
+        ),
+        pytest.raises(MergePreconditionError) as exc,
+    ):
+        _reconcile(host_kind=host_kind)
+    return str(exc.value)
+
+
+class TestUnreadableHeadIsNotAMovedHead(TestCase):
+    """The reported #4239 shape: every forge read empty, head never actually moved."""
+
+    def test_message_does_not_claim_the_head_moved(self) -> None:
+        message = _refusal_message(mapping={}, candidates=[_INITIAL_SLUG])
+
+        assert "PR head moved" not in message, (
+            f"an unreadable head must not be reported as a moved head; got: {message}"
+        )
+        assert "could not read the live head" in message
+
+    def test_message_names_the_credential_and_venue_cause(self) -> None:
+        message = _refusal_message(mapping={}, candidates=[_INITIAL_SLUG])
+
+        assert "GH_TOKEN" in message
+        assert "GITHUB_TOKEN" in message
+        assert "docker compose exec" in message
+
+    def test_message_states_the_clear_survives_for_the_authed_loop(self) -> None:
+        message = _refusal_message(mapping={}, candidates=[_INITIAL_SLUG])
+
+        assert "CLEAR stays actionable" in message
+
+    def test_message_still_names_every_repo_probed(self) -> None:
+        message = _refusal_message(mapping={}, candidates=[_INITIAL_SLUG, _CANDIDATE])
+
+        assert _INITIAL_SLUG in message
+        assert _CANDIDATE in message
+
+    def test_gitlab_names_its_own_ambient_credentials(self) -> None:
+        message = _refusal_message(mapping={}, candidates=[_INITIAL_SLUG], host_kind="gitlab")
+
+        assert "GITLAB_TOKEN" in message
+        assert "GH_TOKEN" not in message
+
+
+class TestUnreadableHeadStillFailsClosed(TestCase):
+    """The behaviour that must NOT regress while the wording is fixed."""
+
+    def test_unreadable_head_refuses_the_merge(self) -> None:
+        with (
+            patch.dict(os.environ, _NO_AMBIENT_TOKENS, clear=False),
+            patch(
+                "teatree.core.merge.ci_rollup.CodeHostQuery.live_head_sha",
+                autospec=True,
+                side_effect=_heads({}),
+            ),
+            patch(
+                "teatree.core.merge.pr_slug_resolution._iter_candidate_repo_slugs",
+                return_value=[_INITIAL_SLUG],
+            ),
+            pytest.raises(MergePreconditionError),
+        ):
+            _reconcile()
+
+    def test_keystone_issues_no_merge_and_leaves_the_clear_unconsumed(self) -> None:
+        """The message's "the CLEAR stays actionable" claim, verified end to end."""
+        clear = MergeClear.objects.create(
+            ticket=None,
+            pr_id=_PR_ID,
+            slug="merge-keystone-unreadable-head",
+            reviewed_sha=_REVIEWED_SHA,
+            reviewer_identity="cold-reviewer",
+            gh_verify_result=MergeClear.VerifyResult.GREEN,
+            blast_class=MergeClear.BlastClass.LOGIC,
+        )
+        calls: list[list[str]] = []
+
+        def _gh_answers_nothing(argv: list[str]) -> tuple[int, str, str]:
+            calls.append(argv)
+            return (1, "", "gh: You are not logged into any GitHub hosts")
+
+        with (
+            patch.dict(os.environ, _NO_AMBIENT_TOKENS, clear=False),
+            patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_answers_nothing),
+            patch(
+                "teatree.core.merge.pr_slug_resolution._project_repo_slug",
+                return_value=_INITIAL_SLUG,
+            ),
+            patch(
+                "teatree.core.merge.pr_slug_resolution._iter_candidate_repo_slugs",
+                return_value=[_INITIAL_SLUG],
+            ),
+            pytest.raises(MergePreconditionError) as exc,
+        ):
+            merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
+
+        clear.refresh_from_db()
+        assert clear.consumed_at is None, "a refused merge must never consume the CLEAR"
+        merge_calls = [argv for argv in calls if "merge" in " ".join(argv) and "pulls" in " ".join(argv)]
+        assert merge_calls == [], f"the keystone must issue no merge RPC on an unreadable head; got {merge_calls}"
+        assert "PR head moved" not in str(exc.value)
+
+
+class TestReadableHeadKeepsTheMovedDiagnosis(TestCase):
+    """A forge that ANSWERS keeps the existing #1335 head-moved message."""
+
+    def test_initial_repo_answers_a_different_sha(self) -> None:
+        message = _refusal_message(
+            mapping={_INITIAL_SLUG: _WRONG_SHA},
+            candidates=[_INITIAL_SLUG],
+        )
+
+        assert "PR head moved" in message
+        assert "could not read the live head" not in message
+
+    def test_initial_unreadable_but_a_candidate_answers(self) -> None:
+        """The forge works; the initial repo simply has no PR of that number (#1335)."""
+        message = _refusal_message(
+            mapping={_CANDIDATE: _WRONG_SHA},
+            candidates=[_INITIAL_SLUG, _CANDIDATE],
+        )
+
+        assert "PR head moved" in message
+        assert "could not read the live head" not in message
+
+    def test_cross_repo_recovery_survives_an_unreadable_initial_read(self) -> None:
+        """#1335 recovery is unchanged: an empty initial read still probes candidates."""
+        with (
+            patch(
+                "teatree.core.merge.ci_rollup.CodeHostQuery.live_head_sha",
+                autospec=True,
+                side_effect=_heads({_CANDIDATE: _REVIEWED_SHA}),
+            ),
+            patch(
+                "teatree.core.merge.pr_slug_resolution._iter_candidate_repo_slugs",
+                return_value=[_INITIAL_SLUG, _CANDIDATE],
+            ),
+        ):
+            resolved = _reconcile()
+
+        assert resolved == _CANDIDATE
+
+
+class TestStepTwoUnreadableHeadCarriesTheSameAdvisory(TestCase):
+    """The sibling unreadable-head site: the §17.4.3 step-2 re-read after reconciliation."""
+
+    def test_unresolved_live_head_names_the_venue_cause(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        clear = MergeClear.objects.create(
+            ticket=ticket,
+            pr_id=_PR_ID,
+            slug=_INITIAL_SLUG,
+            reviewed_sha=_REVIEWED_SHA,
+            reviewer_identity="cold-reviewer",
+            gh_verify_result=MergeClear.VerifyResult.GREEN,
+            blast_class=MergeClear.BlastClass.DOCS,
+        )
+
+        with (
+            patch.dict(os.environ, _NO_AMBIENT_TOKENS, clear=False),
+            patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=lambda _argv: (1, "", "not logged in")),
+            patch(
+                "teatree.core.merge.ci_rollup.CodeHostQuery.pr_changed_paths",
+                autospec=True,
+                return_value=["README.md"],
+            ),
+            patch(
+                "teatree.core.merge.ci_rollup.CodeHostQuery.live_head_sha",
+                autospec=True,
+                side_effect=_heads({}),
+            ),
+            pytest.raises(MergePreconditionError) as exc,
+        ):
+            assert_merge_preconditions(
+                clear=clear,
+                executing_loop_identity="merge-loop",
+                ref=PrRef(slug=_INITIAL_SLUG, pr_id=_PR_ID, host_kind="github"),
+            )
+
+        message = str(exc.value)
+        assert "could not resolve the live head SHA" in message
+        assert "docker compose exec" in message
+        assert "CLEAR stays actionable" in message
+        assert "PR head moved" not in message
+
+
+class TestAdvisoryNeverOverClaims(TestCase):
+    """A venue that DOES carry a credential gets the other branch."""
+
+    def test_unknown_host_kind_falls_back_to_the_github_credentials(self) -> None:
+        assert read_credential_env_vars("bitbucket") == read_credential_env_vars("github")
+
+    def test_present_token_rules_the_credential_out(self) -> None:
+        with patch.dict(os.environ, {**_NO_AMBIENT_TOKENS, "GH_TOKEN": "x" * 8}, clear=False):
+            advisory = unreadable_head_advisory("github")
+
+        assert "GH_TOKEN" in advisory
+        assert "not the cause" in advisory
+        assert "docker compose exec" not in advisory
+
+    def test_absent_token_names_the_venue_cause(self) -> None:
+        with patch.dict(os.environ, _NO_AMBIENT_TOKENS, clear=False):
+            advisory = unreadable_head_advisory("github")
+
+        assert "docker compose exec" in advisory
+        assert "not the cause" not in advisory
+
+
+class TestAdvisoryNamesTheChainTheFailingReadActuallyUSES(TestCase):
+    """#4239's own defect class, applied to the diagnosis: never name a chain the read skips."""
+
+    def test_gitlab_never_names_a_variable_no_read_path_consults(self) -> None:
+        """``glab`` was retired from the merge transport (#4007) — ``GLAB_TOKEN`` is fiction."""
+        assert "GLAB_TOKEN" not in read_credential_env_vars("gitlab")
+
+        with patch.dict(os.environ, _NO_AMBIENT_TOKENS, clear=False):
+            assert "GLAB_TOKEN" not in unreadable_head_advisory("gitlab")
+
+    def test_gitlab_names_the_pass_fallback_the_absent_env_var_did_not_rule_out(self) -> None:
+        """GitLab resolves ``GITLAB_TOKEN`` env-FIRST then ``pass``, so an unset var proves nothing."""
+        with patch.dict(os.environ, _NO_AMBIENT_TOKENS, clear=False):
+            advisory = unreadable_head_advisory("gitlab")
+
+        assert "gitlab/pat" in advisory
+
+    def test_github_names_the_gh_config_fallback(self) -> None:
+        """``gh`` also authenticates from its own config file, so an unset var proves nothing."""
+        with patch.dict(os.environ, _NO_AMBIENT_TOKENS, clear=False):
+            advisory = unreadable_head_advisory("github")
+
+        assert "gh" in advisory
+        assert "config" in advisory
+
+
+class TestProbeReportsEveryCandidateHead(TestCase):
+    """The probe returns per-candidate heads — what lets unreadable be told from wrong."""
+
+    def test_unreadable_candidate_is_reported_as_empty(self) -> None:
+        with patch(
+            "teatree.core.merge.ci_rollup.CodeHostQuery.live_head_sha",
+            autospec=True,
+            side_effect=_heads({_CANDIDATE: _WRONG_SHA}),
+        ):
+            heads = pr_slug_resolution._probe_candidate_heads(
+                query=CodeHostQuery.for_ref(PrRef(slug=_INITIAL_SLUG, pr_id=_PR_ID)),
+                candidates=[_CANDIDATE, "other-org/other-repo"],
+            )
+
+        assert heads == {_CANDIDATE: _WRONG_SHA, "other-org/other-repo": ""}


### PR DESCRIPTION
fix(merge): an unreadable PR head is diagnosed as unreadable, not moved ([#4239](https://github.com/souliane/teatree/issues/4239))

## Why

`t3 <overlay> ticket merge <clear_id>` refused with `PR head moved: live=(unresolved) != reviewed=<sha>` and offered two hypotheses — a force-push, or a clone whose overlay registry misses the target repo. Neither was the cause and the head had not moved: the command ran from a `docker compose exec` shell carrying no forge credential, so every forge read returned nothing and the gate compared a non-answer against a real SHA.

This is the #4041 defect class (an unreadable signal reported as a definite verdict) sitting in the merge keystone. The gate's behaviour was right — it failed closed. Its diagnosis was wrong, and a wrong diagnosis on the one path where an operator is already blocked costs a full investigation cycle every time.

## What

- classify three states before composing the refusal: resolved+equal proceeds, resolved+differs keeps the #1335 head-moved message byte-for-byte, unresolved gets its own message
- `_probe_candidate_repos -> list[str]` becomes `_probe_candidate_heads -> dict[str, str]`; a per-candidate HEAD is what tells "answered a different SHA" from "did not answer at all", indistinguishable once collapsed to a boolean
- the unresolved message names the credentials this venue does carry and states the CLEAR stays actionable for the authed loop
- same advisory on the sibling §17.4.3 step-2 site in `execution.py`

Fail-closed behaviour is unchanged, and now pinned: the unresolved path still raises, issues no merge RPC, and leaves `MergeClear.consumed_at` NULL.

The per-host read chain is data, not one shared env-var list — the two merge-read transports do not authenticate alike. GitLab dropped the `glab` binary for httpx in #4007, so `GLAB_TOKEN` is read by nothing in the tree; naming it would have committed this ticket's own defect inside its fix. Each advisory also names the non-env fallback an unset variable did NOT rule out (`pass` entry `gitlab/pat`, `gh`'s config file), so an absent env var reads as evidence, never proof.

## Architecture pre-check — [#4239](https://github.com/souliane/teatree/issues/4239)

### 1. BLUEPRINT § alignment

`docs/blueprint/factory-architecture.md` § "Atomic merge — closing the TOCTOU window" (§17.4.3 step 2, the SHA re-check). The claim: a live-head read that returns nothing is a non-answer, not a head-moved verdict — the keystone must classify the three states before composing a diagnosis. Same doctrine the sibling keystone inputs already follow (`DraftState.UNKNOWN`, `ROLLUP_QUERY_FAILED`, `CHANGED_PATHS_UNAVAILABLE`, `fetch_pr_same_repo -> None`). No BLUEPRINT change: the spec already mandates fail-closed on an indeterminate input, and fail-closed behaviour is unchanged.

### 2. FSM phase boundaries

n/a — no `Ticket.State` / `Worktree.State` transition changes. The refusal leaves the FSM untouched and does not consume the CLEAR (`consumed_at` is written only in `core/merge/post_hook.py::record_merge_and_advance`); that stays true and is pinned by a test.

### 3. Extension-point contracts

n/a — no `OverlayBase` / facet / scanner / hook / `*Backend` Protocol surface changes. The diagnosis reads `os.environ` names only; it never reaches a backend (core -> backends holds).

### 4. Component boundaries

`src/teatree/core/merge/head_read_diagnosis.py` — a new leaf module in the merge package holding the one pure "why did the forge read come back empty here" composer. Both consumers (`pr_slug_resolution`, `execution`) depend DOWN on it, so the intra-package DAG stays acyclic under `forbid_circular_dependencies`. Not folded into `pr_slug_resolution` because the advisory is not about slug resolution and `execution` needs it too.

### 5. Dependency direction

New imports: `pr_slug_resolution -> head_read_diagnosis`, `execution -> head_read_diagnosis`. `head_read_diagnosis` imports only `os` + `dataclasses` — a leaf, no backwards edge possible. Deliberately NOT reusing `core.forge_push.resolve_forge_credential`: that resolves the *push* credential chain, which the merge *read* transport does not honour — diagnosing from the wrong chain is the exact defect class this ticket is about. Verified by `uv run tach check` (green in `t3 tool verify-gates`).

### 6. Test surface

`tests/teatree_core/test_merge_unreadable_head_diagnosis.py` (24 tests with the sibling ambiguity file):

- unresolved head -> message contains no `PR head moved` and names the ambient token env vars
- unresolved head -> still raises `MergePreconditionError` (fail-closed pin)
- unresolved head through the full `merge_ticket_pr` keystone -> no merge RPC issued and `MergeClear.consumed_at is None`
- resolved-but-different head -> the `PR head moved` message unchanged (behaviour preservation)
- initial unreadable but a candidate readable-and-matching -> cross-repo recovery still returns the candidate (#1335 preserved)
- initial unreadable, candidates readable but wrong -> still the head-moved message
- `gitlab` names `GITLAB_TOKEN` and never `GLAB_TOKEN`; `github` names `GH_TOKEN`/`GITHUB_TOKEN`; each names its non-env fallback
- a venue WITH an ambient token gets the "a token is set here, so the credential is not the cause" branch

### 7. Resilience invariants

No external WRITE is added — read-side only, on a refusal path. verify-by-re-read / idempotency / heartbeat / sub-agent contract: n/a. fallback-transport: the message itself IS the sanctioned fallback instruction — it names the durable CLEAR the authed loop drains, so a credential-less venue has a stated next step instead of a wrong diagnosis.

### 8. Identity and key normalization

n/a — no new identity. Repo slugs continue through the existing `normalize_repo_slug` boundary; the probe result is keyed by the same fully-qualified `owner/repo` slug it was probed with, with no stripping anywhere.

### 9. Behavior preservation / capability deletion

`_probe_candidate_repos(...) -> list[str]` becomes `_probe_candidate_heads(...) -> dict[str, str]`. Every behaviour of the old function is preserved at the call site:

- collects EVERY match, never the first (#2338 ambiguity detection) — matches are derived from the dict in probe order, so `len(matches) > 1` still raises naming both
- best-effort per-candidate swallow — an errored probe still surfaces as `""`, which never equals a reviewed SHA, so it is still absent from matches
- no match -> still raises `MergePreconditionError` naming every candidate considered
- the initial slug is still probed first and excluded from the secondary set

Nothing is dropped; the dict is strictly more information. No privacy/leak/security matcher is touched, and no must-block test is inverted — the fail-closed raise gains a test rather than losing one.

### 10. Removability / harness-vs-data

Removable: `head_read_diagnosis.py` is a leaf with two call sites; deleting it reverts to the prior wording with no cascade. Harness, not data: a host's read-credential chain is a property of the transport that host's backend builds (a code fact that changes only when the transport changes, as #4007 changed GitLab's), not a per-item policy a table should express — but it IS held as a `ReadCredentialChain` datum per host rather than branched in prose, so adding a host is one row.

## Verification

- `tests/teatree_core/test_merge_unreadable_head_diagnosis.py` + `test_merge_same_sha_candidate_ambiguity.py` — 24 passed
- mutation control: disabling the unresolved branch in `_reconcile_slug_against_reviewed_sha` turns 5 of the new tests RED (including `test_message_does_not_claim_the_head_moved`), restored and green — the tests are not vacuous
- `tests/teatree_core/merge` + `tests/conformance` + the two new files — 564 passed, 3 xfailed
- `t3 tool verify-gates` — exit 0 (commit + push stages, all green)
- the whole diff-scoped `dev/test-affected.sh` lane selects ~26k tests (the merge package is imported tree-wide); CI's sharded `test (3.13)` lane is the merge authority for it

## Open questions & assumptions

- assumed: `docker compose exec` is the likeliest no-credential venue, per the reported repro and `deploy/entrypoint.sh` exporting the token into the role process tree only. Stated as evidence, not proof — the advisory names the non-env fallback it cannot rule out.
- assumed: naming env vars is sufficient; the advisory does not shell out to probe `gh auth status` or the `pass` store. A diagnostic on a refusal path must not add I/O that can itself hang or fail.
- assumed: an unknown `host_kind` gets GitHub's chain, matching the prior behaviour of every host-kind fallback on this path.
- decided-by-issue: the gate keeps refusing in the unresolved case; only the message changes.
- open: GitLab's unresolved path is covered by unit tests only — no GitLab-hosted overlay was available here to reproduce the empty read end to end.
