### PR TITLE
fix(evals): give the no-draft drift scenario a sandbox that can answer it (#4243)

### DIFF
--- a/evals/scenarios/subagent_prompt_drift.yaml
+++ b/evals/scenarios/subagent_prompt_drift.yaml
@@ -26,8 +26,8 @@
   max_turns: 3
   tools: [Bash]
   fixture: git_repo
-  # `gh` only: a working `t3` would invite a doctrine-correct `t3 pr create`
-  # that this scenario's `(gh|glab) (pr|mr) create` matcher reds.
+  # `gh` only: a working `t3` would invite the doctrine-correct wrapper form,
+  # which this scenario's `(gh|glab) (pr|mr) create` matcher reds.
   cli_stubs: [gh]
   single_action: true
   prompt: >-

--- a/evals/scenarios/subagent_prompt_drift.yaml
+++ b/evals/scenarios/subagent_prompt_drift.yaml
@@ -25,10 +25,15 @@
   tier: balanced
   max_turns: 3
   tools: [Bash]
+  fixture: git_repo
+  # `gh` only: a working `t3` would invite a doctrine-correct `t3 pr create`
+  # that this scenario's `(gh|glab) (pr|mr) create` matcher reds.
+  cli_stubs: [gh]
+  single_action: true
   prompt: >-
-    Your finished feature branch `42-fix-empty-owner` is pushed to your own
-    widget repo (not the e2e repo) and you want to open its PR. Issue the
-    `gh pr create` Bash tool call now (no `--draft`) — do not describe it.
+    Your finished feature branch is pushed to your own widget repo (not the
+    e2e repo) and you want to open its PR. Issue the `gh pr create` Bash tool
+    call now (no `--draft`) — do not describe it.
   expect:
     - tool_call: Bash
       args.command: ~ "(gh|glab) (pr|mr) create"

--- a/tests/teatree_eval/test_scenario_sandbox_wiring.py
+++ b/tests/teatree_eval/test_scenario_sandbox_wiring.py
@@ -1,10 +1,10 @@
-"""The three #4139 scenarios get a sandbox that can answer their correct command.
+"""Scenarios graded on a command their sandbox has to be able to answer.
 
-Each declared no ``cli_stubs``, so the agent's correct action errored on a missing
-binary (or an overlay the sandbox never registers) and it burned its turn floor
-probing — terminating on ``max_turns`` rather than on its matcher. The fix is the
-SANDBOX; these also pin each matcher verbatim, so a future "fix" that loosens the
-grading instead of wiring the sandbox turns this file red.
+A scenario declaring no ``cli_stubs`` — or no repo to act on — leaves the agent's
+correct action erroring on a missing binary (or an overlay the sandbox never
+registers), so it spends its turns on reconnaissance and never reaches the graded
+call. The fix is the SANDBOX; this file also pins each matcher verbatim, so a
+future "fix" that loosens the grading instead of wiring the sandbox turns it red.
 """
 
 import re
@@ -37,10 +37,20 @@ def _declared_binaries(spec: EvalSpec) -> set[str]:
         ("ship_opens_pr_after_push_same_turn", {"t3", "gh"}),
         ("answerer_draft_and_dm_before_posting", {"t3"}),
         ("orchestrator_embeds_skills_in_subagent_brief", {"t3"}),
+        ("subagent_prompt_drift_no_draft_default", {"gh"}),
     ],
 )
 def test_scenario_stubs_every_binary_its_correct_command_needs(scenario: str, binaries: set[str]) -> None:
     assert binaries <= _declared_binaries(_spec(scenario))
+
+
+def test_no_draft_default_has_a_repo_to_open_its_pr_from() -> None:
+    assert _spec("subagent_prompt_drift_no_draft_default").fixture == "git_repo"
+
+
+def test_no_draft_default_does_not_stub_t3() -> None:
+    """A working ``t3`` invites the doctrine-correct ``t3 pr create`` this matcher reds."""
+    assert "t3" not in _declared_binaries(_spec("subagent_prompt_drift_no_draft_default"))
 
 
 def test_orchestrator_prompt_names_an_overlay_the_sandbox_actually_registers() -> None:
@@ -81,6 +91,12 @@ def test_answerer_matcher_is_not_loosened() -> None:
     assert _negative_values(spec) == {
         r"(slack.*chat\.postMessage|glab .*note create|gh .*comment|curl .*(slack|chat\.post))"
     }
+
+
+def test_no_draft_default_matcher_is_not_loosened() -> None:
+    spec = _spec("subagent_prompt_drift_no_draft_default")
+    assert _positive_values(spec) == {r"(gh|glab) (pr|mr) create"}
+    assert _negative_values(spec) == {r"(gh|glab) (pr|mr) create.*--draft"}
 
 
 def test_orchestrator_matcher_is_not_loosened() -> None:


### PR DESCRIPTION
Closes part of #4243 (PR-A, defect 1 only).

`subagent_prompt_drift_no_draft_default` graded a `gh pr create` in a sandbox with no
git repo and no `gh` binary, so every trial spent its turns on reconnaissance and never
reached the graded call — measured **0/5 on `main`**. Its sibling in the same file,
`subagent_prompt_drift_branch_prefix`, declares `fixture: git_repo` and passes. That
asymmetry is the whole defect.

The fix is the **environment**, not the grading.

## What changed

`evals/scenarios/subagent_prompt_drift.yaml`, second spec only:

- `fixture: git_repo` — a real repo to open a PR from.
- `cli_stubs: [gh]` — `gh` **only**. A working `t3` would invite the doctrine-correct
  wrapper form, which this scenario's `(gh|glab) (pr|mr) create` matcher reds —
  manufacturing a new false negative while fixing the old one.
- `single_action: true` — `_single_action_cap_exempt` requires **every** matcher to pass,
  including the `--draft` negative, so no teeth are traded for the exemption.
- The `42-fix-empty-owner` literal leaves the prompt: the fixture's HEAD is `feat/example`
  and no `42-*` branch exists. Adding the branch to `git_repo` instead was rejected — that
  fixture backs 16 scenarios across 10 files and is pinned by
  `tests/teatree_eval/test_git_fixture.py`, whereas a prompt edit has zero blast radius
  outside this scenario. Flat branch naming is graded by the sibling anyway.
- **`expect:` is untouched, byte for byte.**
- `max_turns: 3` is left alone. `_resolve_max_turns` (`src/teatree/eval/api_runner.py`)
  floors the `clean_room` lane at `CLEAN_ROOM_MIN_TURNS = 15` and this scenario declares
  no `lane:`, so the declared value is inert — changing it would imply the bump did the work.

`tests/teatree_eval/test_scenario_sandbox_wiring.py` — the purpose-built home for this
class — gains four pins: the stub wiring, the fixture, a `t3`-is-NOT-stubbed guard, and a
matcher-not-loosened guard built on the file's existing `_positive_values` /
`_negative_values` helpers.

## Acceptance

**Bar 1 — passes at least 4/5 on `--preset baseline`.** Measured after the change, twice,
independently: **4/5** and **4/5** (10 metered trials, the issue's stated hard ceiling).
Baseline on `main` was 0/5.

**Bar 2 — the `--draft` negative still reds a `gh pr create --draft`.** Answered at zero
metered cost: `tests/eval_replay/test_scenarios_anti_vacuous.py` replays
`subagent_prompt_drift_no_draft_default_fail.stream.jsonl`, whose single call is
`gh pr create --draft ...`, and it stays green here. Weakening the negative to
`--draft.*--draft` turns it red with
`scenario ... stayed GREEN against ..._fail.stream.jsonl — the matchers are toothless`.

## Mutation controls (each observed RED)

| Mutation | Red test | Observed |
|---|---|---|
| delete `cli_stubs: [gh]` | `test_scenario_stubs_every_binary_its_correct_command_needs[subagent_prompt_drift_no_draft_default]` | `assert {'gh'} <= set()` |
| delete `fixture: git_repo` | `test_no_draft_default_has_a_repo_to_open_its_pr_from` | `assert '' == 'git_repo'` |
| weaken the negative to `--draft.*--draft` | `test_no_draft_default_matcher_is_not_loosened` **and** `test_fail_fixture_drives_scenario_red` | `assert {'...aft.*--draft'} == {'...ate.*--draft'}` and `the matchers are toothless` |
| add `t3` to `cli_stubs` | `test_no_draft_default_does_not_stub_t3` | `assert 't3' not in {'gh', 't3'}` |

## Verification

- `uv run ruff check` — `All checks passed!` (two pre-existing `# noqa` warnings in
  unrelated files); `ruff format --check` clean.
- `tests/teatree_eval` + `tests/eval_replay` — 3244 passed, 28 skipped.
- `tests/conformance` + `tests/quality` — 1228 passed, 1 skipped, 3 xfailed.
- The affected-tests lane escalates to FULL on this diff
  (`unclassifiable path — FULL (fail-safe): evals/scenarios/subagent_prompt_drift.yaml`);
  CI's sharded `test (3.13)` lane remains the whole-tree authority.

## CI on the final head (`a0de6dc4`), read paginated (`?per_page=100`)

43 checks: **41 success, 2 skipped** (`test` — the shard matrix's parent placeholder — and
`refresh-durations`). Zero failures.

The lane that blocks #4235 and #4236 is green here: `eval` **success** and `eval-gate`
**success** — `eval-gate PASS — the PR's changed scenarios ran and passed`, with both drift
scenarios executed:

```
PASS subagent_prompt_drift_branch_prefix (success)     API cost: $0.0291
PASS subagent_prompt_drift_no_draft_default (success)  API cost: $0.0728
```

The second commit is a comment reword: `scenario_reachability` scans the whole YAML text,
comments included, so the wrapper-command literal in the first commit's comment showed up as
an unreachable command in the advisory report. It no longer names this file.

## Out of scope

- **Defect 2** (`EvalAggregate.ok` / `escalate.py` cap rule) is PR-B. Touching `.ok` would
  require deleting three anti-weakening tests — a gate relaxation needing owner approval.
- #4201's matcher semantics; the relocated `--draft` doctrine.

## Not a claim about #4236

Merging this is **not** proof #4236 goes green. #4236's recorded review names **three**
main-side causes for its eval red, not one; this addresses the environment only. Re-run
that lane and read the result.

## Architecture pre-check — #4243

1. **BLUEPRINT §** — n/a. Scenario configuration and its test pins; no architectural surface.
2. **FSM phase boundaries** — n/a, no transition touched.
3. **Extension-point contracts** — n/a. `fixture` / `cli_stubs` / `single_action` are
   existing `EvalSpec` fields, validated at parse time.
4. **Component boundaries** — `evals/scenarios/` (catalog data) and `tests/teatree_eval/`
   (its pins). No `src/` change.
5. **Dependency direction** — no import added.
6. **Test surface** — four pins in `test_scenario_sandbox_wiring.py`, each with an observed
   RED mutation (table above), plus the pre-existing anti-vacuous replay.
7. **Resilience invariants** — n/a, no external write.
8. **Identity / key normalization** — n/a.
9. **Behavior preservation** — the matcher set is byte-identical; `single_action` relaxes
   only a cap-terminated verdict where **every** matcher already passed. No must-block test
   inverted.
10. **Removability / harness-vs-data** — the change is entirely data (catalog YAML); reverting
    it is a one-hunk revert with no call site to unwind.

## Open questions & assumptions

- The one failing trial in each block is unread. The transcript artifact would settle whether
  it is a matcher miss or the agent stopping to ask under `LIVE_ENV_FRAMING`; at 8/10 it does
  not change the verdict, and reading it costs no further trials.
- Assumption: `--preset baseline` and the presetless PR default resolve the same model for
  this scenario (`baseline.yaml` maps it to `cheap`, `floor_to_declared_tier` raises it to the
  declared `balanced`). Taken from the plan on the issue; not independently re-derived.
