### PR TITLE
fix(board): declare reopen_revivals so the revival cap actually fires (#4152)

### DIFF
--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -100,6 +100,9 @@ class TicketExtra(TypedDict, total=False):
     ship_invoking_branch: str
     ignored_from: str
     reopened_from: str
+    # Board reconcile rule E's revival cap. Undeclared it is stripped by every
+    # ladder transition, so the cap reads 0 forever and never fires (#4152).
+    reopen_revivals: int
     visual_qa: VisualQASummary
     branch: str
     # #33 per-repo branch override map (repo → branch). A ticket whose repos

--- a/tests/conformance/test_model_extra_keys_are_declared.py
+++ b/tests/conformance/test_model_extra_keys_are_declared.py
@@ -1,0 +1,131 @@
+"""Every key written into a model ``extra`` is declared on its ``TypedDict``.
+
+``Ticket.extra`` / ``Worktree.extra`` are JSONFields, so an undeclared key is
+accepted at the write and dropped silently by the next transition that rewrites
+the field through ``validated_*_extra`` — no error, no log, just a value that is
+there until it is not. #4152 shipped a revival cap keyed on such a key: the
+counter was written on every revival, stripped by the ``test()`` transition on
+the way back round the ladder, and so read ``0`` forever. The cap never fired.
+
+Both write shapes are walked, because covering only one is a guard that reads as
+coverage: the direct ``extra["key"] = …`` subscript that shipped the defect, and
+the ``merge_extra(set_keys=…)`` locked primitive every other writer uses.
+
+Whole-tree by construction: the write and the declaration sit in different
+modules, so no diff-scoped lane sees both ends.
+"""
+
+import ast
+from pathlib import Path
+
+from teatree.core.models.types import TicketExtra, WorktreeExtra
+from tests.conformance._src_tree import REPO_ROOT, src_modules
+
+# Unioned, not per-model: the AST knows the key, never which model the receiver is.
+DECLARED_KEYS = frozenset(TicketExtra.__annotations__) | frozenset(WorktreeExtra.__annotations__)
+
+_MODEL_EXTRA_CALLS = {"_extra", "validated_ticket_extra", "validated_worktree_extra"}
+_EXTRA_TYPED_DICTS = {"TicketExtra", "WorktreeExtra"}
+#: ``merge_extra`` parameters whose keys land in ``extra``; ``pop_keys`` removes, so it cannot strand one.
+_MERGE_EXTRA_KEY_PARAMS = {"set_keys", "merge_into_dicts", "append_to_lists"}
+
+
+def _reads_a_model_extra(node: ast.AST) -> bool:
+    """Whether *node* sources a model's ``extra`` field rather than a fresh local dict."""
+    return any(
+        (isinstance(sub, ast.Attribute) and sub.attr == "extra")
+        or (isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute) and sub.func.attr in _MODEL_EXTRA_CALLS)
+        or (isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name) and sub.func.id in _MODEL_EXTRA_CALLS)
+        for sub in ast.walk(node)
+    )
+
+
+def _model_extra_names(scope: ast.AST) -> set[str]:
+    """Local names in *scope* bound from a model ``extra`` read."""
+    names: set[str] = set()
+    for node in ast.walk(scope):
+        if not isinstance(node, ast.Assign | ast.AnnAssign) or node.value is None:
+            continue
+        if not _reads_a_model_extra(node.value):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        names.update(target.id for target in targets if isinstance(target, ast.Name))
+    return names
+
+
+def _undeclared_subscript_key(target: ast.expr, tracked: set[str]) -> tuple[int, str] | None:
+    """The undeclared key *target* writes into a tracked ``extra`` name, when it is such a write."""
+    if not (isinstance(target, ast.Subscript) and isinstance(target.value, ast.Name) and target.value.id in tracked):
+        return None
+    key = target.slice
+    if not isinstance(key, ast.Constant) or not isinstance(key.value, str) or key.value in DECLARED_KEYS:
+        return None
+    return target.lineno, key.value
+
+
+def _subscript_writes(tree: ast.Module) -> list[tuple[int, str]]:
+    """``<name>["<key>"] = …`` writes, on a name bound from a model ``extra``, with an undeclared key."""
+    tracked = _model_extra_names(tree)
+    return [
+        found
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if (found := _undeclared_subscript_key(target, tracked)) is not None
+    ]
+
+
+def _argument_keys(value: ast.expr) -> list[tuple[int, str]]:
+    """Constant keys a ``merge_extra`` argument contributes, as a dict literal or a ``TicketExtra(...)`` call."""
+    if isinstance(value, ast.Dict):
+        return [(k.lineno, k.value) for k in value.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)]
+    if isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id in _EXTRA_TYPED_DICTS:
+        return [(value.lineno, kw.arg) for kw in value.keywords if kw.arg]
+    return []
+
+
+def _merge_extra_writes(tree: ast.Module) -> list[tuple[int, str]]:
+    """``merge_extra(set_keys={"<key>": …})`` writes with an undeclared key."""
+    return [
+        (lineno, key)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "merge_extra"
+        for kw in node.keywords
+        if kw.arg in _MERGE_EXTRA_KEY_PARAMS
+        for lineno, key in _argument_keys(kw.value)
+        if key not in DECLARED_KEYS
+    ]
+
+
+def _undeclared_writes(path: Path, tree: ast.Module) -> list[str]:
+    """Every undeclared model-``extra`` key write in *tree*, as reportable lines."""
+    rel = path.relative_to(REPO_ROOT)
+    return [
+        f"{rel}:{lineno} writes undeclared key '{key}'"
+        for lineno, key in sorted(_subscript_writes(tree) + _merge_extra_writes(tree))
+    ]
+
+
+def test_every_model_extra_key_written_in_src_is_declared() -> None:
+    findings = [finding for path, tree in src_modules() for finding in _undeclared_writes(path, tree)]
+
+    assert not findings, (
+        "Undeclared model ``extra`` key(s) — validated_*_extra will drop these on the next transition:\n"
+        + "\n".join(findings)
+    )
+
+
+def test_the_walk_detects_both_write_shapes() -> None:
+    """The control: a walk blind to either shape passes the tree above for the wrong reason."""
+    planted = ast.parse(
+        "def f(ticket):\n"
+        "    extra = ticket.extra or {}\n"
+        "    extra['zz_undeclared_subscript'] = 1\n"
+        "    ticket.merge_extra(set_keys={'zz_undeclared_merge': 2})\n"
+        "    ticket.merge_extra(set_keys={'branch': 'declared-so-not-a-finding'})\n"
+    )
+
+    assert _undeclared_writes(REPO_ROOT / "planted.py", planted) == [
+        "planted.py:3 writes undeclared key 'zz_undeclared_subscript'",
+        "planted.py:4 writes undeclared key 'zz_undeclared_merge'",
+    ]

--- a/tests/teatree_core/test_extra_validators.py
+++ b/tests/teatree_core/test_extra_validators.py
@@ -27,6 +27,10 @@ class TestValidatedTicketExtra:
         result = validated_ticket_extra(raw)
         assert "123" in result["prs"]
 
+    def test_reopen_revivals_survives_validation(self) -> None:
+        """Undeclared, the board's revival counter is stripped by every ladder transition (#4152)."""
+        assert validated_ticket_extra({"reopen_revivals": 2})["reopen_revivals"] == 2
+
 
 class TestValidatedWorktreeExtra:
     def test_none_returns_empty(self) -> None:

--- a/tests/teatree_loop/test_board_reconcile.py
+++ b/tests/teatree_loop/test_board_reconcile.py
@@ -533,11 +533,39 @@ class TestReopenedIssueRule(TestCase):
         assert [t.to_state for t in report.transitions] == [Ticket.State.STARTED]
         assert report.applied == ()
 
+    def _walk_back_to_delivered(self, ticket: Ticket) -> None:
+        """Return a revived ticket to DELIVERED the way the ladder does.
+
+        ``test()`` is the step that matters: it rewrites ``extra`` through
+        ``validated_ticket_extra``, so a counter it does not know is dropped here.
+        """
+        Ticket.objects.filter(pk=ticket.pk).update(state=Ticket.State.CODED)
+        ticket.refresh_from_db()
+        ticket.test(passed=True)
+        ticket.save()
+        Ticket.objects.filter(pk=ticket.pk).update(state=Ticket.State.DELIVERED)
+        ticket.refresh_from_db()
+
     def _capped(self) -> Ticket:
         ticket = self._delivered()
-        ticket.extra = {"reopen_revivals": board_reconcile.MAX_REOPEN_REVIVALS}
-        ticket.save()
+        Ticket.objects.filter(pk=ticket.pk).update(extra={"reopen_revivals": board_reconcile.MAX_REOPEN_REVIVALS})
+        ticket.refresh_from_db()
+        self._walk_back_to_delivered(ticket)
         return ticket
+
+    def test_the_cap_fires_after_max_revivals_across_ladder_walks(self) -> None:
+        """A revival only recurs after a full ladder walk, so the counter must survive one (#4152)."""
+        ticket = self._delivered()
+        applied = 0
+
+        with patch.object(board_reconcile, "_reopened_issue_urls", return_value={self.URL}):
+            for _ in range(board_reconcile.MAX_REOPEN_REVIVALS + 2):
+                applied += len(reconcile_board().applied)
+                ticket.refresh_from_db()
+                self._walk_back_to_delivered(ticket)
+
+        assert applied == board_reconcile.MAX_REOPEN_REVIVALS
+        assert DeferredQuestion.objects.filter(dedupe_marker=f"reopen-revival-capped:{ticket.pk}").count() == 1
 
     def test_the_revival_cap_halts_and_escalates_exactly_once(self) -> None:
         """The cap must not become the silence this rule exists to remove."""


### PR DESCRIPTION
Closes [#4152](https://github.com/souliane/teatree/issues/4152).

## What

- declare `reopen_revivals: int` on `TicketExtra` — the one-line fix
- conformance walk: every `extra` key written in `src/` is declared on its TypedDict, across both write shapes (`extra["k"] = …` subscript and `merge_extra(set_keys=…)`), with a planted-violation control
- the rule E tests now walk the ladder back to `DELIVERED` between revivals, so they exercise the strip the old direct-`extra`-write fixtures missed

## Why

Rule E's revival cap is keyed on `ticket.extra["reopen_revivals"]`, an undeclared key. `TicketExtra` is the allowlist `validated_ticket_extra` filters through, so every ladder transition that rewrites `extra` via `_extra()` — `test()`, `skip_shipping()`, `rework()`, `reopen()`, `ignore()` — dropped the counter. A revival only recurs after a full ladder walk, so the counter read `0` forever: revivals were unbounded and the cap's `DeferredQuestion` escalation never fired.

This is the follow-up to [#4233](https://github.com/souliane/teatree/pull/4233), which shipped the cap. The cap's semantics are unchanged — this makes them take effect.

## Verification

- mutation control (declaration removed, this session): **5 RED** — `test_the_cap_fires_after_max_revivals_across_ladder_walks` (5 revivals against `MAX=3`), `test_the_revival_cap_halts_and_escalates_exactly_once`, `test_an_answered_escalation_is_never_re_asked`, `test_every_model_extra_key_written_in_src_is_declared`, `test_reopen_revivals_survives_validation`. Declaration restored: **53 passed**.
- `t3 tool verify-gates` → **rc=0** (commit + push stages).
- `bash dev/test-affected.sh` → 28808 passed, 13 failed. All 13 pre-existing on `main`: 12 reproduce with `src/` reverted to `origin/main` (env-shaped — `gh`-token doctor checks, `test_backend_factory`, the known-local-red `test_outbound_audit`); the 13th, `tests/conformance/test_lane_ceiling.py::test_the_running_item_carries_the_lane_ceiling`, is [#4247](https://github.com/souliane/teatree/issues/4247) — it fails whenever `-p teatree.quality.force_keep_plugin` is loaded (that hook wrapper hides force-kept items from the inner hooks, so the conformance conftest's `apply_lane_ceiling` never sees them), and passes on a plain run. Not touched by this diff.

## Architecture pre-check — #4152

### 1. BLUEPRINT § alignment

§5.6 Loop Topology (board reconcile is a loop scanner) and §17.1 invariant 9 (the `DeferredQuestion` operator surface the cap escalates onto). No BLUEPRINT claim changes: rule E's contract is already documented as "capped at 3, then escalate once" — this makes the shipped code match that claim. No doc references `MAX_REOPEN_REVIVALS` (grepped BLUEPRINT.md, AGENTS.md, docs/, skills/ — zero hits), so nothing to realign.

### 2. FSM phase boundaries

No transition added, moved, or removed. The change is to what SURVIVES an existing transition: `Ticket._extra()` → `validated_ticket_extra` is called by `test()`, `skip_shipping()`, `rework()`, `reopen()`, `ignore()`. `test()` (CODED→TESTED) is the one on rule E's revive→ladder→deliver path. The FSM-graph pin `tests/teatree_core/test_ticket_structure.py` already covers `reopen`'s `delivered` source and is untouched.

### 3. Extension-point contracts

None. No `OverlayBase` hook, no scanner registration, no `*Backend` Protocol, no hook surface. `TicketExtra` is an internal TypedDict with no overlay consumer.

### 4. Component boundaries

`src/teatree/core/models/types.py` — the allowlist already lives there beside every other ticket-extra key. One key added to an existing TypedDict; no new module, no straddle.

### 5. Dependency direction

No new import in `src/`. The conformance test imports `teatree.core.models.types` and the package-local `tests/conformance/_src_tree`, both already-established edges. `uv run tach check` → "✅ All modules validated!".

### 6. Test surface

- `tests/teatree_core/test_extra_validators.py::test_reopen_revivals_survives_validation` — the validator round-trip. RED: `KeyError: 'reopen_revivals'`.
- `tests/teatree_loop/test_board_reconcile.py::test_the_cap_fires_after_max_revivals_across_ladder_walks` — the production consequence. RED: `assert 5 == 3`.
- The two pre-existing cap tests, made load-bearing by reshaping `_capped()` to round-trip through the real `test()` transition. Previously vacuous-green; RED after reshaping.
- `tests/conformance/test_model_extra_keys_are_declared.py` — the class guard, plus `test_the_walk_detects_both_write_shapes` as its anti-vacuity control (a planted violation in each write shape).

### 7. Resilience invariants

No new external write. The change makes an EXISTING one reachable: `DeferredQuestion.record` in `_escalate_revival_cap_once` never fired before, because the cap it gates on never tripped.

- idempotency — preserved: the escalation dedupes once-ever on the indexed `dedupe_marker`, counting answered rows (pinned by `test_an_answered_escalation_is_never_re_asked`).
- heartbeat / fallback-transport / verify-by-re-read / sub-agent contract — n/a, no new external call is introduced.

### 8. Identity and key normalization

`reopen_revivals` is the fully-qualified key at both ends — `board_reconcile` writes it and `_revival_count` reads it under the same literal. No strip/split/prefix transformation added, and none existed. The defect was an absent DECLARATION, not a mismatched form.

### 9. Behavior preservation / capability deletion

Purely additive on the production side — one TypedDict key. Nothing removed, nothing narrowed. No privacy/leak/security matcher touched.

The one replacement is a test helper: `_capped()` previously assigned the raw JSONField and never round-tripped. Both behaviours it supported (a ticket at the cap; a `DELIVERED` end state) are preserved — the helper still returns a `DELIVERED` ticket carrying `MAX_REOPEN_REVIVALS`. What changes is that it now persists the counter the way production does. No must-block test was inverted: the two cap tests keep their original must-halt/must-escalate assertions verbatim, and go from vacuous-green to genuinely RED-then-GREEN.

### 10. Removability / harness-vs-data

- **Removability.** Deleting the key reverts exactly to today's behaviour (silent strip); blast radius is one line plus the four tests that pin it. Fully removable.
- **Harness vs data.** The key BELONGS in the harness: `TicketExtra` is the schema, and `validated_ticket_extra` is the mechanism that reads it. The varying part — the cap VALUE — is already separated as the `MAX_REOPEN_REVIVALS` constant. This change adds no policy, only the declaration that lets the existing policy execute.

## Open questions & assumptions

- **assumed** — the cap semantics ratified in [#4233](https://github.com/souliane/teatree/pull/4233) stand unchanged: 3 revivals, then halt at `DELIVERED` with one `DeferredQuestion`. This PR fixes only that they never took effect.
- **assumed** — `also_set` is excluded from the conformance walk's key params because it writes sibling model fields, not `extra` keys; `pop_keys` removes a key, so it cannot strand one.
- **assumed** — the 12 env-shaped local test failures are pre-existing; verified by re-running them with `src/` reverted to `origin/main` (same 12 fail). CI is the merge authority.
- **open** — `_revive_reopened` still does an unlocked `ticket.extra = …; ticket.save()` RMW rather than the `merge_extra` locked primitive (#800 N3). Left as-is: it matches the idiom every FSM transition uses, rewriting it needs `also_set` for the state the transition set in memory, and board reconcile is single-threaded in the loop tick.
- **open** — the conformance walk is AST-only, so a computed key (`extra[f"{p}_n"] = …`) is invisible to it. No such site exists today — a strong backstop, not a proof.
- **open** — [#4247](https://github.com/souliane/teatree/issues/4247) (conformance items lose the lane ceiling under the force-keep plugin) is hit by this branch's local lane run but is main-side; not fixed here to keep this diff to one root cause.
