### PR TITLE
fix(evals): classify escalation on trials passed, not the weekly gate verdict (#4243)

### DIFF
--- a/src/teatree/cli/eval/escalate.py
+++ b/src/teatree/cli/eval/escalate.py
@@ -154,7 +154,10 @@ def escalate_failures(
     Returns the per-scenario :class:`EscalationOutcome` list (empty when nothing
     failed trial 1) and, via :attr:`EscalationReport.hard_red`, whether the lane
     must go RED. A scenario re-runs at ``require="any"`` semantics: passing on any
-    escalation trial is enough to clear it as ``flaky``.
+    escalation trial is enough to clear it as ``flaky``. An escalation whose every
+    trial SKIPPED produced no evidence at all — a provisioning gate that fell away
+    between trial 1 and the re-runs (an expired key, a vanished binary) — so it
+    clears as ``flaky`` rather than reddening the lane on an absent verdict.
     """
     if escalate_trials < 2:  # noqa: PLR2004 — one trial is no escalation; the trial-1 result already covers it.
         msg = f"escalate_trials must be >= 2 (got {escalate_trials}); a single trial is not an escalation."
@@ -166,7 +169,8 @@ def escalate_failures(
         aggregate = run_pass_at_k(result.spec, runner, k=escalate_trials, require="any")
         # NOT `aggregate.ok`: that is the weekly gate's verdict and vetoes on cap taint (#2192),
         # which reds a scenario a majority of whose escalation trials passed cleanly (#4243).
-        classification: EscalationClass = "flaky" if aggregate.passes >= 1 else "confirmed"
+        cleared = aggregate.skipped or aggregate.passes >= 1
+        classification: EscalationClass = "flaky" if cleared else "confirmed"
         outcomes.append(
             EscalationOutcome(
                 spec_name=result.spec.name,

--- a/src/teatree/cli/eval/escalate.py
+++ b/src/teatree/cli/eval/escalate.py
@@ -26,7 +26,7 @@ import dataclasses
 from collections.abc import Callable
 from typing import Literal
 
-from teatree.eval.models import EvalSpec
+from teatree.eval.models import CAP_TERMINAL_REASONS, EvalSpec
 from teatree.eval.pass_at_k import run_pass_at_k
 from teatree.eval.report import ScenarioResult
 from teatree.eval.surface import is_advisory
@@ -63,6 +63,12 @@ class EscalationOutcome:
     ``advisory`` carries the scenario's question SURFACE through to the verdict: an
     ``interactive``-surface scenario is re-run and reported exactly like any other,
     but never reds the lane (#3855).
+
+    ``cap_tainted`` records that at least one escalation trial was cap-truncated
+    (``max_turns``/budget/timeout), so the trial evidence is incomplete. It is
+    REPORTED by both renderers and never gates: the cap veto belongs to the weekly
+    gate (:attr:`~teatree.eval.pass_at_k.PassAtKResult.ok`), and applying it here
+    reds a scenario that passed a majority of its escalation trials (#4243).
     """
 
     spec_name: str
@@ -70,6 +76,7 @@ class EscalationOutcome:
     passes: int
     classification: EscalationClass
     advisory: bool = False
+    cap_tainted: bool = False
 
     @property
     def is_hard_red(self) -> bool:
@@ -126,8 +133,9 @@ def render_escalation_markdown(report: EscalationReport) -> str:
 
 
 def describe_classification(outcome: EscalationOutcome) -> str:
-    """The outcome's classification, tagged when it is reported-but-non-gating."""
-    return f"{outcome.classification} (advisory)" if outcome.advisory else outcome.classification
+    """The outcome's classification, tagged with every reported-but-non-gating qualifier."""
+    tags = [tag for tag, present in (("advisory", outcome.advisory), ("cap-truncated", outcome.cap_tainted)) if present]
+    return f"{outcome.classification} ({', '.join(tags)})" if tags else outcome.classification
 
 
 def _failed(result: ScenarioResult) -> bool:
@@ -156,7 +164,9 @@ def escalate_failures(
         if not _failed(result):
             continue
         aggregate = run_pass_at_k(result.spec, runner, k=escalate_trials, require="any")
-        classification: EscalationClass = "flaky" if aggregate.ok else "confirmed"
+        # NOT `aggregate.ok`: that is the weekly gate's verdict and vetoes on cap taint (#2192),
+        # which reds a scenario a majority of whose escalation trials passed cleanly (#4243).
+        classification: EscalationClass = "flaky" if aggregate.passes >= 1 else "confirmed"
         outcomes.append(
             EscalationOutcome(
                 spec_name=result.spec.name,
@@ -164,6 +174,7 @@ def escalate_failures(
                 passes=aggregate.passes,
                 classification=classification,
                 advisory=is_advisory(result.spec),
+                cap_tainted=aggregate.terminal_reason in CAP_TERMINAL_REASONS,
             )
         )
     return EscalationReport(outcomes=outcomes)

--- a/tests/eval_harness/test_escalate_on_fail.py
+++ b/tests/eval_harness/test_escalate_on_fail.py
@@ -161,6 +161,22 @@ class TestEscalateFailures:
         assert outcome.is_hard_red
         assert report.hard_red
 
+    def test_an_all_skipped_escalation_clears_rather_than_reddening_the_lane(self) -> None:
+        # A provisioning gate that fell away after trial 1 (expired key, vanished
+        # binary) yields zero graded trials — an absent verdict, not a confirmed one.
+        spec = _spec("gate_fell_away")
+        initial = [_result(spec, passed=False)]
+
+        class _SkippingRunner:
+            def __call__(self, spec: EvalSpec) -> ScenarioResult:
+                return _result(spec, passed=False, skipped=True)
+
+        report = escalate_failures(initial, _SkippingRunner(), escalate_trials=3)
+        outcome = report.outcomes[0]
+        assert outcome.passes == 0
+        assert outcome.classification == "flaky"
+        assert not report.hard_red
+
     def test_escalate_trials_must_be_at_least_two(self) -> None:
         spec = _spec("x")
         initial = [_result(spec, passed=False)]

--- a/tests/eval_harness/test_escalate_on_fail.py
+++ b/tests/eval_harness/test_escalate_on_fail.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 from teatree.cli.eval.escalate import EscalationOutcome, EscalationReport, escalate_failures, render_escalation_markdown
+from teatree.cli.eval.single_trial import _render_escalation_text
 from teatree.eval.models import EvalRun, EvalSpec, Matcher
 from teatree.eval.report import ScenarioResult
 
@@ -33,14 +34,14 @@ def _spec(name: str) -> EvalSpec:
     )
 
 
-def _result(spec: EvalSpec, *, passed: bool, skipped: bool = False) -> ScenarioResult:
-    reason = "skipped: x" if skipped else ("success" if passed else "end_turn")
+def _result(spec: EvalSpec, *, passed: bool, skipped: bool = False, cap_reason: str = "") -> ScenarioResult:
+    reason = cap_reason or ("skipped: x" if skipped else ("success" if passed else "end_turn"))
     run = EvalRun(
         spec_name=spec.name,
         tool_calls=(),
         text_blocks=(),
         terminal_reason=reason,
-        is_error=not passed and not skipped,
+        is_error=not passed and not skipped and not cap_reason,
         raw_stdout="",
         raw_stderr="",
     )
@@ -48,15 +49,24 @@ def _result(spec: EvalSpec, *, passed: bool, skipped: bool = False) -> ScenarioR
 
 
 class _ScriptedRunner:
-    """Maps a scenario name to a queue of pass/fail verdicts for its escalation trials."""
+    """Maps a scenario name to a queue of verdicts for its escalation trials.
 
-    def __init__(self, scripts: dict[str, list[bool]]) -> None:
+    A ``bool`` entry is a clean pass/fail. A ``str`` entry is a cap reason
+    (``max_turns``) for a trial whose matchers were satisfied by a partial
+    trajectory the harness then truncated — the #2192 shape, which
+    :attr:`ScenarioResult.passed` scores as a non-pass.
+    """
+
+    def __init__(self, scripts: dict[str, list[bool | str]]) -> None:
         self._iters = {name: iter(verdicts) for name, verdicts in scripts.items()}
         self.calls: dict[str, int] = {}
 
     def __call__(self, spec: EvalSpec) -> ScenarioResult:
         self.calls[spec.name] = self.calls.get(spec.name, 0) + 1
-        return _result(spec, passed=next(self._iters[spec.name]))
+        verdict = next(self._iters[spec.name])
+        if isinstance(verdict, str):
+            return _result(spec, passed=True, cap_reason=verdict)
+        return _result(spec, passed=verdict)
 
 
 class TestEscalateFailures:
@@ -125,6 +135,32 @@ class TestEscalateFailures:
         assert by_name["flaky"].classification == "flaky"
         assert by_name["confirmed"].classification == "confirmed"
 
+    def test_flaky_when_a_clean_trial_passes_despite_a_cap_truncated_sibling(self) -> None:
+        # The live CI shape recorded as CONFIRMED (2/3): two clean passes and one
+        # cap-truncated trial. Passing ANY escalation trial is flaky, never a hard red.
+        spec = _spec("capped_sibling")
+        initial = [_result(spec, passed=False)]
+        runner = _ScriptedRunner({"capped_sibling": [True, "max_turns", True]})
+        report = escalate_failures(initial, runner, escalate_trials=3)
+        outcome = report.outcomes[0]
+        assert outcome.passes == 2
+        assert outcome.classification == "flaky"
+        assert outcome.cap_tainted
+        assert not outcome.is_hard_red
+        assert not report.hard_red
+
+    def test_confirmed_when_every_escalation_trial_is_cap_truncated(self) -> None:
+        spec = _spec("all_capped")
+        initial = [_result(spec, passed=False)]
+        runner = _ScriptedRunner({"all_capped": ["max_turns", "max_turns", "max_turns"]})
+        report = escalate_failures(initial, runner, escalate_trials=3)
+        outcome = report.outcomes[0]
+        assert outcome.passes == 0
+        assert outcome.classification == "confirmed"
+        assert outcome.cap_tainted
+        assert outcome.is_hard_red
+        assert report.hard_red
+
     def test_escalate_trials_must_be_at_least_two(self) -> None:
         spec = _spec("x")
         initial = [_result(spec, passed=False)]
@@ -163,3 +199,16 @@ class TestRenderEscalationMarkdown:
         assert "1 confirmed, 1 flaky" in md
         assert "| flaky_one | 1/3 | flaky |" in md
         assert "| solid_red | 0/3 | confirmed |" in md
+
+    def test_cap_taint_is_reported_but_never_gates(self) -> None:
+        report = EscalationReport(
+            outcomes=[
+                EscalationOutcome(
+                    spec_name="capped_sibling", trials=3, passes=2, classification="flaky", cap_tainted=True
+                )
+            ]
+        )
+        assert "cap-truncated" in render_escalation_markdown(report)
+        assert "CAP-TRUNCATED" in _render_escalation_text(report)
+        assert not report.outcomes[0].is_hard_red
+        assert not report.hard_red


### PR DESCRIPTION
fix(evals): classify escalation on trials passed, not the weekly gate verdict (#4243)

PR-B of [#4243](https://github.com/souliane/teatree/issues/4243) — the separable second defect. PR-A (the eval sandbox) merged as [#4257](https://github.com/souliane/teatree/pull/4257).

## What

- `escalate_failures` classified on `PassAtKResult.ok` instead of the trials it just ran. `.ok` layers on a cap veto (#2192) that neither of `escalate.py`s docstrings mentions, so a single `max_turns`-terminated trial reds a `--require any` aggregate.
- Classify on `aggregate.passes >= 1` so the implementation matches the contract the module already documents.
- Carry the cap taint as a non-gating `cap_tainted: bool` on `EscalationOutcome`, surfaced by both renderers (`render_escalation_markdown` and the CLI text renderer) via the shared `describe_classification` seam.
- Clear an all-SKIPPED escalation as flaky, preserving the pre-change behaviour (see Blast radius).

## Why

A majority-pass was recorded as a confirmed regression. One CI job classified `orchestrator_boundary_no_foreground_edit_in_main_agent` as CONFIRMED (2/3 escalation trials) while classifying `orchestrator_collects_result_not_polls_subagent` as FLAKY (2/3) — identical counts, opposite verdicts, same run. `escalate.py:58-61` documents `confirmed` as meaning every escalation trial failed.

## `PassAtKResult.ok` is untouched

Its cap veto is the gate verdict for six other consumers including the weekly gate and the dream live gate, and is defended by `TestCostAndTurnGatesRetainTeethAfterWatchdogFix` and `test_any_fails_when_a_trial_hit_max_turns_even_with_a_clean_pass`. Both stay green and unmodified — the diff touches two files, neither of them `pass_at_k.py` nor its test.

## Blast radius

- Exactly one call site: `single_trial._escalate_and_gate` (the `--escalate-on-fail` PR lane). Verified by grep over `escalate_failures`, `is_hard_red` and `hard_red`.
- Only `eval-pr`, `eval-pr-reusable`, `eval-nightly` and `eval-ci-heal` pass `--escalate-on-fail`. `eval.yml` and `eval-weekly-reusable.yml` do not, so zero recorded weekly aggregates change.
- For `require="any"` the new predicate is a superset of the old, so it cannot turn a green aggregate red — with one exception found while checking rather than assuming: `.ok` short-circuits True on a SKIPPED aggregate before consulting `passes`, so a bare `passes >= 1` would have classified an all-skipped escalation as `confirmed`. That is reachable (a fresh-run backend stamps `skipped: <reason>` when its provisioning gate is unmet, so a credential expiring between trial 1 and the re-runs turns an environment problem into a hard CI red). The second commit preserves it.

## Architecture pre-check

1. BLUEPRINT — §"Escalate-on-fail" (the `--escalate-on-fail` PR lane). The BLUEPRINT already states the corrected contract (flaky = recovered, confirmed = the lane reds); no BLUEPRINT change needed because the code now matches what it says.
2. FSM phase boundaries — n/a, no `Ticket.State` or `Worktree.State` transition.
3. Extension-point contracts — none. `EscalationOutcome.is_hard_red` stays in `ADVISORY_EXEMPT_VERDICT_POINTS`; `tests/conformance/test_advisory_verdict_points.py` resolves it and passes.
4. Component boundaries — `src/teatree/cli/eval/` (the lane classifier). Correct: this is lane policy, not the pass@k primitive.
5. Dependency direction — one added import, `CAP_TERMINAL_REASONS` from `teatree.eval.models` into `teatree.cli.eval.escalate` (cli to eval, the existing direction; the module already imports `EvalSpec` from there). `tach` and `import-linter` both Passed in prek.
6. Test surface — `tests/eval_harness/test_escalate_on_fail.py`: three new tests plus the skipped-aggregate guard, each proved by the mutation that reds it (listed below).
7. Resilience invariants — n/a, no external write.
8. Identity and key normalization — n/a, no bare-vs-qualified identity.
9. Behavior preservation — the only behaviour the old `.ok` delegation carried that the new predicate would drop is the skipped-aggregate clearance; preserved explicitly in commit 2 with its own test. No matcher narrowed, no must-block test inverted.
10. Removability / harness-vs-data — `cap_tainted` is a defaulted field on one frozen dataclass with one producer and one renderer seam; deleting it reverts to the prior rendering with no cascade. Harness side is right: this is a verdict rule, not per-item policy a table could express.

## Mutation controls (all observed RED)

| Mutation | Result |
| --- | --- |
| `cleared = aggregate.skipped or aggregate.ok` | 1 failed — `test_flaky_when_a_clean_trial_passes_despite_a_cap_truncated_sibling`: `assert 'confirmed' == 'flaky'` |
| `cleared = True` | 3 failed — incl. `test_confirmed_when_every_escalation_trial_is_cap_truncated`: `assert 'flaky' == 'confirmed'` |
| `cleared = aggregate.trials >= 1` | 3 failed — same set |
| drop `cap-truncated` from `describe_classification` | 1 failed — `assert 'cap-truncated' in ...` (markdown renderer) |
| text renderer bypasses `describe_classification` | 1 failed — `assert 'CAP-TRUNCATED' in ...` (text renderer) |
| `is_hard_red` consults `cap_tainted` | 2 failed — `assert not True` on both cap tests |
| drop `aggregate.skipped or` | 1 failed — `test_an_all_skipped_escalation_clears_rather_than_reddening_the_lane` |

## Verification

- `tests/eval_harness/test_escalate_on_fail.py` + `test_pass_at_k.py` + `tests/teatree_cli/eval/test_advisory_surface.py`: 58 passed.
- `uv run ruff check`: All checks passed. `ruff format --check`: 2 files already formatted.
- `dev/ci-parity-fast.sh`: prek Passed, `makemigrations --check` Passed. The affected-tests step reds on ONE pre-existing item unrelated to this diff — see below.
- Zero metered eval trials. This PR touches no scenario YAML and no `agent_path`, so `changed-scenarios` selects nothing and the eval gate should skip.

## Pre-existing lane failure (not this diff)

`tests/conformance/test_lane_ceiling.py::TestTheCeilingIsLiveOnThisLane::test_the_running_item_carries_the_lane_ceiling` reds under `dev/test-affected.sh`. Isolated to `-p teatree.quality.force_keep_plugin`: items the force-keep layer re-adds arrive AFTER the `tests/conformance` package conftest ran `apply_lane_ceiling`, so they carry no `timeout` marker.

Controls, each reproducing in under 8s:

- with `--tach-base HEAD` (zero diff, this change invisible to the selector): still fails.
- without `force_keep_plugin`: tach deselects everything, `no tests ran`.
- `tests/conformance` in its own invocation (the shape `dev/push-gate.sh` and CI use): green.

It reds `ci-parity-fast` for any diff and is out of scope here; filed as an observation rather than fixed, because the fix touches the lane selection machinery (which forces FULL selection).

## Open questions & assumptions

- assumed: the cap veto stays the right rule for the WEEKLY gate and is wrong only for escalation classification. `eval.yml` never calls `escalate_failures`, so no recorded aggregate changes.
- assumed: an all-SKIPPED escalation should clear rather than red. This preserves the pre-change behaviour exactly; the alternative (red) would be a new gate the old code never applied.
- open: the pre-existing `force_keep_plugin` / lane-ceiling interaction above. Not fixed here.

docs: n/a — no new command, flag, env var, FSM state or skill; the corrected behaviour is what BLUEPRINT and the module docstrings already describe.

Closes #4243
