### PR TITLE
docs: make the causeless prose agree with the corrected claim (#4075)

### DIFF
--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -579,7 +579,7 @@ def _record_landed(task: Task, *, evidence: str, lease_loss: str) -> TaskAttempt
 
     The row is landed COMPLETED only while NOTHING holds it — a conditional
     ``UPDATE ... WHERE status=PENDING``, the same compare-and-swap
-    ``transient_requeue._retire_superseded`` uses. A live successor's claim is therefore
+    ``transient_requeue_disposal._retire_superseded`` uses. A live successor's claim is therefore
     never terminated out from under it, and a row nobody took up after the in-process
     reclaim stops being re-dispatched for work that already shipped. No FSM side effect is
     needed: the evidence IS that the ticket already reached this phase's target state.

--- a/src/teatree/core/modelkit/task_failure_taxonomy.py
+++ b/src/teatree/core/modelkit/task_failure_taxonomy.py
@@ -119,9 +119,10 @@ _ENVIRONMENTAL: frozenset[str] = frozenset(
     },
 )
 
-#: Kinds that are the ABSENCE of a cause rather than a cause, recorded with a CONSTANT
-#: reason — so two of them collide on one fingerprint by construction. See the module
-#: docstring: dropped from the stall comparison, never from the iteration budget.
+#: Kinds that are the ABSENCE of a cause rather than a cause. Membership is that test, NOT
+#: fingerprint collision — ``no_result_envelope``'s constant reason self-collides,
+#: ``runtime_ceiling``'s interpolated one does not. See the module docstring: dropped from
+#: the stall comparison, never from the iteration budget.
 _CAUSELESS: frozenset[str] = frozenset(
     {
         FailureKind.NO_RESULT_ENVELOPE,

--- a/src/teatree/core/repair_loop.py
+++ b/src/teatree/core/repair_loop.py
@@ -19,12 +19,14 @@ re-running the identical failure.
 
 Both stall checks compare only what the CALLER hands them, and it is the caller's
 job to withhold a comparison that cannot mean anything. A CAUSELESS failure — one
-recorded with a constant reason because the run reported nothing at all — collides
-with itself by construction, so
+whose run reported nothing at all about why the work is unfinished — is withheld by
+that absence-of-a-cause test, not by whether its text repeats:
 :func:`~teatree.core.modelkit.task_failure_taxonomy.stall_fingerprints` drops it
-before it reaches :func:`is_stalled` (#4075). That, like the deterministic-kinds
-filter below, is what keeps this module a dependency-free leaf with no import of
-the failure taxonomy.
+before it reaches :func:`is_stalled` (#4075). ``no_result_envelope``'s reason is a
+constant, so it does self-collide here; ``runtime_ceiling``'s interpolates the breach
+and does not, and for it the kind-level drop is what does the work. That, like the
+deterministic-kinds filter below, is what keeps this module a dependency-free leaf
+with no import of the failure taxonomy.
 
 Named-cause stall (#3958) — a fingerprint compares FREE TEXT, so one deterministic
 defect whose message carries a varying detail (a differing sha, a differing spec

--- a/tests/teatree_core/test_task_failure_reason.py
+++ b/tests/teatree_core/test_task_failure_reason.py
@@ -150,9 +150,10 @@ class TestClassifier(TestCase):
 class TestCauselessKinds:
     """#4075: a failure that named no cause must not be compared against itself.
 
-    Both causeless kinds are recorded with a CONSTANT reason, so two of them collide on
-    one fingerprint by construction — "we learned nothing, twice" would otherwise read as
-    "one defect recurred twice" and halt a phase that was never doomed.
+    Membership is the absence-of-a-cause test, not fingerprint collision:
+    ``no_result_envelope``'s constant reason self-collides, ``runtime_ceiling``'s
+    interpolated one does not. Without the drop, "we learned nothing, twice" reads as
+    "one defect recurred twice" and halts a phase that was never doomed.
     """
 
     def test_the_two_reporting_failures_are_causeless(self) -> None:


### PR DESCRIPTION
docs: make the causeless prose agree with the corrected claim (#4075)

## What
The module docstring at task_failure_taxonomy.py:48-54 was corrected to say membership in _CAUSELESS is decided by the absence-of-a-cause test, not by fingerprint collision. Three prose blocks still carried the refuted claim that both causeless kinds collide on one fingerprint by construction - including the comment on _CAUSELESS itself, 70 lines below the docstring that refutes it.

Measured: runtime_ceiling reasons interpolate the breach, so two of them fingerprint differently (b9fb7c74... for ran 3601s vs 7de4e65b... for ran 3722s, is_stalled False); no_result_envelope reason is a module constant and self-collides (25eb6d3d... twice, is_stalled True). For runtime_ceiling the kind-level drop in _deterministic_kinds is what does the work.

Also repoints a stale symbol reference: headless.py named transient_requeue._retire_superseded, which this branch moved to transient_requeue_disposal.

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.