### PR TITLE
fix(deploy): cut worktrees from a clone every venue can name (#4120)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -152,6 +152,12 @@ RUN mkdir -p \
     # worktree provisioning ("No git clone found for souliane/teatree") and the
     # issue-implementer intake is silently disabled. This mirrors the host
     # layout (~/workspace/souliane/teatree -> the teatree clone).
+    #
+    # This target is the FALLBACK. ~/teatree is this container's volume and no
+    # other venue's path, so a worktree cut from it carries a `gitdir:` only this
+    # container resolves (#4120) — deploy/entrypoint.sh's retarget_clone_discovery
+    # repoints the link at the path-identity-mounted deploy checkout whenever one
+    # is there, and leaves this link when there is not.
     mkdir -p /home/teatree/workspace/souliane && \
     ln -s /home/teatree/teatree /home/teatree/workspace/souliane/teatree && \
     chown -R teatree:teatree /home/teatree /opt/teatree /var/lib/teatree

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -864,7 +864,7 @@ docker compose -p teatree logs -f teatree-watchdog
 | `TEATREE_WATCHDOG_DEPLOY_LOCK` | `/host-tmp/teatree-deploy.lock` (compose) | deploy.sh's convergence flock, as seen from this container — the deploy-in-flight probe |
 | `TEATREE_WATCHDOG_DEPLOY_RECREATE_WINDOW` | `$TEATREE_WATCHDOG_INTERVAL` | seconds after a container was *created* that still count as the image swap settling |
 | `TEATREE_WATCHDOG_DEPLOY_PENDING_STATE` | `/var/tmp/teatree-watchdog-deploy-sensitive.state` | the two-strikes ledger for the deploy-gated findings |
-| `TEATREE_DEPLOY_CHECKOUT` | `/home/teatree/teatree-deploy` | the checkout holding `deploy/` — bind source AND target for the watchdog's read-only mount, and the root it execs `deploy/watchdog.sh` from; exported by `deploy.sh` and `deploy/t3` |
+| `TEATREE_DEPLOY_CHECKOUT` | `/home/teatree/teatree-deploy` | the checkout holding `deploy/` — bind source AND target (path identity) for the watchdog's read-only mount and the app services' read-write one, the clone `workspace ticket` cuts worktrees from (#4120), and the root the watchdog execs `deploy/watchdog.sh` from; exported by `deploy.sh` and `deploy/t3` <!-- privacy-scan:allow — the box's public, documented deploy home --> |
 | `TEATREE_DOCKER_SOCKET_GID` | `0`, or the host socket's group on Linux | the supplementary group `teatree-worker` is given so the non-root worker can drive the daemon; resolved by `deploy/deploy.sh` and `deploy/t3` |
 
 It needs `python3` in the image for the richest DM body (baked into the image);

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -86,13 +86,33 @@ x-teatree-common: &teatree-common
     # tries to open the canonical DB gets a directory it cannot create, and fails
     # loudly instead of quietly opening a second database.
     - teatree_control_db:/var/lib/teatree/control-db
-    # The container's own CLONE root (`config.clone_root()`), holding the source
-    # clones worktrees are cut from. Mounted BENEATH the `t3-workspaces` bind
-    # below: docker orders mounts by target depth, so this lands first and the
-    # worktree bind lands on top of it. That nesting is deliberate — the clones
-    # are container-owned and invisible to the host, while the worktrees they
-    # produce stay host-visible so an operator can read and edit the code.
+    # The container's own CLONE root (`config.clone_root()`). Mounted BENEATH the
+    # `t3-workspaces` bind below: docker orders mounts by target depth, so this
+    # lands first and the worktree bind lands on top of it. The root itself is
+    # container-owned; what it holds for a repo is a discovery SYMLINK, and the
+    # mount below is what that link resolves to.
     - teatree_clones:/home/teatree/workspace
+    # The checkout this stack was deployed from, at PATH IDENTITY, READ-WRITE —
+    # the clone `workspace ticket` cuts worktrees from (deploy/entrypoint.sh's
+    # retarget_clone_discovery points the discovery link at it).
+    #
+    # `git worktree add` bakes an ABSOLUTE `gitdir:` pointer into its source
+    # clone, so the CLONE's path decides who can use the worktree, not the
+    # worktree's own. Cutting from the container-only `teatree_src` volume at
+    # `$TEATREE_CLONE_DIR` recorded a path that exists in no other venue: the
+    # files stayed readable from the host (t3-workspaces is bind-mounted) while
+    # every git command against them answered `fatal: not a git repository`
+    # (#4120). Path identity is the same device the watchdog's own read-only
+    # spelling of this mount already relies on, and both sides read ONE variable
+    # so identity holds on any topology rather than only at the box default.
+    #
+    # Read-write because `worktree add` writes `.git/worktrees/<n>` into the
+    # clone — the watchdog's read-only mount cannot serve provisioning. The
+    # container's UID is the host deploy user's (README § UID invariant), so
+    # those writes land with the ownership the host expects.
+    - type: bind
+      source: ${TEATREE_DEPLOY_CHECKOUT:-/home/teatree/teatree-deploy}  # privacy-scan:allow — the box's public, documented deploy home
+      target: ${TEATREE_DEPLOY_CHECKOUT:-/home/teatree/teatree-deploy}  # privacy-scan:allow — the box's public, documented deploy home
     - type: bind
       source: ${TEATREE_HOST_HOME:-/home/teatree}/.local/share/teatree
       target: /home/teatree/.local/share/teatree
@@ -204,6 +224,10 @@ services:
       # install that registers the overlay entry point. Interpolated from the
       # host env because that is the only channel deploy/t3 can reach compose on.
       TEATREE_CLONE_DIR: ${TEATREE_CLONE_DIR:-/home/teatree/teatree}
+      # Init owns the shared clone root, so it is where the discovery link is
+      # retargeted at the host-visible checkout — before the worker that reads
+      # it starts (#4120).
+      TEATREE_DEPLOY_CHECKOUT: ${TEATREE_DEPLOY_CHECKOUT:-/home/teatree/teatree-deploy}  # privacy-scan:allow — the box's public, documented deploy home
     restart: "no"
 
   # The loop cadence owner. DEBUG off — a long-running DEBUG Django process grows
@@ -216,6 +240,10 @@ services:
       T3_DEBUG: "0"
       TMPDIR: ${TEATREE_DISK_TMPDIR:-/var/tmp}
       TEATREE_CLONE_DIR: ${TEATREE_CLONE_DIR:-/home/teatree/teatree}
+      # Same value as the checkout bind in the shared anchor: the entrypoint
+      # points clone discovery at it so the worktrees this role cuts carry a
+      # `gitdir:` the host resolves too (#4120).
+      TEATREE_DEPLOY_CHECKOUT: ${TEATREE_DEPLOY_CHECKOUT:-/home/teatree/teatree-deploy}  # privacy-scan:allow — the box's public, documented deploy home
     # THE ONE SERVICE THAT MAY DRIVE THE DAEMON. The shared mount set carries
     # /var/run/docker.sock, but the socket is mode 0660 root-owned and every app
     # service runs as the non-root TEATREE_UID, so the mount alone grants nothing.

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -291,6 +291,37 @@ git config --global user.email "${GIT_AUTHOR_EMAIL:-teatree@localhost}"
 git config --global init.defaultBranch main
 git config --global --add safe.directory "$CLONE_DIR"
 
+# Point clone discovery at a checkout every venue can reach.
+#
+# `git worktree add` bakes an ABSOLUTE `gitdir:` pointer into its SOURCE CLONE,
+# so the clone's path — not the worktree's — decides who can use the result. The
+# image links `~/workspace/souliane/teatree` at the `teatree_src` volume, a path
+# that exists nowhere but this container, so a worktree cut here answered
+# `fatal: not a git repository` from the host even though its files were readable
+# through the `t3-workspaces` bind (#4120). The deploy checkout is bind-mounted at
+# path identity, so pointing the link there makes the recorded pointer portable.
+#
+# Degrades to the image's link rather than failing: with nothing exported dockerd
+# creates an empty dir at the default path, and a container that provisions
+# container-only worktrees is still better than one that cannot provision at all.
+retarget_clone_discovery() {
+    local link="${1:-/home/teatree/workspace/souliane/teatree}"  # privacy-scan:allow — the box's public, documented deploy home
+    local checkout="${TEATREE_DEPLOY_CHECKOUT:-}"
+    if [ -z "$checkout" ] || ! git -C "$checkout" rev-parse --git-dir >/dev/null 2>&1; then
+        echo "entrypoint: no git checkout at TEATREE_DEPLOY_CHECKOUT='${checkout}' - leaving clone discovery on the image link; worktrees cut here resolve only inside this container (#4120)" >&2
+        return 0
+    fi
+    # A real directory is someone's clone, not the image's link — never clobber it.
+    if [ -e "$link" ] && [ ! -L "$link" ]; then
+        echo "entrypoint: $link is a real directory, not the image's discovery link - leaving it untouched (#4120)" >&2
+        return 0
+    fi
+    mkdir -p "$(dirname "$link")"
+    ln -sfn "$checkout" "$link"
+}
+
+retarget_clone_discovery
+
 # True when the box pass store holds at least one Anthropic account entry —
 # the option-b credential source (anthropic_oauth_pass_paths routing).
 pass_store_has_anthropic() {

--- a/src/teatree/core/worktree/clone_provision.py
+++ b/src/teatree/core/worktree/clone_provision.py
@@ -5,13 +5,16 @@ sure there is one". The distinction is what lets a runtime own its workspace
 instead of inheriting one.
 
 The containerized stack is the case that forces it. Its clone root is a
-container-owned volume, not a bind of the operator's ``~/workspace`` — deliberately,
-because a bind would not help: a git worktree records an ABSOLUTE ``gitdir``
-pointer into its source clone, so a worktree created on the host is structurally
-unusable in the container (``fatal: not a git repository: /Users/...``) and the
-reverse. Sharing the checkouts across the boundary cannot work; each side owning
-its own clones can. So the container clones what it needs, and every worktree it
-creates points at a clone in its own coordinates.
+container-owned volume, not a bind of the operator's ``~/workspace``: a git
+worktree records an ABSOLUTE ``gitdir`` pointer into its source clone, so sharing
+a clone across the boundary works only where the two venues agree on its path,
+and a bind that lands the operator's clones at a DIFFERENT container path makes
+every worktree structurally unusable on the other side (``fatal: not a git
+repository``, naming a gitdir the reading venue has no such path for). So the
+container clones what it needs into its own root. What the root then holds for
+a repo may be a link to a clone mounted at
+PATH IDENTITY — the deploy checkout, which every venue names the same way
+(souliane/teatree#4120) — and that is the shape a shared clone has to take.
 
 Cloning is by definition a network operation against a private remote, so it
 depends on the runtime's git credential helper being wired (``deploy/entrypoint.sh``

--- a/tests/test_deploy_bindmount_compose.py
+++ b/tests/test_deploy_bindmount_compose.py
@@ -68,14 +68,23 @@ SESSION_PLANE = {
 }
 # Every host bind mount the shared list must carry, by canonical container target.
 ALL_BIND_TARGETS = EXTERNALIZED | CREDENTIAL_PLANE | SESSION_PLANE
+# The deploy checkout: the clone `workspace ticket` cuts worktrees from (#4120).
+# A different KIND of bind from the state planes above — it is not a container
+# path rebased onto the host home but the SAME path on both sides, so the
+# absolute `gitdir:` a worktree records resolves in either venue.
+DEPLOY_CHECKOUT_PLACEHOLDER = (
+    "${TEATREE_DEPLOY_CHECKOUT:-/home/teatree/teatree-deploy}"  # privacy-scan:allow — public deploy home
+)
 # The mounts that stay Docker-managed named volumes by default.
 #: ``teatree_control_db`` holds the control database itself — a named volume so the
 #: file has no host path for a host process to open (teatree.db.write_domain).
 #: ``teatree_clones`` is the container's own CLONE root. Deliberately NOT a bind of
 #: the host's ``~/workspace``: a git worktree records an absolute ``gitdir`` pointer
-#: into its source clone, so checkouts cannot be shared across the boundary at all
-#: — each side must own its clones. A volume rather than the image layer so the
-#: clones survive container recreation.
+#: into its source clone, so a clone is shareable only where both venues name it
+#: identically — which the host home variable cannot guarantee for a whole root.
+#: Sharing is done per-clone instead, by a discovery symlink into the deploy
+#: checkout bound at path identity (#4120). A volume rather than the image layer so
+#: the clones survive container recreation.
 CLONE_ROOT_VOLUME = "teatree_clones"
 CLONE_ROOT_TARGET = f"{CONTAINER_HOME}/workspace"
 KEPT_NAMED_VOLUMES = {DEFAULT_SOURCE_VOLUME, "teatree_uv", "teatree_control_db", CLONE_ROOT_VOLUME}
@@ -162,17 +171,28 @@ class TestExternalizedBindMounts:
 
     def test_state_dirs_are_bind_mounts_at_canonical_container_targets(self) -> None:
         binds = self._bind_mounts()
-        assert set(binds) == ALL_BIND_TARGETS, "every state + credential dir must be a host bind mount"
+        assert set(binds) == ALL_BIND_TARGETS | {DEPLOY_CHECKOUT_PLACEHOLDER}, (
+            "every state + credential dir must be a host bind mount, plus the deploy checkout"
+        )
 
-    def test_every_bind_source_is_the_target_rebased_on_the_host_home(self) -> None:
+    def test_every_state_bind_source_is_the_target_rebased_on_the_host_home(self) -> None:
         # The target is fixed (it is what `teatree.paths` resolves inside the
         # container); only the host-side root varies, through ONE variable whose
         # default keeps source == target on the box.
-        for target, entry in self._bind_mounts().items():
+        binds = self._bind_mounts()
+        for target in ALL_BIND_TARGETS:
             suffix = target.removeprefix(CONTAINER_HOME)
-            assert entry["source"] == f"{HOST_HOME_PLACEHOLDER}{suffix}", (
+            assert binds[target]["source"] == f"{HOST_HOME_PLACEHOLDER}{suffix}", (
                 f"{target}: source must be the target rebased on {HOST_HOME_PLACEHOLDER}"
             )
+
+    def test_the_deploy_checkout_is_bound_at_path_identity_and_writable(self) -> None:
+        # `git worktree add` bakes an ABSOLUTE `gitdir:` into its source clone, so
+        # only source == target makes the recorded pointer resolve in both venues;
+        # writable because that same add writes `.git/worktrees/<n>` into the clone.
+        entry = self._bind_mounts()[DEPLOY_CHECKOUT_PLACEHOLDER]
+        assert entry["source"] == DEPLOY_CHECKOUT_PLACEHOLDER == entry["target"]
+        assert not entry.get("read_only", False)
 
     def test_credential_plane_is_a_dedicated_bind_mount(self) -> None:
         # The pass store + GPG home must be their own mounts (not nested under the
@@ -249,11 +269,12 @@ class TestDockerComposeConfigGolden:
 class TestContainerOwnedCloneRoot:
     """The clone root is the container's own volume, with the worktree bind inside it.
 
-    Checkouts cannot be shared across the container boundary — a git worktree
-    records an absolute ``gitdir`` into its source clone, so a host-made worktree
-    reads as ``fatal: not a git repository: /Users/...`` inside and vice versa.
-    The container therefore owns its clones and cuts worktrees from them, while
-    the worktrees themselves stay host-visible for reading and editing.
+    A git worktree records an absolute ``gitdir`` into its source clone, so a clone
+    is usable on both sides only where the two venues name it identically; bound at
+    a DIFFERENT path it reads as ``fatal: not a git repository``. The
+    root therefore stays container-owned, and the one clone worktrees are cut from
+    is shared per-clone through the path-identity checkout mount (#4120), while the
+    worktrees themselves stay host-visible for reading and editing.
     """
 
     def test_clone_root_is_a_named_volume_at_the_canonical_workspace_path(self, tmp_path: Path) -> None:
@@ -262,8 +283,9 @@ class TestContainerOwnedCloneRoot:
         assert mount["source"] == CLONE_ROOT_VOLUME
 
     def test_clone_root_is_never_a_host_bind(self, tmp_path: Path) -> None:
-        # Binding the operator's ~/workspace is the fix that does NOT work: it
-        # would still leave every gitdir pointer naming the wrong side.
+        # Binding the operator's ~/workspace is the fix that does NOT work: off-box
+        # the host root differs from the container's, so every gitdir pointer would
+        # still name a path the other side cannot resolve.
         for env in ({}, {"TEATREE_HOST_HOME": "/home/operator"}):
             assert _rendered_mounts(_render(tmp_path, env))[CLONE_ROOT_TARGET]["type"] == "volume"
 

--- a/tests/test_deploy_clone_venue_portability.py
+++ b/tests/test_deploy_clone_venue_portability.py
@@ -1,0 +1,244 @@
+# test-path: cross-cutting — drives deploy/entrypoint.sh + docker-compose.yml (no src mirror).
+"""The clone worktrees are cut from must resolve at ONE path in every venue.
+
+``git worktree add`` bakes an ABSOLUTE ``gitdir:`` pointer into its source clone,
+so the clone's path — not the worktree's — decides who can use the result. The
+container cut worktrees from the ``teatree_src`` volume at ``$TEATREE_CLONE_DIR``,
+a path that exists in no other venue, so every worktree the containerised
+``workspace ticket`` handed back answered ``fatal: not a git repository`` from the
+host where an agent's file tools run (#4120). The worktree tree itself was already
+bind-mounted at path identity, which is why the files looked fine and only git failed.
+
+The deploy checkout is ALREADY bind-mounted at path identity for the watchdog
+(source == target, one variable read by both sides). These tests pin the fix: that
+mount joins the shared set read-write, and the entrypoint points the org-prefixed
+discovery link at it, so the pointer git records names a directory both venues resolve.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash (present in the deploy image and CI)")
+
+_DEPLOY = Path(__file__).resolve().parents[1] / "deploy"
+_COMPOSE = _DEPLOY / "docker-compose.yml"
+_ENTRYPOINT = _DEPLOY / "entrypoint.sh"
+
+_BASH = shutil.which("bash") or "/bin/bash"
+_GIT = shutil.which("git") or "/usr/bin/git"
+
+#: Both mount sides and the forwarded env read this ONE placeholder, so path
+#: identity holds by construction rather than only at the box's default path.
+_CHECKOUT_PLACEHOLDER = (
+    "${TEATREE_DEPLOY_CHECKOUT:-/home/teatree/teatree-deploy}"  # privacy-scan:allow — public deploy home
+)
+
+#: The roles that provision worktrees (worker) or prepare the shared state it reads
+#: (init). Both need the checkout's path in their environment for the retarget.
+_RETARGETING_SERVICES = ("teatree-init", "teatree-worker")
+
+_DISCOVERY_LINK = (
+    "/home/teatree/workspace/souliane/teatree"  # privacy-scan:allow — the box's public, documented deploy home
+)
+
+
+def _compose() -> dict:
+    # SafeLoader resolves `&teatree-common` and the `<<` merge keys, so each
+    # service's list is what that role actually runs with.
+    return yaml.safe_load(_COMPOSE.read_text(encoding="utf-8"))
+
+
+def _volumes(service: str) -> list:
+    return _compose()["services"][service]["volumes"]
+
+
+def _extract_shell_function(name: str) -> str:
+    """Return the verbatim source of shell function *name* from the entrypoint."""
+    body: list[str] = []
+    capturing = False
+    for line in _ENTRYPOINT.read_text(encoding="utf-8").splitlines():
+        if line.startswith(f"{name}() {{"):
+            capturing = True
+        if capturing:
+            body.append(line)
+            if line == "}":
+                return "\n".join(body)
+    not_found = f"function {name!r} not found in {_ENTRYPOINT}"
+    raise AssertionError(not_found)
+
+
+def _run_retarget(tmp_path: Path, link: Path, checkout: str) -> subprocess.CompletedProcess[str]:
+    """Run the REAL ``retarget_clone_discovery`` against *link* in a bash subprocess."""
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        f'set -euo pipefail\n{_extract_shell_function("retarget_clone_discovery")}\nretarget_clone_discovery "$1"\n',
+        encoding="utf-8",
+    )
+    env = {**os.environ, "TEATREE_DEPLOY_CHECKOUT": checkout}
+    return subprocess.run([_BASH, str(harness), str(link)], capture_output=True, text=True, check=True, env=env)
+
+
+def _make_clone(path: Path) -> Path:
+    path.mkdir(parents=True)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+    }
+    subprocess.run([_GIT, "init", "-b", "main", str(path)], check=True, capture_output=True, env=env)
+    (path / "README.md").write_text("x\n", encoding="utf-8")
+    subprocess.run([_GIT, "-C", str(path), "add", "-A"], check=True, capture_output=True, env=env)
+    subprocess.run([_GIT, "-C", str(path), "commit", "-m", "init"], check=True, capture_output=True, env=env)
+    return path
+
+
+class TestSharedCheckoutMount:
+    """The deploy checkout is mounted at path identity for the roles that provision."""
+
+    def test_app_services_mount_the_checkout_at_path_identity(self) -> None:
+        for service in _RETARGETING_SERVICES:
+            binds = [v for v in _volumes(service) if isinstance(v, dict) and v.get("type") == "bind"]
+            identity = [v for v in binds if v["source"] == _CHECKOUT_PLACEHOLDER]
+            assert identity, f"{service} must bind the deploy checkout so the recorded gitdir resolves off-box"
+            assert identity[0]["target"] == _CHECKOUT_PLACEHOLDER, (
+                f"{service}'s checkout mount must be at PATH IDENTITY (source == target) — "
+                "a different target is exactly the #4120 split"
+            )
+
+    def test_the_provisioning_mount_is_writable(self) -> None:
+        # `git worktree add` writes `.git/worktrees/<n>` into the clone, so the
+        # watchdog's read-only spelling of this same mount cannot serve provisioning.
+        binds = [v for v in _volumes("teatree-worker") if isinstance(v, dict) and v.get("type") == "bind"]
+        checkout = next(v for v in binds if v["source"] == _CHECKOUT_PLACEHOLDER)
+        assert not checkout.get("read_only", False)
+
+    def test_the_watchdogs_own_checkout_mount_stays_read_only(self) -> None:
+        # Behaviour preservation: the supervisor only READS deploy/watchdog.sh.
+        binds = [v for v in _volumes("teatree-watchdog") if isinstance(v, dict) and v.get("type") == "bind"]
+        checkout = next(v for v in binds if v["source"] == _CHECKOUT_PLACEHOLDER)
+        assert checkout.get("read_only") is True
+
+    def test_retargeting_services_receive_the_checkout_path(self) -> None:
+        services = _compose()["services"]
+        for service in _RETARGETING_SERVICES:
+            assert services[service]["environment"]["TEATREE_DEPLOY_CHECKOUT"] == _CHECKOUT_PLACEHOLDER
+
+
+class TestRetargetCloneDiscovery:
+    def test_points_the_discovery_link_at_the_mounted_checkout(self, tmp_path: Path) -> None:
+        clone = _make_clone(tmp_path / "teatree-deploy")
+        link = tmp_path / "workspace" / "souliane" / "teatree"
+
+        _run_retarget(tmp_path, link, str(clone))
+
+        assert link.is_symlink()
+        assert link.resolve() == clone.resolve()
+
+    def test_replaces_the_images_container_only_link(self, tmp_path: Path) -> None:
+        # The image bakes the link at the `teatree_src` volume. That
+        # link is the #4120 defect, so the retarget must overwrite it, not skip it.
+        clone = _make_clone(tmp_path / "teatree-deploy")
+        container_only = _make_clone(tmp_path / "container-src")
+        link = tmp_path / "workspace" / "souliane" / "teatree"
+        link.parent.mkdir(parents=True)
+        link.symlink_to(container_only)
+
+        _run_retarget(tmp_path, link, str(clone))
+
+        assert link.resolve() == clone.resolve()
+
+    def test_leaves_the_link_alone_when_no_checkout_is_mounted(self, tmp_path: Path) -> None:
+        # A bare `docker compose up` with nothing exported: dockerd creates an empty
+        # host dir at the default path. Degrading to the image's link keeps the
+        # container working exactly as it did before, rather than breaking discovery.
+        empty = tmp_path / "not-a-checkout"
+        empty.mkdir()
+        container_only = _make_clone(tmp_path / "container-src")
+        link = tmp_path / "workspace" / "souliane" / "teatree"
+        link.parent.mkdir(parents=True)
+        link.symlink_to(container_only)
+
+        result = _run_retarget(tmp_path, link, str(empty))
+
+        assert link.resolve() == container_only.resolve()
+        assert "4120" in result.stderr
+
+    def test_unset_checkout_leaves_the_link_alone(self, tmp_path: Path) -> None:
+        container_only = _make_clone(tmp_path / "container-src")
+        link = tmp_path / "workspace" / "souliane" / "teatree"
+        link.parent.mkdir(parents=True)
+        link.symlink_to(container_only)
+
+        _run_retarget(tmp_path, link, "")
+
+        assert link.resolve() == container_only.resolve()
+
+    def test_never_replaces_a_real_clone_at_the_link_path(self, tmp_path: Path) -> None:
+        # An operator (or `ensure_clone`) may have put a REAL clone there. Replacing
+        # a directory with a symlink would strand whatever it holds.
+        clone = _make_clone(tmp_path / "teatree-deploy")
+        real = _make_clone(tmp_path / "workspace" / "souliane" / "teatree")
+
+        result = _run_retarget(tmp_path, real, str(clone))
+
+        assert not real.is_symlink()
+        assert (real / ".git").is_dir()
+        assert "4120" in result.stderr
+
+    def test_is_idempotent(self, tmp_path: Path) -> None:
+        clone = _make_clone(tmp_path / "teatree-deploy")
+        link = tmp_path / "workspace" / "souliane" / "teatree"
+
+        _run_retarget(tmp_path, link, str(clone))
+        _run_retarget(tmp_path, link, str(clone))
+
+        assert link.resolve() == clone.resolve()
+
+    def test_the_entrypoint_actually_calls_it(self) -> None:
+        # A defined-but-uncalled function is the failure this whole file exists to
+        # prevent, and every assertion above passes without the call site.
+        text = _ENTRYPOINT.read_text(encoding="utf-8")
+        assert "\nretarget_clone_discovery\n" in text
+
+    def test_the_production_default_is_the_org_prefixed_discovery_link(self) -> None:
+        # `find_clone_path(clone_root, "souliane/teatree")` matches the slug's
+        # LITERAL path; a bare `workspace/teatree` link is invisible to it.
+        assert _DISCOVERY_LINK in _extract_shell_function("retarget_clone_discovery")
+
+
+class TestRecordedGitdirNamesTheCloneItResolvesTo:
+    """The mechanism the fix rests on, asserted rather than assumed."""
+
+    def test_worktree_records_the_symlink_target_not_the_link(self, tmp_path: Path) -> None:
+        # git resolves the clone path before recording it, so the SYMLINK TARGET is
+        # what lands in the worktree's `.git` — which is why the target, not the
+        # link, is the path that has to exist in both venues.
+        clone = _make_clone(tmp_path / "real-clone")
+        link = tmp_path / "souliane" / "teatree"
+        link.parent.mkdir(parents=True)
+        link.symlink_to(clone)
+        worktree = tmp_path / "wt"
+
+        subprocess.run(
+            [_GIT, "-C", str(link), "worktree", "add", "-b", "topic", str(worktree)],
+            check=True,
+            capture_output=True,
+        )
+
+        recorded = (worktree / ".git").read_text(encoding="utf-8").strip()
+        assert recorded.startswith("gitdir: ")
+        assert recorded.removeprefix("gitdir: ").startswith(str(clone.resolve()))
+        assert not recorded.removeprefix("gitdir: ").startswith(str(link))
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_deploy_freshbox_bootstrap.py
+++ b/tests/test_deploy_freshbox_bootstrap.py
@@ -33,6 +33,9 @@ _HOME = "/home/teatree"  # privacy-scan:allow — the box's public, documented d
 # The host-side root every compose bind SOURCE is written against. Both scripts
 # that create those dirs set it from `$HOME`, which on the box IS `_HOME`.
 _HOST_HOME_PLACEHOLDER = "${TEATREE_HOST_HOME:-" + _HOME + "}"
+# The deploy checkout mount's source — the checkout each script runs out of, not a
+# dir either creates (#4120).
+_DEPLOY_CHECKOUT_PLACEHOLDER = "${TEATREE_DEPLOY_CHECKOUT:-" + _HOME + "/teatree-deploy}"
 
 
 def _bind_sources() -> set[str]:
@@ -41,6 +44,11 @@ def _bind_sources() -> set[str]:
     Sources are written as ``${TEATREE_HOST_HOME:-/home/teatree}/<suffix>``; the
     placeholder resolves to the box's deploy home so the paths compare directly
     against the ``$HOME``-rooted dirs the scripts pre-create.
+
+    The deploy checkout is excluded: it is not a state dir either script creates
+    but the directory each is EXECUTING FROM, so it exists by construction and no
+    fresh box can meet dockerd's auto-create-as-root hazard on it. What pins that
+    is :class:`TestDeployCheckoutSourceIsTheCheckoutTheScriptsRunFrom` below.
     """
     compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
     volumes = compose["x-teatree-common"]["volumes"]
@@ -48,7 +56,7 @@ def _bind_sources() -> set[str]:
         entry["source"].replace(_HOST_HOME_PLACEHOLDER, _HOME, 1)
         for entry in volumes
         if isinstance(entry, dict) and entry.get("type") == "bind"
-    }
+    } - {_DEPLOY_CHECKOUT_PLACEHOLDER}
 
 
 def _created_dirs(script: str, command: str, var: str) -> set[str]:
@@ -144,6 +152,34 @@ class TestCliWrapperPreCreatesEveryBindSource:
             assert expanding, f"{name} must be passed to install -d"
             for line in expanding:
                 assert "-m 700" in line, "credential-plane dirs must be created mode 700"
+
+
+class TestDeployCheckoutSourceIsTheCheckoutTheScriptsRunFrom:
+    """What replaces the pre-create rule for the one bind source nobody creates.
+
+    The pre-create invariant exists because dockerd auto-creates an absent bind
+    source ROOT-owned. The deploy checkout can never be absent: both entry points
+    derive it from their own ``$REPO_ROOT``, the directory holding the script
+    being executed. Pinning that derivation is what keeps the exclusion in
+    :func:`_bind_sources` honest rather than a hole (#4120).
+    """
+
+    def test_deploy_sh_exports_it_from_its_own_repo_root(self) -> None:
+        assert 'export TEATREE_DEPLOY_CHECKOUT="$REPO_ROOT"' in DEPLOY_SH.read_text(encoding="utf-8")
+
+    def test_cli_wrapper_exports_it_from_its_own_repo_root(self) -> None:
+        assert 'export TEATREE_DEPLOY_CHECKOUT="${TEATREE_DEPLOY_CHECKOUT:-$REPO_ROOT}"' in CLI_WRAPPER.read_text(
+            encoding="utf-8"
+        )
+
+    def test_the_compose_source_reads_that_same_variable(self) -> None:
+        compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+        sources = {
+            entry["source"]
+            for entry in compose["x-teatree-common"]["volumes"]
+            if isinstance(entry, dict) and entry.get("type") == "bind"
+        }
+        assert _DEPLOY_CHECKOUT_PLACEHOLDER in sources
 
 
 class TestHostDerivedRuntimeUid:


### PR DESCRIPTION
fix(deploy): cut worktrees from a clone every venue can name (#4120)

## What
`git worktree add` bakes an ABSOLUTE `gitdir:` pointer into its SOURCE CLONE, so
the clone's path — not the worktree's — decides who can use the result. The image
links the org-prefixed discovery path at the `teatree_src` volume, a path that
exists in no other venue. A worktree the containerised `workspace ticket` handed
back therefore answered `fatal: not a git repository` from the host, while its
files stayed readable through the `t3-workspaces` bind — so the failure named the
admin dir, not the cause, and an agent whose file tools run host-side had to route
every git command back through `docker exec -w`.

- compose: the deploy checkout joins the SHARED volume anchor as a read-write
  bind at PATH IDENTITY (source == target == the one `TEATREE_DEPLOY_CHECKOUT`
  placeholder the watchdog's read-only mount already reads); `teatree-init` and
  `teatree-worker` carry the value in their environment.
- entrypoint: `retarget_clone_discovery` points the discovery link at that
  checkout when it is a git checkout, degrades to the image link when it is not,
  and never replaces a real directory at the link path.
- Dockerfile: the baked link stays, now documented as the fallback.
- docs: deploy/README.md's variable table and `clone_provision`'s module
  docstring no longer describe the container's clones as unshareable — a bind at
  path identity is exactly what makes one shareable.

Read-write because `worktree add` writes `.git/worktrees/<n>` into the clone; the
watchdog keeps its own read-only spelling, pinned by a test. The container's UID
is the host deploy user's, so those writes land with the ownership the host
expects.

Why not the issue's literal option 1 (swap the `teatree_src` volume for a host
bind): 49 live worktrees record gitdirs into that volume and `doctor` reports 21
checkouts holding unshipped work — replacing it orphans them. Option 2 (rewrite
the recorded pointer) cannot work at all: the admin dir lives inside the
container-only volume, unreadable from the host at any spelling. Option 3 (refuse)
would stop the only sanctioned `t3` venue on this box. This shape is additive:
`teatree_src` stays mounted, so the existing worktrees keep resolving.

Four existing deploy invariants enumerate the anchor's binds as one homogeneous
set, so the new mount — legitimately a different KIND — turned them red. Each is
repaired by splitting the set, never by loosening the assertion:

- the state-dir test still asserts EXACT equality, now over the state planes plus
  the checkout, so a fifth mount still cannot slip in unnoticed;
- the rebased-on-host-home rule iterates the state planes only, and the checkout
  gets its own STRONGER rule — source == target == the one placeholder, writable;
- the fresh-box pre-create rule excludes the checkout, because dockerd's
  auto-create-as-root hazard cannot reach a directory that exists by construction:
  it is the checkout each entry point is EXECUTING FROM. Replacing that coverage
  is a positive pin that both scripts derive `TEATREE_DEPLOY_CHECKOUT` from their
  own `$REPO_ROOT`, so the exclusion is an argument rather than a hole.

Tests: `tests/test_deploy_clone_venue_portability.py` — compose invariants (path
identity, writable, watchdog still read-only, env forwarded), the real shell
function run in bash across six cases, and a git control proving the recorded
`gitdir:` names the symlink TARGET, which is why the target is what must be
mounted. Observed RED first (11 failed, 2 passed — the 2 pin unchanged behaviour).
Anti-vacuity control on the repaired invariants: retargeting the checkout mount
off path identity turns the path-identity test and the exact-set test RED
(2 failed, 14 passed); restored, 44 pass across the three deploy files.

Open questions & assumptions
- assumed: sharing the deploy checkout as the worktree source clone is
  acceptable. `deploy.sh` fetches/pulls there and the worker will now also
  `worktree add` and fetch into it; git's own locking covers the overlap, and the
  host already cuts worktrees from this clone (28 of them today).
- assumed: read-write on the shared mount is wanted. The alternative — a second,
  dedicated clone under a new host bind — costs disk and a first-boot clone but
  leaves the deploy checkout untouched. Say the word and it is a small change.
- assumed: excluding the checkout from the pre-create rule is correct rather than
  adding an `install -d` for it. The source is the script's own `$REPO_ROOT`, so
  creating it is a no-op, and the watchdog already binds this same source today —
  a `TEATREE_DEPLOY_CHECKOUT` naming a nonexistent path already fails the deploy,
  so the anchor mount adds no new fresh-box failure mode.
- assumed: the state-plane rule should not be widened to "source == target OR
  rebased on host home". A disjunction would let a future state mount silently
  drop off the host-home knob; two rules, each exact, keep both properties.
- open: this closes container -> host only. A worktree cut on the HOST from the
  same checkout is now also resolvable inside the container, but nothing yet
  repoints the host's own discovery link, so host-cut worktrees keep whatever
  spelling they have.
- open: the issue's acceptance test (`git -C <path> rev-parse --show-toplevel`
  from the HOST) cannot be observed from inside the worker container where this
  was built. Proof here is the deterministic deploy-invariant lane plus a
  rendered `docker compose config` showing init/worker at path identity and the
  watchdog still read-only; the end-to-end assertion needs a redeploy.
- open: 15 other tests are red in this venue for environmental reasons (a live
  `GH_TOKEN` in the worker container defeats the no-token cases, the live control
  DB defeats the host-projection case, and `cli_doctor` runs the real `t3 doctor
  check` against a box carrying WARNs). None is reachable from this branch — its
  only `src/` change is module-docstring prose — so they are read as pre-existing,
  not verified against a clean checkout of main.
- decided-by-user: option 1 ("mount the main clone at the same path on both
  sides") was marked Preferred in the issue; this is that, in the shape the
  existing wiring allows.

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.