### PR TITLE
fix(quality): catch signal-for-core-flow's connect() registration form

### DIFF
--- a/docs/generated/antipattern-catalog.md
+++ b/docs/generated/antipattern-catalog.md
@@ -248,7 +248,7 @@ holistic (`ac-reviewing-codebase`).
 - **id:** `signal-for-core-flow`
 - **severity:** medium
 - **detection:** greppable
-- **grep hint:** `@receiver\(\s*post_save|@receiver\(\s*pre_save`
+- **grep hint:** `@receiver\(\s*post_save|@receiver\(\s*pre_save|post_save\.connect\(|pre_save\.connect\(`
 - **linter:** _(none — gap)_
 - **consumers:** architecture-design, ac-reviewing-codebase, linter
 - **refs:** ac-django-antipatterns-22

--- a/src/teatree/quality/antipatterns.yaml
+++ b/src/teatree/quality/antipatterns.yaml
@@ -263,7 +263,7 @@
   preferred_pattern: >-
     Call domain behaviour explicitly from a model method; reserve signals for
     integrating third-party app events.
-  grep_hint: '@receiver\(\s*post_save|@receiver\(\s*pre_save'
+  grep_hint: '@receiver\(\s*post_save|@receiver\(\s*pre_save|post_save\.connect\(|pre_save\.connect\('
   consumers: [architecture-design, ac-reviewing-codebase, linter]
   refs: ["ac-django-antipatterns-22"]
   linter: null

--- a/tests/quality/test_catalog.py
+++ b/tests/quality/test_catalog.py
@@ -66,6 +66,18 @@ class TestSchemaInvariants:
             if entry.grep_hint is not None:
                 re.compile(entry.grep_hint)
 
+    def test_signal_for_core_flow_hint_matches_connect_style_registration(
+        self, catalog: tuple[AntiPatternEntry, ...]
+    ) -> None:
+        by_id = {e.id: e for e in catalog}
+        grep_hint = by_id["signal-for-core-flow"].grep_hint
+        assert grep_hint is not None
+        pattern = re.compile(grep_hint)
+        assert pattern.search("post_save.connect(_auto_enqueue_headless_task, sender=Task)")
+        assert pattern.search("pre_save.connect(_stamp_something, sender=Ticket)")
+        assert pattern.search("@receiver(post_save, sender=Task)")
+        assert not pattern.search("post_delete.connect(_cleanup_orphans, sender=Task)")
+
 
 class TestReachabilityLedger:
     def test_named_linter_resolves_to_a_real_hook_or_tool(self, catalog: tuple[AntiPatternEntry, ...]) -> None:


### PR DESCRIPTION
## What

The `signal-for-core-flow` catalog entry's grep hint only matched the
`@receiver(post_save/pre_save)` decorator idiom, so a receiver registered
via Django's imperative `signal.connect(handler, ...)` form was invisible
to the per-PR mechanized check (`scripts/hooks/check_antipatterns.py`).

`src/teatree/core/signals.py` registers three `post_save` receivers this
way (`post_save.connect(...)`), including `_auto_enqueue_headless_task` —
core task-dispatch/admission logic living in a signal receiver rather than
an explicit model-method call site. That module's own docstring documents
a prior production incident traceable to this exact re-entrancy shape
(47,172 park rows on a single task in eight hours, since fixed). The
pattern is exactly what this catalog entry exists to catch, and it was a
detection blind spot.

Fix: widen the `grep_hint` regex to also match `post_save\.connect\(` /
`pre_save\.connect\(`, regenerate the derived catalog doc, and add a test
(`test_signal_for_core_flow_hint_matches_connect_style_registration`)
proving the hint now fires on both registration styles and stays silent
on an unrelated signal (`post_delete`).

This is one finding from a periodic holistic architectural review
(`architectural-review://t3-teatree`, dispatched by `ArchitecturalReviewScanner`).
The review also surfaced two units of work that need an owner decision
before they can be implemented — proposed as tickets, NOT filed yet
(issue creation needs explicit approval per `AGENTS.md` § "Issue Creation"):

1. **`core/signals.py`'s `_auto_enqueue_headless_task` (and its two sibling
   `post_save` receivers) implement core task-dispatch logic inside a signal
   receiver instead of an explicit model-method call site.** This is the
   primary work-dispatch chokepoint for the whole factory — every `Task`
   creation call site relies on the uniform auto-enqueue behavior the signal
   gives for free, and moving it to an explicit call would mean auditing and
   updating every creator, with real risk of silently breaking dispatch if one
   is missed. Two defensible designs (keep the uniform signal-based dispatch
   vs. an explicit call + a lint that enforces every creator calls it) — an
   architectural call for the owner, not decidable unilaterally in a review pass.
2. **`src/teatree/config/`'s six `cold_*` modules** (`cold_db`, `cold_defaults`,
   `cold_hook_settings`, `cold_mode`, `cold_reader`, `cold_writer`) are a
   cohesive "Django-free cold path" concern (each explicitly layers on the
   others per their own docstrings) that has grown past flat-file scale —
   matching the `file-outside-its-package` catalog entry's subpackage clause.
   Not implemented here: `cold_reader` alone has 67+ call sites, including
   bash/hook scripts that import by exact dotted path and BLUEPRINT.md prose
   citing the exact module names as part of the multi-PR "config-unify"
   narrative. The right target shape (one subpackage vs. a different regroup,
   naming) is a design call, not a mechanical move.

## Why

Closes a real gap in the mechanized catalog check rather than duplicating
judgement-tier review effort on every future PR that touches this pattern —
per BLUEPRINT § 17.1 invariant 2/6, the flywheel's output should be the
smallest enforcement artifact, not a rule someone has to remember to apply
by eye.

## Testing

- `uv run pytest tests/quality/test_catalog.py -q` — 23 passed (new test
  observed RED against the unwidened hint before the fix, GREEN after).
- `bash dev/test-affected.sh` escalated to the whole suite (editing a YAML
  data file under `src/` is unclassifiable to the tach-based selector) —
  40723 passed, 69 skipped, 5 xfailed, 13 failed. All 13 failures reproduce
  identically against unmodified `main` (verified directly) — network/`gh
  api`-dependent tests and `cli_doctor` checks reading live host state, none
  touching the 3 files this PR changes. No new failures.
- `t3 tool verify-gates` — all gate stages green (commit + push).

## Open questions & assumptions

- open: whether the two proposed tickets above should be filed — awaiting
  owner review/approval per `AGENTS.md` § "Issue Creation" (never create
  issues without explicit approval).
- assumed: this PR itself still needs an independent cold review before
  merge (this review pass is the PR's author, per `ac-reviewing-codebase`
  skill § "Maker≠checker holds at the merge gate, not at the keyboard") —
  not self-mergeable.
