### PR TITLE
fix(dream): a deferred compliance escalation must not stamp remediation=escalation (#4176)

### DIFF
--- a/src/teatree/loops/dream/compliance.py
+++ b/src/teatree/loops/dream/compliance.py
@@ -130,15 +130,18 @@ class EscalationOutcome:
     """The result of driving one recurring rule onto the standing umbrella issue.
 
     ``filed`` is True when a new umbrella checkbox was added OR a coding task was
-    scheduled (the ``promote_gap`` outcome); ``ticket_url`` is the umbrella issue URL;
-    ``withheld`` is True when the rendered body would leak a banned term / bare
-    reference.
+    scheduled (the ``promote_gap`` outcome); ``ticket_url`` is the umbrella issue URL
+    (set ONLY when ``filed`` is True — a withheld or deferred gap carries no URL, so
+    the audit row is never stamped for work that was not actually done); ``withheld``
+    is True when the rendered body would leak a banned term / bare reference;
+    ``deferred`` is True when the pass's promotion cap was already spent (#4176).
     """
 
     rule_identity: str
     filed: bool
     ticket_url: str = ""
     withheld: bool = False
+    deferred: bool = False
     reason: str = ""
 
 
@@ -409,11 +412,17 @@ def escalate_recurrences(
 def stamp_escalations(
     snapshot: InstructionComplianceSnapshot | None, outcomes: Sequence[EscalationOutcome], *, dry_run: bool
 ) -> None:
-    """Stamp each escalated recurrence's audit row with the umbrella it now rides."""
+    """Stamp each escalated recurrence's audit row with the umbrella it now rides.
+
+    Only a ``filed`` outcome stamps — a deferred (cap-exhausted) or withheld
+    (banned-term/bare-reference) outcome wrote nothing to the umbrella, so its audit
+    row must stay ``RemediationKind.NONE`` rather than falsely reading as escalated
+    (#4176).
+    """
     if dry_run or snapshot is None:
         return
     for outcome in outcomes:
-        if outcome.ticket_url:
+        if outcome.filed and outcome.ticket_url:
             _stamp_escalated(snapshot, outcome.rule_identity, outcome.ticket_url)
 
 
@@ -547,6 +556,8 @@ def _escalate_one_recurrence(
     )
     if outcome.withheld:
         return EscalationOutcome(rule_identity=finding.rule_identity, filed=False, withheld=True, reason=outcome.reason)
+    if outcome.deferred:
+        return EscalationOutcome(rule_identity=finding.rule_identity, filed=False, deferred=True, reason=outcome.reason)
     return EscalationOutcome(
         rule_identity=finding.rule_identity,
         filed=outcome.scheduled or outcome.checkbox_added or dry_run,

--- a/tests/teatree_loops/dream/test_compliance.py
+++ b/tests/teatree_loops/dream/test_compliance.py
@@ -24,6 +24,7 @@ from teatree.loops.dream.compliance import (
     run_compliance_escalation,
     run_compliance_measurement,
 )
+from teatree.loops.dream.pass_config import PromotionBudget
 from teatree.loops.dream.replay import ConsolidationExtract, WeightedSnippet
 
 
@@ -240,6 +241,25 @@ class PersistCompliancePassTestCase(TestCase):
         assert row.remediation == RemediationKind.ESCALATION
         # The escalation is now the standing umbrella (the recurrence rides it + a coding task).
         assert row.escalation_url == UMBRELLA
+
+    def test_a_deferred_recurrence_is_not_stamped_escalated(self) -> None:
+        # #4176 review finding: an exhausted budget must defer the gap AND leave the
+        # audit row alone — nothing was written to the umbrella, so the row must not
+        # read as escalated.
+        host = _fake_host()
+        finding = ComplianceFinding(
+            rule_source=RuleSource.MEMORY,
+            rule_identity="feedback_a",
+            evidence="violated a",
+            is_recurrence=True,
+        )
+        snapshot = persist_compliance_pass([finding], instructions_observed=4)
+        budget = PromotionBudget(remaining=0)
+        run_compliance_escalation(snapshot=snapshot, findings=[finding], host=host, dry_run=False, budget=budget)
+        row = InstructionComplianceRecord.objects.get(snapshot=snapshot, rule_identity="feedback_a")
+        assert row.remediation == RemediationKind.NONE
+        assert row.escalation_url == ""
+        assert not host.update_issue.called
 
 
 class RunComplianceMeasurementTestCase(TestCase):


### PR DESCRIPTION
fix(dream): a deferred compliance escalation must not stamp remediation=escalation (#4176)

Review of PR #4313 found that `_escalate_one_recurrence` handled
`outcome.withheld` but not `outcome.deferred` (the per-pass promotion cap
exhausted), so a cap-deferred recurrence still returned `ticket_url=umbrella_url`.
`stamp_escalations` keyed on `ticket_url` truthiness rather than `outcome.filed`,
so a recurrence for which nothing was written to the umbrella and no coding task
was scheduled was stamped `remediation=ESCALATION` anyway. `t3 dream compliance
show` would report an open escalation with no checkbox and no fix behind it, and
the record is per-snapshot so no later pass corrects it.

Fixed by adding `EscalationOutcome.deferred` (mirroring the existing `withheld`
field) and gating `stamp_escalations` on `outcome.filed` instead of the URL.
Does not touch gate (g) — `compliance_non_regression` only fails on MEMORY
remediation, unaffected here.

Open questions & assumptions:
- (decided) Scoped this fix to the compliance-escalation path only, the one the
  review proved is actually consumed via `.ticket_url`. The sibling promoting
  phases (promote_memory._promote_one_gap, automation_ask.promote_ask_findings)
  carry the identical unconditional-ticket_url shape on their deferred/withheld
  paths, but every current consumer of their outcomes reads `.filed`, not
  `.ticket_url` — so hardening them is deferred rather than bundled into this fix.

## What

## Why