### PR TITLE
fix(config): a store present but unread is unknown, never a confident "off" (#4205)

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -87,14 +87,18 @@ fi
 # Echoes the decoded value — empty when the key is simply unset — and returns:
 #   0  the projection ANSWERED (a value, or a readable projection with no such key)
 #   1  there is no projection on this host to answer with
-#   2  a projection is present but could not be parsed
+#   2  a projection is present but could not be read or parsed
 # The 1/2 split is the whole point: "no store here" is a plain-clone host that has
 # genuinely opted into nothing, while "a store is here and I cannot read it" is an
 # unknown that must never be rendered as a stored value.
 _projection_setting() {
     command -v jq >/dev/null 2>&1 || return 1
     local proj="${TEATREE_HOST_PROJECTION:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/host-projection.json}"
-    [ -r "$proj" ] || return 1
+    if [ ! -r "$proj" ]; then
+        # Present yet denied is the unreadable half of the 1/2 split, not an absence (#4205).
+        [ -e "$proj" ] && return 2
+        return 1
+    fi
     # `settings` is keyed by SCOPE; "" is global. Values are stored decoded, so a
     # bool arrives as `true`/`false` — the same text the sqlite read yields.
     local out
@@ -118,7 +122,10 @@ _projection_setting() {
 # them is what rendered a confident "off" for a setting the DB actually holds as
 # true (#4041). The DB is tested with `-s`, not `-f`: the control-DB migration left
 # a 0-byte stub at the old host path, and a stub that holds nothing is a store this
-# host cannot see — exactly the case the projection exists to answer.
+# host cannot see — exactly the case the projection exists to answer. Presence is
+# then re-tested with `-e` at the end (#4205): the stub, and a non-empty DB on a
+# host with no sqlite3, both reach the projection, and when THAT cannot answer
+# either, a store is here that nothing read — the same unknown, not a fresh clone.
 _config_setting_read() {
     local key="$1" db out rc
     db="${T3_CONFIG_DB:-${XDG_DATA_HOME:-$HOME/.local/share}/teatree/db.sqlite3}"
@@ -141,6 +148,9 @@ _config_setting_read() {
         0) return 0 ;;
         2) return 1 ;;
     esac
+    # A store IS on this host (the 0-byte stub, or a DB no sqlite3 exists to open)
+    # and no tier read it — unknown, exactly as in the sqlite branch above.
+    [ -e "$db" ] && return 1
     # No store on this host at all: nothing was ever written here to read, so the
     # shipped default is the answer rather than a guess. This keeps the #256
     # colleague guarantee — a plain clone renders the neutral off hint, not a "?".

--- a/hooks/scripts/teatree_settings.py
+++ b/hooks/scripts/teatree_settings.py
@@ -40,9 +40,15 @@ def read_cold_setting_status(name: str) -> tuple[object | None, str]:
     """The stored GLOBAL-scope value for ``[teatree] <name>``, un-coerced, plus HOW it resolved.
 
     Returns ``(value, status)``. ``status`` is :data:`COLD_READ_UNREADABLE` when the
-    read MACHINERY itself failed — ``teatree`` not importable, or ``read_setting``
-    raising — and :data:`COLD_READ_OK` otherwise, INCLUDING when the row is simply
-    absent (``value`` is then ``None``).
+    read MACHINERY itself failed — ``teatree`` not importable, the reader raising, or
+    the STORE itself unreadable — and :data:`COLD_READ_OK` otherwise, INCLUDING when the
+    row is simply absent (``value`` is then ``None``).
+
+    The store's own readability arrives through ``read_setting_confirmed``, never the
+    value half: ``read_setting`` collapses a sqlite that could not be opened into the
+    same ``None`` an absent row yields, so reading through it made this status a report
+    on the IMPORT alone and the unreadable branch below unreachable from a read fault
+    (#4205).
 
     The status exists because the value alone cannot express the difference between
     "the operator never opted in" and "this install cannot read its own settings"
@@ -82,11 +88,13 @@ def read_cold_setting_status(name: str) -> tuple[object | None, str]:
     if added:
         sys.path.insert(0, src_dir)
     try:
-        from teatree.config.cold_reader import read_setting  # noqa: PLC0415 — deferred: cold-hook import
+        from teatree.config.cold_reader import read_setting_confirmed  # noqa: PLC0415 — deferred: cold-hook import
 
-        return read_setting(name, scope=_GLOBAL_SCOPE), COLD_READ_OK
+        read = read_setting_confirmed(name, scope=_GLOBAL_SCOPE)
     except Exception:  # noqa: BLE001 — crash-proof hook: any failure degrades silently, never breaks the tool call
         return None, COLD_READ_UNREADABLE
+    else:
+        return read.value, (COLD_READ_OK if read.readable else COLD_READ_UNREADABLE)
     finally:
         if added:
             with contextlib.suppress(ValueError):

--- a/src/teatree/config/cold_reader.py
+++ b/src/teatree/config/cold_reader.py
@@ -59,9 +59,13 @@ _GLOBAL_SCOPE = ""
 class SettingRead:
     """One cold read's outcome: the decoded `value`, and whether the store could be READ.
 
-    `readable` is `False` only when sqlite itself errored. Confirmed ABSENCE — no DB file, no
-    row, an undecodable value — is `readable=True` with a `None` value: there was nothing to
-    read, which is a legitimate answer rather than a failure.
+    `readable` is `False` when sqlite itself errored, AND when a present-but-unreadable
+    store's projection fallback has no answer for the key (:func:`_unreadable_db_read`) —
+    that projection gap is indistinguishable from the corrupt store simply holding a value
+    the projection never saw, so it is treated as unread rather than as a confirmed unset
+    (#4205). Confirmed ABSENCE — no DB file at all, no row, an undecodable value — is
+    `readable=True` with a `None` value: there was nothing to read, which is a legitimate
+    answer rather than a failure.
     """
 
     value: object | None
@@ -108,15 +112,24 @@ def _unreadable_db_read(key: str, *, scope: str, env: Mapping[str, str], db_path
     or a database locked by a live writer. Keying the fall-through on absence alone left
     that stub with no tier at all, which is the shape #4197 closed in the shell (#4205).
 
-    Unreadable is preserved when the projection cannot answer either: this widens WHERE an
-    answer may come from, never what counts as having read one.
+    Unreadable is preserved when the projection cannot answer either — no projection at
+    all, OR a trustworthy projection with no row for THIS key. The per-key case matters
+    because `trustworthy` is generation-monotonic, not recency-checked: a projection whose
+    publish failed after the corrupt DB's last write is still FRESH, so a missing key there
+    is not evidence the key is unset — it is evidence the projection never saw it. Reporting
+    `readable=True` for that gap is exactly the fail-open #4008 exists to close: it silently
+    reopened it, letting a corrupt canonical DB collapse to "not configured" for
+    `banned_terms` (measured: `resolve_banned_terms` moved from a raised
+    `BannedTermsUnreadableError`, exit 2, to an allowed exit 0). This widens WHERE an answer
+    may come from, never what counts as having read one.
     """
     if db_path is not None:
         return SettingRead(None, readable=False)
     projection = canonical_projection(env=env)
     if projection is None:
         return SettingRead(None, readable=False)
-    return SettingRead(projection.setting(key, scope=scope), readable=True)
+    value = projection.setting(key, scope=scope)
+    return SettingRead(value, readable=value is not None)
 
 
 def read_setting_confirmed(

--- a/src/teatree/config/cold_reader.py
+++ b/src/teatree/config/cold_reader.py
@@ -100,6 +100,25 @@ def _absent_db_read(key: str, *, scope: str, env: Mapping[str, str], db_path: Pa
     return SettingRead(projection.setting(key, scope=scope) if projection is not None else None, readable=True)
 
 
+def _unreadable_db_read(key: str, *, scope: str, env: Mapping[str, str], db_path: Path | None) -> "SettingRead":
+    """The read when the canonical database file is HERE but sqlite could not read it.
+
+    The same projection tier :func:`_absent_db_read` uses, for the file that exists and
+    answers nothing — the 0-byte stub the control-DB migration left at the old host path,
+    or a database locked by a live writer. Keying the fall-through on absence alone left
+    that stub with no tier at all, which is the shape #4197 closed in the shell (#4205).
+
+    Unreadable is preserved when the projection cannot answer either: this widens WHERE an
+    answer may come from, never what counts as having read one.
+    """
+    if db_path is not None:
+        return SettingRead(None, readable=False)
+    projection = canonical_projection(env=env)
+    if projection is None:
+        return SettingRead(None, readable=False)
+    return SettingRead(projection.setting(key, scope=scope), readable=True)
+
+
 def read_setting_confirmed(
     key: str,
     *,
@@ -127,7 +146,7 @@ def read_setting_confirmed(
         (scope, key),
     )
     if not ran:
-        return SettingRead(None, readable=False)
+        return _unreadable_db_read(key, scope=scope, env=env, db_path=db_path)
     if row is None:
         return SettingRead(None, readable=True)
     raw = row[0]

--- a/src/teatree/config/override_read_health.py
+++ b/src/teatree/config/override_read_health.py
@@ -148,11 +148,17 @@ def fallback_marker_path() -> Path:
 
 
 def _dir_is_writable(directory: Path) -> bool:
-    try:
-        directory.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        return False
-    return os.access(directory, os.W_OK)
+    """Whether a marker could be written under *directory* — WITHOUT creating anything.
+
+    The nearest existing ancestor answers it, because that is what a later
+    ``mkdir(parents=True)`` would need. Asking by ATTEMPTING the directory made
+    :func:`marker_paths` — and so ``degraded_read_report``, ``clear_degraded_read`` and the
+    doctor check — materialise a directory tree on a pure read (#4205).
+    """
+    for candidate in (directory, *directory.parents):
+        if candidate.exists():
+            return candidate.is_dir() and os.access(candidate, os.W_OK)
+    return False
 
 
 def marker_paths() -> tuple[Path, ...]:

--- a/tests/config/test_cold_reader.py
+++ b/tests/config/test_cold_reader.py
@@ -231,6 +231,20 @@ class TestAnUnreadableCanonicalDbFallsThroughToTheProjection:
         read = cold_reader.read_setting_confirmed("autoload", db_path=tmp_path / "stub.sqlite3")
         assert (read.value, read.readable) == (None, False)
 
+    def test_a_projection_with_no_row_for_the_key_stays_unreadable(self, tmp_path: Path) -> None:
+        """A trustworthy projection missing THIS key is not a confirmed unset (#4205).
+
+        `trustworthy` is generation-monotonic, not recency-checked: a projection whose
+        publish failed after the corrupt store's last write is still FRESH, so a missing
+        key here is evidence the projection never saw it, not that the operator left it
+        unset. Reporting ``readable=True`` for that gap reopened #4008: the corrupt DB
+        that gates ``resolve_banned_terms`` would silently collapse to "not configured"
+        instead of raising ``BannedTermsUnreadableError``.
+        """
+        self._publish(tmp_path, [("", "some_other_key", True)])  # answers, but not for "autoload"
+        read = cold_reader.read_setting_confirmed("autoload")
+        assert (read.value, read.readable) == (None, False)
+
 
 class TestTypedWrappers:
     @pytest.fixture

--- a/tests/config/test_cold_reader.py
+++ b/tests/config/test_cold_reader.py
@@ -14,8 +14,25 @@ from pathlib import Path
 import pytest
 
 from teatree.config import cold_reader
+from teatree.config.host_projection import ProjectionPublisher
 
 Row = tuple[str, str, object]
+
+# The publisher projects the loop/mode tables alongside settings, so a source database it
+# is pointed at has to carry them. Empty is honest: these tests are about the settings tier.
+_PROJECTION_SOURCE_TABLES = (
+    "CREATE TABLE IF NOT EXISTS teatree_loop_state (name TEXT, status TEXT)",
+    (
+        "CREATE TABLE IF NOT EXISTS teatree_loop_preset "
+        "(name TEXT, defers_questions INT, pauses_self_pump INT, presence_sensitive INT)"
+    ),
+    "CREATE TABLE IF NOT EXISTS teatree_loop_preset_override (preset_name TEXT, until TEXT, set_at TEXT)",
+    "CREATE TABLE IF NOT EXISTS teatree_loop_schedule (name TEXT, id INT, timezone TEXT)",
+    (
+        "CREATE TABLE IF NOT EXISTS teatree_loop_schedule_slot "
+        "(schedule_id INT, days TEXT, start_time TEXT, preset_name TEXT)"
+    ),
+)
 
 
 def _make_db(path: Path, rows: Iterable[Row], *, wal: bool = False) -> None:
@@ -159,6 +176,60 @@ class TestReadSettingConfirmed:
         finally:
             writer.rollback()
             writer.close()
+
+
+class TestAnUnreadableCanonicalDbFallsThroughToTheProjection:
+    """The projection answers for a store that is PRESENT but unreadable, not only an absent one (#4205).
+
+    The fall-through was keyed on `not db.exists()`, so the 0-byte stub the control-DB
+    migration left at the old host path — a file that exists and holds no table — never
+    reached the projection published for exactly that host. The shell tier gained this
+    fall-through in #4197; the asymmetry is what made aligning the two path resolvers
+    hazardous. An unreadable store with NO projection is still unreadable: the point is to
+    answer where an answer exists, never to launder a read fault into a confident value.
+    """
+
+    @pytest.fixture(autouse=True)
+    def stub_db(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        db = tmp_path / "stub.sqlite3"
+        db.touch()  # the migration leftover: present, 0 bytes, no table
+        monkeypatch.setenv("T3_CONFIG_DB", str(db))
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+        monkeypatch.delenv("T3_DATA_DIR", raising=False)
+        return db
+
+    def _publish(self, tmp_path: Path, rows: Iterable[Row]) -> None:
+        """Write the projection the way production does — through the real publisher."""
+        source = tmp_path / "source.sqlite3"
+        _make_db(source, rows)
+        conn = sqlite3.connect(source)
+        try:
+            for ddl in _PROJECTION_SOURCE_TABLES:
+                conn.execute(ddl)
+            conn.commit()
+        finally:
+            conn.close()
+        data_dir = tmp_path / "xdg" / "teatree"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        ProjectionPublisher(source, data_dir).publish()
+
+    def test_a_published_value_answers_for_the_stub(self, tmp_path: Path) -> None:
+        self._publish(tmp_path, [("", "autoload", True)])
+        read = cold_reader.read_setting_confirmed("autoload")
+        assert (read.value, read.readable) == (True, True)
+
+    def test_no_projection_keeps_the_store_unreadable(self) -> None:
+        # Anti-vacuous foil: a fall-through that always reported readable would pass the
+        # test above and hide exactly the conflation this whole ticket is about.
+        read = cold_reader.read_setting_confirmed("autoload")
+        assert (read.value, read.readable) == (None, False)
+
+    def test_an_explicit_db_path_never_substitutes_the_projection(self, tmp_path: Path) -> None:
+        # A caller that NAMED a file means that file; answering from a projection would
+        # answer a different question — the banned-terms readers depend on this.
+        self._publish(tmp_path, [("", "autoload", True)])
+        read = cold_reader.read_setting_confirmed("autoload", db_path=tmp_path / "stub.sqlite3")
+        assert (read.value, read.readable) == (None, False)
 
 
 class TestTypedWrappers:

--- a/tests/config/test_teatree_settings_db_flip.py
+++ b/tests/config/test_teatree_settings_db_flip.py
@@ -137,20 +137,21 @@ class TestNonTeatreeSection:
 
 
 class TestDelegatesToColdReader:
-    """Anti-vacuous: patching ``cold_reader.read_setting`` flips the reader's output.
+    """Anti-vacuous: patching ``cold_reader.read_setting_confirmed`` flips the reader's output.
 
     That flip is observable only if ``teatree_settings`` routes through the cold
-    reader — proving the DB read is live.
+    reader — proving the DB read is live. The confirming sibling is the seam, not the
+    value half: the leaf needs the store's readability, which ``read_setting`` discards.
     """
 
     def test_reader_routes_through_cold_reader(self, settings_module, monkeypatch: pytest.MonkeyPatch) -> None:
         seen: list[tuple[str, str]] = []
 
-        def _fake(name: str, *, scope: str = "", **_: object) -> object:
+        def _fake(name: str, *, scope: str = "", **_: object) -> cold_reader.SettingRead:
             seen.append((name, scope))
-            return False
+            return cold_reader.SettingRead(value=False, readable=True)
 
-        monkeypatch.setattr(cold_reader, "read_setting", _fake)
+        monkeypatch.setattr(cold_reader, "read_setting_confirmed", _fake)
         assert settings_module.teatree_bool_setting("memory_recall_enabled", default=True) is False
         assert ("memory_recall_enabled", "") in seen
 
@@ -159,5 +160,5 @@ class TestDelegatesToColdReader:
             msg = "db layer exploded"
             raise RuntimeError(msg)
 
-        monkeypatch.setattr(cold_reader, "read_setting", _boom)
+        monkeypatch.setattr(cold_reader, "read_setting_confirmed", _boom)
         assert settings_module.teatree_bool_setting("memory_recall_enabled", default=True) is True

--- a/tests/config/test_teatree_settings_int_flip.py
+++ b/tests/config/test_teatree_settings_int_flip.py
@@ -147,18 +147,18 @@ class TestIntHelperSemantics:
 
 
 class TestDelegatesToColdReader:
-    """Anti-vacuous: patching ``cold_reader.read_setting`` flips the int reader output."""
+    """Anti-vacuous: patching ``cold_reader.read_setting_confirmed`` flips the int reader output."""
 
     def test_reader_routes_through_cold_reader(self, home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from hooks.scripts import teatree_settings  # noqa: PLC0415
 
         seen: list[tuple[str, str]] = []
 
-        def _fake(name: str, *, scope: str = "", **_: object) -> object:
+        def _fake(name: str, *, scope: str = "", **_: object) -> cold_reader.SettingRead:
             seen.append((name, scope))
-            return 17
+            return cold_reader.SettingRead(17, readable=True)
 
-        monkeypatch.setattr(cold_reader, "read_setting", _fake)
+        monkeypatch.setattr(cold_reader, "read_setting_confirmed", _fake)
         assert teatree_settings.teatree_int_setting("orchestrator_turn_budget", default=25, minimum=0) == 17
         assert ("orchestrator_turn_budget", "") in seen
 
@@ -169,5 +169,5 @@ class TestDelegatesToColdReader:
             msg = "db layer exploded"
             raise RuntimeError(msg)
 
-        monkeypatch.setattr(cold_reader, "read_setting", _boom)
+        monkeypatch.setattr(cold_reader, "read_setting_confirmed", _boom)
         assert teatree_settings.teatree_int_setting("orchestrator_turn_budget", default=25, minimum=0) == 25

--- a/tests/teatree_config/test_override_read_degradation.py
+++ b/tests/teatree_config/test_override_read_degradation.py
@@ -12,9 +12,11 @@ being useless, so every fail-closed case has an absent-override twin that must s
 resolve to the shipped default.
 """
 
+import json
 import os
 import shutil
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 from unittest import mock
@@ -428,3 +430,115 @@ class TestTheMarkerIsRecordedWhereTheFaultWasObserved(TestCase):
             clear_degraded_read()
             assert degraded_read_report() is None
         assert not fallback.exists()
+
+
+class TestReadingTheHealthRecordWritesNothing(TestCase):
+    """Asking whether the tier is degraded must not touch the filesystem (#4205).
+
+    ``marker_paths`` decided "can this venue write here?" by ATTEMPTING the directory —
+    ``mkdir(parents=True)`` — so ``degraded_read_report``, ``clear_degraded_read`` and the
+    doctor check each materialised a directory tree on a pure read. A health probe that
+    creates the venue it is inspecting reports on its own side effect.
+    """
+
+    def _absent_tree(self) -> tuple[Path, Path]:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        return root / "control-db" / "nested" / MARKER_FILENAME, root / MARKER_FILENAME
+
+    def test_a_report_read_creates_no_directory(self) -> None:
+        canonical, fallback = self._absent_tree()
+        with (
+            mock.patch("teatree.config.override_read_health.marker_path", return_value=canonical),
+            mock.patch("teatree.config.override_read_health.fallback_marker_path", return_value=fallback),
+        ):
+            assert degraded_read_report() is None
+        assert not canonical.parent.exists(), "a pure read materialised the marker directory"
+
+    def test_clearing_creates_no_directory(self) -> None:
+        canonical, fallback = self._absent_tree()
+        with (
+            mock.patch("teatree.config.override_read_health.marker_path", return_value=canonical),
+            mock.patch("teatree.config.override_read_health.fallback_marker_path", return_value=fallback),
+        ):
+            clear_degraded_read()
+        assert not canonical.parent.exists(), "acknowledging a fault materialised the marker directory"
+
+    def test_a_creatable_canonical_dir_is_still_the_only_candidate(self) -> None:
+        # Foil: probing without creating must not start reporting a writable venue as
+        # unwritable — that would offer the per-user path unconditionally, the very
+        # stale-marker-outvotes-a-healthy-venue defect `marker_paths` guards against.
+        canonical, fallback = self._absent_tree()
+        with (
+            mock.patch("teatree.config.override_read_health.marker_path", return_value=canonical),
+            mock.patch("teatree.config.override_read_health.fallback_marker_path", return_value=fallback),
+        ):
+            assert marker_paths() == (canonical,)
+
+    def test_an_uncreatable_canonical_dir_still_offers_the_fallback(self) -> None:
+        # The other foil: the write path must keep both candidates when the canonical
+        # directory cannot be created here, which is the whole point of the fallback.
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        (root / "blocking-file").write_text("not a directory")
+        canonical = root / "blocking-file" / "control-db" / MARKER_FILENAME
+        fallback = root / MARKER_FILENAME
+        with (
+            mock.patch("teatree.config.override_read_health.marker_path", return_value=canonical),
+            mock.patch("teatree.config.override_read_health.fallback_marker_path", return_value=fallback),
+        ):
+            assert marker_paths() == (canonical, fallback)
+
+
+class TestTheFreshestRecordDecides(TestCase):
+    """Recency, not candidate order, answers "is the tier degraded NOW?" (#4205).
+
+    The candidates are venue-local files that never see each other's writes, so a
+    canonical-first read answers "did it ever degrade in this one directory?" instead.
+    That was documented as load-bearing and pinned by nothing: `found[0]` left the whole
+    degradation lane green.
+
+    `marker_paths` is patched rather than reconstructed from an unwritable canonical dir:
+    the ordering inside `_read_marker` is the property under test, and a permission-bit
+    fixture would couple the assertion to a filesystem mechanism it is not about.
+    """
+
+    def _marker(self, *, scope: str, last_seen: float) -> Path:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        path = root / MARKER_FILENAME
+        path.write_text(
+            json.dumps(
+                {
+                    "scopes": [scope],
+                    "callers": [],
+                    "occurrences": 1,
+                    "first_seen": last_seen,
+                    "last_seen": last_seen,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def _both(self) -> tuple[Path, Path]:
+        now = time.time()
+        # Both well inside MARKER_TTL_SECONDS, so this is about ordering, not staleness.
+        return self._marker(scope="stale", last_seen=now - 3600), self._marker(scope="fresh", last_seen=now - 5)
+
+    def _report_over(self, candidates: tuple[Path, ...]) -> Any:
+        with mock.patch("teatree.config.override_read_health.marker_paths", return_value=candidates):
+            return degraded_read_report()
+
+    def test_the_newest_record_wins_when_it_is_last(self) -> None:
+        stale, fresh = self._both()
+        report = self._report_over((stale, fresh))
+        assert report is not None
+        assert (report.scopes, report.path) == (("fresh",), fresh)
+
+    def test_the_newest_record_wins_when_it_is_first(self) -> None:
+        # The paired foil: "always take the last candidate" passes the case above.
+        stale, fresh = self._both()
+        report = self._report_over((fresh, stale))
+        assert report is not None
+        assert (report.scopes, report.path) == (("fresh",), fresh)

--- a/tests/test_engagement_advisory.py
+++ b/tests/test_engagement_advisory.py
@@ -7,6 +7,8 @@ an UNREADABLE store gets its own text naming the breakage, everything else keeps
 original how-to-start line, and fail-closed is unchanged throughout.
 """
 
+from pathlib import Path
+
 import pytest
 
 from hooks.scripts import teatree_settings
@@ -86,6 +88,37 @@ class TestAutoloadResolutionMatchesEnabled:
         _stub_store(monkeypatch, value=None, status=COLD_READ_OK)
         monkeypatch.setenv("T3_AUTOLOAD", env)
         assert autoload_resolution()[0] is autoload_enabled()
+
+
+class TestARealReadFaultReachesTheAdvisory:
+    """No stub: the UNREADABLE branch must be reachable from an actual store fault (#4205).
+
+    Every other test here forces the status. That left the branch pinned but unreached —
+    ``read_cold_setting_status`` called the VALUE half of the cold read, so a store sqlite
+    itself could not open arrived as an indistinguishable ``None`` and resolved to
+    "the operator never opted in". The advisory then named the wrong fault on the one
+    install that needed it, and only an IMPORT failure could ever produce the right line.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_store(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+        monkeypatch.delenv("T3_DATA_DIR", raising=False)
+
+    def test_an_unreadable_store_resolves_unreadable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        corrupt = tmp_path / "corrupt.sqlite3"
+        corrupt.write_bytes(b"this is not a sqlite database")
+        monkeypatch.setenv("T3_CONFIG_DB", str(corrupt))
+        assert autoload_resolution() == (False, AUTOLOAD_UNREADABLE)
+        assert session_start_advisory() == TEATREE_SETTINGS_UNREADABLE_ADVISORY
+
+    def test_an_absent_store_still_resolves_to_the_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Foil: nothing to read is a confirmed absence, so the how-to-start line is right.
+        monkeypatch.setenv("T3_CONFIG_DB", str(tmp_path / "absent.sqlite3"))
+        assert autoload_resolution() == (False, AUTOLOAD_FROM_DEFAULT)
+        assert session_start_advisory() == TEATREE_NOT_ACTIVE_ADVISORY
 
 
 class TestSessionStartAdvisory:

--- a/tests/test_statusline_shell_parity.py
+++ b/tests/test_statusline_shell_parity.py
@@ -421,11 +421,20 @@ class TestAnUnreadableStoreRendersUnknownNotOff:
         return _strip_ansi(result.stdout)
 
     def _unreadable_db(self, sandbox: Path) -> Path:
-        # Present and non-empty, yet no sqlite reader can open it — the same observable
-        # state as the 0-byte stub and the volume the host cannot reach.
+        # Present and non-empty, yet no sqlite reader can open it. NOT the same observable
+        # state as the 0-byte stub: non-empty takes the sqlite branch and fails inside it,
+        # while the stub is routed straight past it. Both are a store this host cannot see;
+        # `_zero_byte_stub` carries the second shape, which no test covered before #4205.
         db = sandbox / "unreadable.sqlite3"
         db.write_text("this is not a sqlite database")
         return db
+
+    def _zero_byte_stub(self, sandbox: Path) -> Path:
+        # The defect's literal shape: the control-DB migration left a 0-byte stub at the old
+        # host path. A stub holds nothing, so it is a store this host cannot see.
+        stub = sandbox / "stub.sqlite3"
+        stub.touch()
+        return stub
 
     def _publish(self, sandbox: Path, body: str) -> None:
         data_dir = sandbox / "xdg" / "teatree"
@@ -444,8 +453,41 @@ class TestAnUnreadableStoreRendersUnknownNotOff:
         assert self._UNKNOWN in out, out
         assert self._OFF not in out
 
+    def test_a_zero_byte_stub_with_no_projection_is_unknown(self, sandbox: Path) -> None:
+        # #4205: the stub skips the sqlite branch, so the ONLY tier left is the projection —
+        # and when that cannot answer either, nothing read the store. Rendering the shipped
+        # default as the owner's stored choice here is the original defect's exact shape.
+        out = self._render(sandbox, self._zero_byte_stub(sandbox))
+        assert self._UNKNOWN in out, out
+        assert self._OFF not in out, "a stub no tier could read was rendered as a stored 'off'"
+
+    def test_a_zero_byte_stub_still_defers_to_a_readable_projection(self, sandbox: Path) -> None:
+        # Foil: the stub is not itself a verdict. A projection that answers still decides.
+        self._publish(sandbox, json.dumps({"settings": {"": {"autoload": True}}}))
+        out = self._render(sandbox, self._zero_byte_stub(sandbox))
+        assert "degraded chip" in out, out
+        assert self._UNKNOWN not in out
+
+    def test_a_projection_that_answers_false_over_a_stub_still_says_off(self, sandbox: Path) -> None:
+        # Second foil: an answered `false` is determinate, so it must NOT degrade to unknown.
+        self._publish(sandbox, json.dumps({"settings": {"": {"autoload": False}}}))
+        out = self._render(sandbox, self._zero_byte_stub(sandbox))
+        assert self._OFF in out, out
+        assert self._UNKNOWN not in out
+
+    def test_a_projection_present_but_unreadable_is_unknown(self, sandbox: Path) -> None:
+        # #4205: `_projection_setting` answered "no projection on this host" for a file that
+        # IS here and denied the read, collapsing the 1/2 split its own contract documents.
+        # With no DB either that verdict is the last word, and it renders a stored "off".
+        self._publish(sandbox, json.dumps({"settings": {"": {"autoload": True}}}))
+        (sandbox / "xdg" / "teatree" / "host-projection.json").chmod(0o000)
+        out = self._render(sandbox, sandbox / "absent.sqlite3")
+        assert self._UNKNOWN in out, out
+        assert self._OFF not in out, "a projection that denied the read was rendered as a stored 'off'"
+
     def test_a_host_with_no_store_at_all_still_says_off(self, sandbox: Path) -> None:
         # Foil for #256: a plain clone stored nothing, so "off" is determinate, not a guess.
+        # Paired with the case above: absent and unreadable must not render alike either.
         out = self._render(sandbox, sandbox / "absent.sqlite3")
         assert self._OFF in out, out
         assert self._UNKNOWN not in out


### PR DESCRIPTION
fix(config): the projection fall-through must answer for the KEY, not just exist (#4205)

Cold-review finding: _unreadable_db_read reported readable=True whenever a
trustworthy projection existed, even when that projection held no row for the
requested key. trustworthy is generation-monotonic, not recency-checked, so a
projection whose publish failed after the corrupt DB's last write is still
FRESH — a missing key there is evidence the projection never saw it, not that
it is unset. This silently reopened #4008: a corrupt canonical banned_terms DB
moved from raising BannedTermsUnreadableError (exit 2) to being read as
genuinely unset (exit 0), measured with a paired before/after probe.

Fix: readable now tracks whether the projection actually answered
(value is not None), not merely whether it was reachable.

## What

## Why