### PR TITLE
fix(bootstrap): report the failure that stalled Django, not the reentrancy guard (#4207)

### DIFF
--- a/src/teatree/utils/django_bootstrap.py
+++ b/src/teatree/utils/django_bootstrap.py
@@ -9,24 +9,97 @@ private wrapper names; :func:`ensure_django` is the one place that owns it.
 ``django.setup`` is registered as a ``module_attr`` chokepoint
 (``quality/chokepoints.yaml``) with this module as the sole allowed caller, so
 a new inline ``django.setup()`` anywhere else fails the chokepoint hook.
+
+``django.setup()`` is a no-op only once it has *finished*. ``Apps.populate``
+sets ``loading = True`` under no ``try``/``finally``, so a setup that dies
+partway leaves the registry stalled for the life of the process and every later
+bootstrap meets Django's reentrancy guard instead. Teatree reaches that state
+through its own fail-safe call sites (``cli/config_view.py``,
+``cli/push_gate_tools.py``, ``cli/ci.py``, ``cli/agent.py``), which swallow the
+first failure — so the CLI reported ``populate() isn't reentrant`` with the real
+cause gone (souliane/teatree#4207).
 """
 
+import inspect
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import FrameType
+
+    from django.apps.registry import Apps
 
 _SETTINGS_MODULE = "teatree.settings"
+
+
+class DjangoBootstrapStalledError(RuntimeError):
+    """An earlier ``django.setup()`` failed and left the app registry unusable.
+
+    A ``RuntimeError`` so the fail-safe handlers already catching Django's own
+    reentrancy error keep behaving as they did.
+    """
+
+    def __init__(self, cause: BaseException | None) -> None:
+        origin = (
+            "Its cause is chained below."
+            if cause is not None
+            else "A caller swallowed that failure, so its cause is not recorded."
+        )
+        super().__init__(
+            "Django's app registry is stalled: an earlier django.setup() in this process failed "
+            f"partway and left it loading. {origin} Django will not re-run AppConfig.ready(), so "
+            "this process cannot recover — fix that failure, or rerun in a fresh process."
+        )
+
+
+class _Bootstrap:
+    """The first failure to escape our own ``django.setup()``, kept as the cause."""
+
+    first_failure: BaseException | None = None
+
+
+def _populate_frame_is_live(registry: "Apps") -> bool:
+    """Is this call already inside the ``populate()`` that will configure ``registry``?
+
+    A frame stack is per-thread, so this answers only for the caller: a *different*
+    thread mid-populate leaves this False and the bootstrap blocks on Django's own
+    lock instead, which is the case Django already handles correctly.
+    """
+    from django.apps.registry import Apps  # noqa: PLC0415 — deferred: keeps CLI startup Django-free
+
+    populating = Apps.populate.__code__
+    frame: FrameType | None = inspect.currentframe()
+    while frame is not None:
+        if frame.f_code is populating and frame.f_locals.get("self") is registry:
+            return True
+        frame = frame.f_back
+    return False
 
 
 def ensure_django() -> None:
     """Configure Django once so an ORM-touching command body can run.
 
     Idempotent: ``DJANGO_SETTINGS_MODULE`` is set with ``setdefault`` and
-    ``django.setup()`` is a no-op after the first call, so repeated invocation
-    across nested command dispatch is safe.
+    ``django.setup()`` is a no-op after a completed first call, so repeated
+    invocation across nested command dispatch is safe.
     """
     import django  # noqa: PLC0415 — deferred: Django import at call time
+    from django.apps import apps  # noqa: PLC0415 — deferred: paired with the Django import above
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", _SETTINGS_MODULE)
-    django.setup()
+
+    if _populate_frame_is_live(apps):
+        return
+
+    stalled = apps.loading and not apps.ready
+    try:
+        django.setup()
+    except Exception as exc:
+        if stalled and isinstance(exc, RuntimeError):
+            raise DjangoBootstrapStalledError(_Bootstrap.first_failure) from (_Bootstrap.first_failure or exc)
+        if _Bootstrap.first_failure is None:
+            _Bootstrap.first_failure = exc
+        raise
 
 
-__all__ = ["ensure_django"]
+__all__ = ["DjangoBootstrapStalledError", "ensure_django"]

--- a/tests/utils/test_django_bootstrap.py
+++ b/tests/utils/test_django_bootstrap.py
@@ -5,13 +5,59 @@ The helper consolidates the 30+ inline ``import django`` +
 drifted across the CLI under two private wrapper names. The call-site
 authorization itself is pinned by the ``django-setup-bootstrap`` chokepoint
 (``tests/quality/test_chokepoints.py``); here we pin the helper's own
-contract: it sets the settings module default and is safe to call repeatedly.
+contract: it sets the settings module default, is safe to call repeatedly,
+and — souliane/teatree#4207 — never lets Django's reentrancy guard speak for a
+registry an earlier failed bootstrap left stalled.
+
+The #4207 cases drive a throwaway :class:`~django.apps.registry.Apps` rather
+than the session's own registry: the states under test are "mid-populate" and
+"stalled", and inflicting either on the live registry would take the whole test
+process down with it. Everything else is real — ``Apps.populate`` runs unmocked,
+so the reentrancy guard exercised is Django's own.
 """
 
 import os
 from unittest.mock import patch
 
-from teatree.utils.django_bootstrap import ensure_django
+import pytest
+from django.apps import AppConfig
+from django.apps.registry import Apps
+
+import teatree.utils
+from teatree.utils.django_bootstrap import DjangoBootstrapStalledError, _Bootstrap, ensure_django
+
+_MISSING_APP = "teatree_no_such_app_4207"
+
+
+@pytest.fixture(autouse=True)
+def _forget_recorded_failure():
+    """The recorded first failure is process-wide, so it must not leak between tests."""
+    with patch.object(_Bootstrap, "first_failure", None):
+        yield
+
+
+def _unpopulated_registry() -> Apps:
+    """A registry rewound to its pre-``populate()`` state.
+
+    ``Apps(installed_apps=None)`` is refused while a global registry exists, so
+    building a populated one and rewinding its flags is the only route.
+    """
+    registry = Apps(installed_apps=())
+    registry.app_configs.clear()
+    registry.all_models.clear()
+    registry.apps_ready = registry.models_ready = registry.ready = False
+    registry.loading = False
+    registry.ready_event.clear()
+    return registry
+
+
+class _ReentrantProbeConfig(AppConfig):
+    """An app whose ``ready()`` re-enters the bootstrap, as a nested dispatch does."""
+
+    label = "reentrant_probe_4207"
+
+    def ready(self) -> None:
+        ensure_django()
 
 
 class TestEnsureDjango:
@@ -38,3 +84,130 @@ class TestEnsureDjango:
             ensure_django()
             ensure_django()
             assert setup.call_count == 2
+
+
+class TestBootstrapReachedFromInsidePopulate:
+    def test_defers_to_the_populate_frame_already_on_this_stack(self) -> None:
+        registry = _unpopulated_registry()
+        probe = _ReentrantProbeConfig("teatree.utils", teatree.utils)
+
+        with (
+            patch("django.apps.apps", registry),
+            patch("django.setup", lambda: registry.populate([probe])),
+        ):
+            registry.populate([probe])
+
+        assert registry.ready
+
+    def test_still_bootstraps_when_no_populate_frame_is_live(self) -> None:
+        with patch("django.setup") as setup:
+            ensure_django()
+            setup.assert_called_once_with()
+
+
+class TestBootstrapAfterAStalledSetup:
+    """#4207: a ``django.setup()`` that dies partway leaves ``loading`` stuck True.
+
+    ``Apps.populate`` sets that flag under no ``try``/``finally``, and teatree has
+    fail-safe call sites (``cli/config_view.py``, ``cli/push_gate_tools.py``,
+    ``cli/ci.py``, ``cli/agent.py``) that swallow the first failure — so the next
+    bootstrap in the process met Django's reentrancy guard and reported
+    ``populate() isn't reentrant``, with the real cause gone.
+    """
+
+    @staticmethod
+    def _stall(registry: Apps) -> ModuleNotFoundError:
+        """Run a real, failing ``populate()`` and return the failure it stalled on."""
+        with (
+            patch("django.apps.apps", registry),
+            patch("django.setup", lambda: registry.populate([_MISSING_APP])),
+            pytest.raises(ModuleNotFoundError) as caught,
+        ):
+            ensure_django()
+        assert registry.loading
+        assert not registry.ready
+        return caught.value
+
+    def test_the_first_failure_propagates_unchanged(self) -> None:
+        assert _MISSING_APP in str(self._stall(_unpopulated_registry()))
+
+    def test_a_later_bootstrap_reports_the_stall_not_the_reentrancy_guard(self) -> None:
+        registry = _unpopulated_registry()
+        self._stall(registry)
+
+        with (
+            patch("django.apps.apps", registry),
+            patch("django.setup", lambda: registry.populate([_MISSING_APP])),
+            pytest.raises(RuntimeError) as caught,
+        ):
+            ensure_django()
+
+        assert "isn't reentrant" not in str(caught.value)
+        assert isinstance(caught.value, DjangoBootstrapStalledError)
+
+    def test_a_later_bootstrap_chains_the_failure_that_caused_the_stall(self) -> None:
+        registry = _unpopulated_registry()
+        first_failure = self._stall(registry)
+
+        with (
+            patch("django.apps.apps", registry),
+            patch("django.setup", lambda: registry.populate([_MISSING_APP])),
+            pytest.raises(DjangoBootstrapStalledError) as caught,
+        ):
+            ensure_django()
+
+        assert caught.value.__cause__ is first_failure
+
+    def test_reports_an_unrecorded_stall_without_inventing_a_cause(self) -> None:
+        registry = _unpopulated_registry()
+        registry.loading = True
+
+        with (
+            patch("django.apps.apps", registry),
+            patch("django.setup", lambda: registry.populate([_MISSING_APP])),
+            pytest.raises(DjangoBootstrapStalledError) as caught,
+        ):
+            ensure_django()
+
+        assert "not recorded" in str(caught.value)
+        assert isinstance(caught.value.__cause__, RuntimeError)
+
+    def test_chains_the_first_failure_not_the_last(self) -> None:
+        registry = _unpopulated_registry()
+        first = ValueError("settings are unreadable")
+        later = TypeError("a second, later failure")
+
+        def raise_(exc: BaseException) -> None:
+            raise exc
+
+        with patch("django.apps.apps", registry):
+            for failure in (first, later):
+                with (
+                    patch("django.setup", lambda exc=failure: raise_(exc)),
+                    pytest.raises(type(failure)),
+                ):
+                    ensure_django()
+
+            registry.loading = True
+            with (
+                patch("django.setup", lambda: registry.populate([_MISSING_APP])),
+                pytest.raises(DjangoBootstrapStalledError) as caught,
+            ):
+                ensure_django()
+
+        assert caught.value.__cause__ is first
+
+    def test_leaves_an_unrelated_failure_from_a_stalled_registry_unlabelled(self) -> None:
+        registry = _unpopulated_registry()
+        registry.loading = True
+
+        def explode() -> None:
+            message = "LOGGING_CONFIG is not importable"
+            raise ValueError(message)
+
+        with (
+            patch("django.apps.apps", registry),
+            patch("django.setup", explode),
+            pytest.raises(ValueError, match="LOGGING_CONFIG"),
+        ):
+            ensure_django()


### PR DESCRIPTION
fix(bootstrap): report the failure that stalled Django, not the reentrancy guard (#4207)

## What
`ensure_django()`'s idempotence held only for a COMPLETED `django.setup()`.
`Apps.populate` (django/apps/registry.py:84) sets `loading = True` under no
try/finally, so a setup that dies partway leaves the registry stalled for the
life of the process. Teatree's own fail-safe call sites swallow that first
failure (cli/config_view.py:95, cli/push_gate_tools.py:32, cli/ci.py:77,
cli/agent.py:29), after which every later bootstrap met Django's reentrancy
guard — so the CLI died with `populate() isn't reentrant`, the symptom, with
the real cause gone.

- a bootstrap reached from inside the `populate()` that will configure the same
  registry defers to that frame instead of raising
- the first failure to escape our own `django.setup()` is kept and re-raised as
  the cause of a `DjangoBootstrapStalledError` (a `RuntimeError` subclass, so
  the existing fail-safe handlers behave identically)
- narrowed to `RuntimeError`, so an unrelated failure from a stalled registry
  still propagates unlabelled

Cross-thread bootstrap is untouched: the frame walk is per-thread, so a second
thread still blocks on Django's own lock and returns once ready.

Anti-vacuity: three mutation controls turn the guarding tests RED (frame check
disabled -> 1 failed; stalled conversion dropped -> 3 failed; first failure not
recorded -> 1 failed), and disabling both reproduces the reported
`RuntimeError: populate() isn't reentrant` at registry.py:83.

Open questions & assumptions
- assumed: a stalled process must NOT be auto-recovered. Resetting
  `apps.loading` would re-run `AppConfig.ready()`, which teatree uses to
  register signals and backends (core/apps.py, backends/apps.py), so a retry
  double-registers. Django's guard exists for that reason — this reports
  instead of retrying.
- assumed: matching the live `populate()` frame by code object is acceptable
  coupling to a Django internal. If a future Django decorates `Apps.populate`
  the check degrades to the stalled diagnostic — a clear error, never a crash.
- open: `hooks/scripts/django_bootstrap.py` shares the shape but already fails
  open and dedups its warning, so the first (real) cause is still printed.
  Left unchanged as out of scope.
- open: an orphaned mutmut scratch pair (`pytest.ini` + `setup.cfg`, for an
  unrelated module) was found at the worktree root from a killed run.
  `pytest.ini` outranks `pyproject.toml`, so it silently overrode pytest config
  and forced the affected-tests lane to FULL. Moved aside, not fixed here.

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.