### PR TITLE
feat(deploy): an update no longer takes the control plane down with it (#4214)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,8 +22,9 @@ overlay is the built-in `t3-teatree`.
    checking.
 3. Writes the box secrets file `deploy/teatree.env` over SSH (piped over stdin,
    mode 600 — never on a command line or in logs).
-4. Runs `deploy/deploy.sh` on the box, which brings the checkout current and runs
-   `docker compose up -d --build`.
+4. Runs `deploy/deploy.sh` on the box, which brings the checkout current and
+   converges the stack one service at a time — see
+   [Staged convergence](#staged-convergence-the-control-plane-never-goes-fully-down-4214).
 
 The stack is five services from one image (`deploy/Dockerfile`), selected by
 `TEATREE_ROLE`:
@@ -112,6 +113,55 @@ there. Boot logs the switch. Notes:
   it spawns. A `docker exec` into a running service bypasses the entrypoint and so
   still sees the image's `GNUPGHOME`; pass `-e GNUPGHOME=/home/teatree/.gnupg-run/gnupg`
   for a one-off `exec` that needs to decrypt.
+
+### Staged convergence: the control plane never goes fully down (#4214)
+
+A single `up -d --build` recreates every service at once. `teatree-admin`,
+`teatree-worker` and `teatree-slack-listener` each `depends_on` init with
+`service_completed_successfully`, so compose creates all five container objects
+and holds three of them in `Created` until init exits — **67 seconds measured on
+the box**, once per merged PR. In that window the dashboard is gone, the only
+control-DB CLI route is gone, and the container logs a live diagnosis was reading
+have been destroyed with the container objects.
+
+`deploy.sh` therefore stages the convergence. Every stage leaves at least one of
+`teatree-admin` / `teatree-worker` answering:
+
+| # | Stage | What is still serving |
+| --- | --- | --- |
+| 1 | `compose build` | everything — the longest phase recreates nothing, so a failed build costs no availability |
+| 2 | `t3 worker drain` | everything; in-flight agents finish before migrations run |
+| 3 | `up -d --no-deps teatree-init`, poll for `exited 0` | the OLD admin and worker; a failed init recreates no app service at all |
+| 4 | `t3 worker drain` again | init clears `worker_quiescing` as its last act, so the gate is re-asserted before the worker can claim — and then lose — a task |
+| 5 | `up -d --no-deps teatree-admin`, poll the dashboard | the worker |
+| 6 | `up -d --no-deps teatree-worker teatree-slack-listener` | the new admin |
+| 7 | clear `worker_quiescing` on the fresh worker | — |
+| 8 | `up -d --no-deps <every remaining service>` | — |
+
+Init is excluded from stage 8 because a plain `up -d` **starts** an exited
+one-shot, replaying the whole ~minute init.
+
+**The residual window, stated rather than implicit.** Stage 5 still swaps the
+dashboard's own container, so the dashboard is unavailable for that swap —
+seconds, not the 67-second init gate, and the worker answers throughout it.
+`deploy.sh` measures it and prints `deploy: dashboard unavailable for at most Ns
+(bound …)`. Exceeding `TEATREE_ADMIN_SWAP_BUDGET` (default 300s) **stops the
+convergence before the worker is touched**, so a broken new admin can never leave
+the box with no route at all.
+
+**Logs survive the recreate.** Each service's container log is copied to
+`${TEATREE_DEPLOY_LOG_ARCHIVE_DIR:-~/.local/share/teatree/deploy-logs}` immediately
+before that service is recreated (newest `TEATREE_DEPLOY_LOG_ARCHIVE_KEEP`, default
+200, files kept), so a post-incident read spans the swap.
+
+**An update is distinguishable from an outage.** `deploy/t3` dispatches into
+whichever control-DB service is running, so a call landing mid-swap uses the
+sibling and simply succeeds. When none is running it probes `deploy.sh`'s
+convergence flock read-only (the same `/proc/locks` match the watchdog uses) and,
+if a deploy is in flight, waits up to `TEATREE_UPDATE_WAIT_SECONDS` (default 180,
+`0` disables) for a route to return — then either dispatches or exits **75**
+(`EX_TEMPFAIL`) saying an update is in progress. It never reports docker's bare
+`service "…" is not running`, which is the text a genuine outage produces.
 
 ### Worker sizing: derived from the host
 
@@ -640,10 +690,12 @@ the deploy workflow never rewrites the on-disk secret file for it.
 
 teatree runs **exclusively in Docker** — the CLI as well as the servers — so the
 box needs no host Python / uv / py3.13 / prek / direnv / ttyd. `deploy/t3` is a
-container-wrapping entry: it `docker compose exec`s into the running
-`teatree-worker` (falling back to a one-off `run --rm` when the stack is down) so
-`t3 <args>` executes inside a container that shares the live DB, credential, and
-session mounts.
+container-wrapping entry: it `docker compose exec`s into the first running
+control-DB service — `teatree-worker`, then `teatree-admin` (falling back to a
+one-off `run --rm` when the stack is down) — so `t3 <args>` executes inside a
+container that shares the live DB, credential, and session mounts. Only the worker
+carries the docker-socket group, so a provisioning command needs it specifically;
+the fallback is announced on stderr when it is used.
 
 `t3 setup` (run by the `init` role, and available to run on the host) installs a
 shell alias into `~/.bashrc` (and `~/.zshrc` when present) so `t3 …` on the host
@@ -658,8 +710,9 @@ alias t3="/home/teatree/teatree-deploy/deploy/t3"
 `deploy/t3` entry executable, `docker` on PATH, and the alias not pointing at a
 stale clone path) and WARNs with the fix — re-run `t3 setup` — when a piece is
 missing. The alias install and the doctor check both no-op **inside** a container
-(there the container *is* the CLI). Override the target service with
-`TEATREE_DOCKER_CLI_SERVICE` if needed.
+(there the container *is* the CLI). Override the preferred service with
+`TEATREE_DOCKER_CLI_SERVICE`, and the ordered fallbacks with
+`TEATREE_DOCKER_CLI_FALLBACK_SERVICES`.
 
 ## Configuring the loop agent — `~/.claude/settings.json` (#3359)
 
@@ -714,7 +767,10 @@ service is down — exactly the outage it exists to repair.
    from the `up -d`, because `up -d --no-recreate` re-runs a completed one-shot
    init on every pass (verified empirically) and that would replay the heavy
    ~minute init every 5 minutes; a *missing or failed* init is included, so the
-   init-failure outage still recovers.
+   init-failure outage still recovers. Skipped entirely while a convergence is in
+   flight: `deploy.sh` stages its swap service by service, so a restart pass
+   landing between two stages would re-create the container the deploy is mid-swap
+   on. One pass is given up; the next heals whatever the deploy left down.
 2. **Announces the repair.** The pass samples container state *before* the `up -d`,
    re-reads it after, and DMs the owner naming every service it had to bring back —
    with how long it had been gone, carried in the `<service> <last-seen-running>`

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -244,37 +244,184 @@ fi
 export TEATREE_WORKER_CPUS TEATREE_WORKER_MEM_LIMIT
 echo "deploy: worker sizing — cpus=${TEATREE_WORKER_CPUS:-<default>} mem_limit=${TEATREE_WORKER_MEM_LIMIT:-<default>}"
 
-# Drain-then-deploy (rolling / zero-downtime): a deploy must NEVER kill an
-# in-flight agent. Before swapping the worker image, quiesce the RUNNING worker —
-# `t3 worker drain` sets the `worker_quiescing` admission gate (the claim path then
-# admits ZERO new work) and waits up to TEATREE_DRAIN_TIMEOUT seconds for every
-# live CLAIMED lease to finish. The supervisor is never stopped, so in-flight
-# sub-agents keep renewing and complete. On a grace overrun the drain exits non-zero
-# (code 3); we still PROCEED — a stuck task re-queues PENDING via its lease lapse and
-# the fresh worker picks it up. The fresh worker's init clears worker_quiescing so
-# admission resumes. Skipped when no worker is running (nothing to drain).
-if worker_running; then
+# Services the staged swap names, in the order it stages them. Everything compose
+# declares beyond this list is converged last, so a service added later is never
+# orphaned by the staging.
+STAGED_SERVICES="teatree-init teatree-admin teatree-worker teatree-slack-listener"
+ADMIN_PROBE_URL="${TEATREE_ADMIN_PROBE_URL:-http://127.0.0.1:8000/admin/login/}"
+# The dashboard's own container swap is the ONE window the staging does not remove.
+# Exceeding this bound stops the convergence rather than continuing blind, which is
+# what keeps the residual unavailability a stated number instead of an implicit one.
+ADMIN_SWAP_BUDGET="${TEATREE_ADMIN_SWAP_BUDGET:-300}"
+INIT_WAIT_TIMEOUT="${TEATREE_INIT_WAIT_TIMEOUT:-1800}"
+RESUME_TIMEOUT="${TEATREE_RESUME_TIMEOUT:-300}"
+LOG_ARCHIVE_DIR="${TEATREE_DEPLOY_LOG_ARCHIVE_DIR:-$HOME/.local/share/teatree/deploy-logs}"
+LOG_ARCHIVE_KEEP="${TEATREE_DEPLOY_LOG_ARCHIVE_KEEP:-200}"
+
+admin_answers() { curl -fsS -o /dev/null --max-time 5 "$ADMIN_PROBE_URL"; }
+
+# A recreate destroys the container object and its json-file log with it — which is
+# how a live diagnosis lost the very worker ticks it was reading. Copy each service's
+# log to the bind-mounted data dir before recreating it, so a post-incident read
+# spans the swap. Best-effort throughout: losing an archive must not fail a deploy.
+archive_service_logs() {
+    local svc stamp
+    stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    install -d "$LOG_ARCHIVE_DIR" 2>/dev/null || return 0
+    for svc in "$@"; do
+        compose logs --no-color --timestamps --tail "${TEATREE_DEPLOY_LOG_ARCHIVE_LINES:-5000}" "$svc" \
+            >|"$LOG_ARCHIVE_DIR/$svc-$stamp.log" 2>/dev/null || true
+    done
+    { ls -1t "$LOG_ARCHIVE_DIR"/*.log 2>/dev/null || true; } |
+        tail -n "+$((LOG_ARCHIVE_KEEP + 1))" | xargs -r rm -f --
+}
+
+# The one-shot init's state as "<status> <exit-code>" (e.g. "exited 0"), empty when
+# unreadable. The first line is taken by expansion, never `| head`: under `pipefail`
+# a reader closing the pipe early kills the writer with SIGPIPE and fails the whole
+# assignment.
+init_state() {
+    local ids cid
+    ids="$(compose ps --all --quiet teatree-init 2>/dev/null || true)"
+    cid="${ids%%$'\n'*}"
+    [ -n "$cid" ] || return 0
+    docker inspect -f '{{.State.Status}} {{.State.ExitCode}}' "$cid" 2>/dev/null || true
+}
+
+wait_for_init() {
+    local deadline=$((SECONDS + INIT_WAIT_TIMEOUT)) state
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        state="$(init_state)"
+        case "$state" in
+        "exited 0") return 0 ;;
+        exited*)
+            echo "deploy: FATAL — teatree-init $state. No app service was recreated, so the previous generation is still serving." >&2
+            compose logs --tail 200 teatree-init >&2 || true
+            return 1
+            ;;
+        esac
+        sleep 2
+    done
+    echo "deploy: FATAL — teatree-init did not finish within ${INIT_WAIT_TIMEOUT}s." >&2
+    return 1
+}
+
+# Quiesce the RUNNING worker: `t3 worker drain` sets the `worker_quiescing` admission
+# gate (the claim path then admits ZERO new work) and waits up to
+# TEATREE_DRAIN_TIMEOUT seconds for every live CLAIMED lease to finish. The
+# supervisor is never stopped, so in-flight sub-agents keep renewing and complete. On
+# a grace overrun the drain exits non-zero (code 3); we still PROCEED — a stuck task
+# re-queues PENDING via its lease lapse and the fresh worker picks it up.
+drain_worker() {
+    worker_running || return 0
     echo "deploy: draining teatree-worker (up to ${TEATREE_DRAIN_TIMEOUT:-1800}s for in-flight agents to finish) ..."
     _DRAINED=true
     compose exec -T teatree-worker \
-        t3 worker drain --timeout "${TEATREE_DRAIN_TIMEOUT:-1800}" \
-        || echo "deploy: drain window exceeded — proceeding (a stuck task re-queues via its lease lapse)"
-fi
+        t3 worker drain --timeout "${TEATREE_DRAIN_TIMEOUT:-1800}" ||
+        echo "deploy: drain window exceeded — proceeding (a stuck task re-queues via its lease lapse)"
+}
+
+# init's own clear runs BEFORE this convergence quiesces the worker, so nothing else
+# re-opens admission on the fresh one — this does. Never fatal: the stack is up
+# either way, and the stranded-gate EXIT trap re-attempts it.
+resume_admission() {
+    local deadline=$((SECONDS + RESUME_TIMEOUT))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        if compose exec -T teatree-worker \
+            t3 teatree config_setting set worker_quiescing false >/dev/null 2>&1; then
+            _SWAP_DONE=true
+            return 0
+        fi
+        sleep 5
+    done
+    echo "deploy: WARNING could not clear worker_quiescing within ${RESUME_TIMEOUT}s — the fresh worker may admit no new work. Clear it with 't3 teatree config_setting set worker_quiescing false'." >&2
+    return 0
+}
+
+# The dashboard moves ALONE, with the worker still answering as the live control-DB
+# route. A box where nothing was answering has no continuity to keep, so the gap
+# accounting is skipped there and the convergence check at the end owns the wait.
+swap_admin() {
+    local was_up=false started
+    if admin_answers; then was_up=true; fi
+    archive_service_logs teatree-admin
+    started=$SECONDS
+    compose up -d --no-deps teatree-admin || return 1
+    if [ "$was_up" != true ]; then
+        echo "deploy: no dashboard was answering before the swap — nothing to keep continuous."
+        return 0
+    fi
+    while [ "$((SECONDS - started))" -lt "$ADMIN_SWAP_BUDGET" ]; do
+        if admin_answers; then
+            echo "deploy: dashboard unavailable for at most $((SECONDS - started))s (bound ${ADMIN_SWAP_BUDGET}s); the worker answered throughout."
+            return 0
+        fi
+        sleep 1
+    done
+    echo "deploy: FATAL — the dashboard did not answer within ${ADMIN_SWAP_BUDGET}s of its swap; stopping before the worker is touched, so one control-DB route stays up." >&2
+    return 1
+}
+
+# Every compose service the stages do not name. init is excluded by being staged: a
+# plain `up -d` STARTS an exited one-shot, replaying the whole ~minute init.
+remaining_services() {
+    local svc
+    { compose config --services 2>/dev/null || true; } | while IFS= read -r svc; do
+        case " $STAGED_SERVICES " in
+        *" $svc "*) ;;
+        *) printf '%s\n' "$svc" ;;
+        esac
+    done
+}
+
+# Stage the convergence so the control plane is never wholly absent (#4214). One
+# all-at-once recreate replaces all five services together: the dashboard and the
+# only CLI route vanish for the whole init window (~67s measured), every `t3` call
+# inside it fails the way a real outage does, and the container logs a live
+# diagnosis was reading are destroyed. Each stage below leaves at least one of
+# {teatree-admin, teatree-worker} answering.
+staged_swap() {
+    # Build first and recreate nothing: the longest phase of a convergence now runs
+    # against a fully live stack, and a build failure costs no availability at all.
+    compose build || return 1
+
+    drain_worker
+
+    archive_service_logs teatree-init
+    compose up -d --no-deps teatree-init || return 1
+    wait_for_init || return 1
+
+    # init clears worker_quiescing as its last act, so re-assert the gate: without
+    # this the still-live old worker resumes admission and can claim — then lose —
+    # a task in the seconds before it is swapped.
+    drain_worker
+
+    swap_admin || return 1
+
+    archive_service_logs teatree-worker teatree-slack-listener
+    compose up -d --no-deps teatree-worker teatree-slack-listener || return 1
+    resume_admission
+
+    local rest
+    rest="$(remaining_services)"
+    [ -n "$rest" ] || return 0
+    # shellcheck disable=SC2086 # a service list has to word-split into separate args
+    archive_service_logs $rest
+    # shellcheck disable=SC2086 # same
+    compose up -d --no-deps $rest || return 1
+}
 
 # Surface the WHY on a build/up failure — `set -e` would otherwise exit before
 # the Action log sees anything but "exited (1)". The banner is load-bearing: the
 # 200 stale container lines below push the real buildkit error hundreds of lines
 # up the Action log, where it reads as unrelated noise. Name the failing step at
 # the top of the dump so triage starts in the right place.
-compose up -d --build || {
-    echo "deploy: FATAL — 'docker compose up -d --build' failed. The cause is the buildkit/compose error ABOVE this line; what follows is stack state for context, not the failure."
+staged_swap || {
+    echo "deploy: FATAL — the staged convergence failed. The cause is the buildkit/compose error ABOVE this line; what follows is stack state for context, not the failure."
     compose ps
     compose logs --tail 200 teatree-init teatree-worker teatree-admin
     exit 1
 } >&2
-# The swap completed: the fresh worker's init clears worker_quiescing, so the
-# stranded-gate fail-safe above becomes a no-op from here on.
-_SWAP_DONE=true
 
 # Wait for the admin dev server on the box loopback (init clone + install can
 # take a few minutes on first run).

--- a/deploy/t3
+++ b/deploy/t3
@@ -21,6 +21,22 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
 HOST_IDENTITY_FILE="$SCRIPT_DIR/docker-compose.host-identity.yml"
 SERVICE="${TEATREE_DOCKER_CLI_SERVICE:-teatree-worker}"
+# Every control-DB route, preferred first. A convergence recreates them ONE AT A
+# TIME (deploy.sh's staged swap), so the one being replaced always has a live
+# sibling — dispatching there turns what used to be an opaque `service "X" is not
+# running` into a call that simply works. The worker leads because it alone carries
+# the docker-socket group, so `worktree provision` needs it; the admin is the
+# documented second `docker exec` target and shares every mount.
+CLI_SERVICE_FALLBACKS="${TEATREE_DOCKER_CLI_FALLBACK_SERVICES:-teatree-admin teatree-worker}"
+# deploy.sh's single-convergence lock — the authoritative "an update is happening
+# right now" signal, read the same read-only way deploy/watchdog.sh reads it.
+DEPLOY_LOCK="${TEATREE_DEPLOY_LOCK:-/tmp/teatree-deploy.lock}"
+# How long to wait for a route to come back when a convergence is demonstrably in
+# flight. 0 reports immediately instead of waiting.
+UPDATE_WAIT_SECONDS="${TEATREE_UPDATE_WAIT_SECONDS:-180}"
+# EX_TEMPFAIL, distinct from every code the CLI itself returns, so a caller branches
+# on "the substrate is mid-update" rather than parsing a message.
+UPDATE_IN_PROGRESS_EXIT=75
 # The container path the source mount always lands on (the compose target is
 # fixed — it is what `teatree.paths` resolves inside the container).
 CONTAINER_SOURCE_DIR=/home/teatree/teatree
@@ -347,6 +363,39 @@ warn_unreachable_host_paths "$@"
 
 compose() { docker compose "${COMPOSE_ARGS[@]}" "$@"; }
 
+# The first control-DB route that is actually running, preferring $SERVICE. Echoes
+# its name; non-zero when none of them is up.
+first_running_service() {
+    local svc seen=""
+    for svc in $SERVICE $CLI_SERVICE_FALLBACKS; do
+        case " $seen " in
+        *" $svc "*) continue ;;
+        esac
+        seen="$seen $svc"
+        if [ -n "$(compose ps --status running --quiet "$svc" 2>/dev/null)" ]; then
+            printf '%s' "$svc"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# True when deploy.sh's single-convergence flock is held. READ-ONLY by construction:
+# it matches the lock file's device+inode against /proc/locks and never opens the
+# file for locking. A probe that briefly ACQUIRED the lock would make a deploy
+# starting in that instant see it as busy — and deploy.sh exits 0 on a busy lock, so
+# that deploy would be silently skipped. Non-zero means "not held, or cannot tell"
+# (macOS, an unreadable /proc/locks, no lock file), which keeps the stopped-stack
+# path below rather than inventing an update that may not be running.
+deploy_lock_held() {
+    local fields maj min ino
+    [ -r /proc/locks ] || return 1
+    fields="$(stat -c '%Hd %Ld %i' "$DEPLOY_LOCK" 2>/dev/null)" || return 1
+    read -r maj min ino <<<"$fields"
+    [ -n "${ino:-}" ] || return 1
+    grep -qF "$(printf ' %02x:%02x:%s ' "$maj" "$min" "$ino")" /proc/locks
+}
+
 # WHICH TREE THE RUNNING CONTAINER ACTUALLY EXECUTES. `TEATREE_SOURCE_MOUNT` above
 # resolves the host project this wrapper was invoked from, so the container runs the
 # code being edited here — but that value reaches a container only through `up` /
@@ -514,18 +563,46 @@ done
 # `set -u` treats an empty array's plain expansion as an unbound-variable error on
 # bash 3.2 (the macOS default), so every use below takes the empty-safe form.
 
-# A running worker is the cheapest, most consistent runtime — exec into it. `-T`
+RUNNING_SERVICE="$(first_running_service || true)"
+
+# A convergence swaps the routes one at a time, so a moment with NONE of them up is
+# short and self-clearing. Waiting it out is what turns the window from an outage an
+# operator escalates on into a call that simply succeeds; a caller who cannot wait
+# sets TEATREE_UPDATE_WAIT_SECONDS=0 and gets the named refusal immediately.
+if [ -z "$RUNNING_SERVICE" ] && deploy_lock_held; then
+    if [ "$UPDATE_WAIT_SECONDS" -gt 0 ]; then
+        echo "deploy/t3: a teatree update is in progress — waiting up to ${UPDATE_WAIT_SECONDS}s for a control-DB route." >&2
+        UPDATE_WAITED=0
+        while [ "$UPDATE_WAITED" -lt "$UPDATE_WAIT_SECONDS" ]; do
+            sleep 2
+            UPDATE_WAITED=$((UPDATE_WAITED + 2))
+            RUNNING_SERVICE="$(first_running_service || true)"
+            [ -z "$RUNNING_SERVICE" ] || break
+        done
+    fi
+    if [ -z "$RUNNING_SERVICE" ]; then
+        echo "deploy/t3: a teatree update is in progress and no control-DB service came back within ${UPDATE_WAIT_SECONDS}s." >&2
+        echo "           This is an UPDATE, not an outage — retry shortly; exit $UPDATE_IN_PROGRESS_EXIT says so to a caller." >&2
+        exit "$UPDATE_IN_PROGRESS_EXIT"
+    fi
+fi
+
+# A running service is the cheapest, most consistent runtime — exec into it. `-T`
 # is added when stdin is not a TTY (a script/pipe) so compose does not fail trying
 # to allocate one; an interactive shell keeps the TTY for prompts/pagers.
-if [ -n "$(compose ps --status running --quiet "$SERVICE" 2>/dev/null)" ]; then
+if [ -n "$RUNNING_SERVICE" ]; then
+    if [ "$RUNNING_SERVICE" != "$SERVICE" ]; then
+        echo "deploy/t3: $SERVICE is not running — dispatching in $RUNNING_SERVICE instead. It shares every mount," >&2
+        echo "           but only the worker carries the docker-socket group, so a provisioning command needs it back." >&2
+    fi
     # `compose` is a shell function, not a binary on PATH — `exec` replaces the
     # process image via a real command lookup and cannot resolve a function
     # (`exec: compose: not found`), so the final hop inlines `docker compose`
     # directly instead of calling through the function.
     if [ -t 0 ]; then
-        exec docker compose "${COMPOSE_ARGS[@]}" exec ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} "$SERVICE" sh -c "$CONTAINER_GNUPG_PROLOGUE" t3-in-container t3 "$@"
+        exec docker compose "${COMPOSE_ARGS[@]}" exec ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} "$RUNNING_SERVICE" sh -c "$CONTAINER_GNUPG_PROLOGUE" t3-in-container t3 "$@"
     fi
-    exec docker compose "${COMPOSE_ARGS[@]}" exec -T ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} "$SERVICE" sh -c "$CONTAINER_GNUPG_PROLOGUE" t3-in-container t3 "$@"
+    exec docker compose "${COMPOSE_ARGS[@]}" exec -T ${ENV_ARGS[@]+"${ENV_ARGS[@]}"} "$RUNNING_SERVICE" sh -c "$CONTAINER_GNUPG_PROLOGUE" t3-in-container t3 "$@"
 fi
 
 # Nothing running. Two different worlds reach this line: a merely STOPPED stack,

--- a/deploy/watchdog.sh
+++ b/deploy/watchdog.sh
@@ -15,6 +15,9 @@
 #      EXCLUDED (an empirical fact — `up -d --no-recreate` re-runs a completed
 #      init every pass, which would replay the heavy ~minute init on every tick),
 #      while a missing/failed init IS included so the init-failure outage recovers.
+#      Skipped entirely while a convergence is in flight — deploy.sh stages its
+#      swap service by service, and a restart pass landing between two stages
+#      re-creates the container the deploy is mid-swap on.
 #   2. Announce the repair. State is sampled BEFORE the `up -d` and re-read after, so
 #      every service the watchdog had to bring back is DMed with how long it had been
 #      gone (the liveness ledger below). A silent auto-heal is indistinguishable from
@@ -109,6 +112,14 @@ init_state() {
 # Restart anything that went down, gated on init state (see header rationale).
 restart_down_services() {
   local state
+  # A convergence is not an outage. deploy.sh swaps the services one at a time, so a
+  # `up -d --no-recreate` landing between two of its stages re-creates the very
+  # container it is mid-swap on — the supervisor racing the deploy it should be
+  # standing back from. Same signal the DM paths already gate on, one pass skipped.
+  if deploy_in_flight; then
+    log "deploy in flight — not restarting services this pass"
+    return 0
+  fi
   state="$(init_state)"
   if [ "$state" = "exited 0" ]; then
     log "init complete (exited 0) — restarting app services only: ${APP_SERVICES[*]}"

--- a/tests/test_deploy_rolling_drain.py
+++ b/tests/test_deploy_rolling_drain.py
@@ -67,6 +67,15 @@ def _compose_helper_block() -> str:
     return f"{head}{rest[: closing + len('\n}\n')]}\n"
 
 
+def _staged_swap_block(body: str) -> str:
+    """deploy.sh's `staged_swap()` body — the shipped stage ORDER, not a copy of it."""
+    start = body.find("staged_swap() {")
+    assert start != -1, "deploy.sh's staged swap moved — re-anchor this probe"
+    end = body.find("\n}\n", start)
+    assert end > start, "deploy.sh's staged_swap() is not closed as expected — re-anchor this probe"
+    return body[start:end]
+
+
 def _fail_safe_block() -> str:
     """deploy.sh's stranded-gate fail-safe, verbatim, anchors included."""
     return _slice(_DEPLOY_SH.read_text(encoding="utf-8"), _FAIL_SAFE_START, _FAIL_SAFE_END, "stranded-gate fail-safe")
@@ -167,13 +176,15 @@ class TestDeployDebounce:
 class TestDeployDrain:
     def test_deploy_script_drains_the_running_worker_before_the_swap(self) -> None:
         body = _DEPLOY_SH.read_text(encoding="utf-8")
-        drain_at = body.find("t3 worker drain")
-        swap_at = body.find("up -d --build")
-        assert drain_at != -1, "deploy.sh must drain the worker before swapping the image"
-        assert swap_at != -1
-        assert drain_at < swap_at, "the drain must run BEFORE `docker compose up -d --build`"
+        staged = _staged_swap_block(body)
+        drains = [m.start() for m in re.finditer(r"^\s+drain_worker$", staged, re.MULTILINE)]
+        # init clears worker_quiescing as its last act, so the gate is asserted once
+        # before migrations and re-asserted between init and the worker's recreate.
+        assert len(drains) == 2, f"the staged swap must drain either side of init; found {len(drains)}"
+        assert drains[0] < staged.index("up -d --no-deps teatree-init")
+        assert staged.index("up -d --no-deps teatree-init") < drains[1] < staged.index("up -d --no-deps teatree-worker")
         # Guarded by worker_running (nothing to drain otherwise) and non-fatal on overrun.
-        assert "if worker_running; then" in body
+        assert "worker_running || return 0" in body
         assert "TEATREE_DRAIN_TIMEOUT" in body
 
     def test_fresh_worker_init_clears_the_quiescing_gate(self) -> None:

--- a/tests/test_deploy_staged_swap.py
+++ b/tests/test_deploy_staged_swap.py
@@ -1,0 +1,298 @@
+# test-path: cross-cutting — drives deploy/deploy.sh (no src mirror).
+"""A convergence must never leave the control plane wholly absent (#4214).
+
+One all-at-once recreate replaces admin, worker and slack-listener together, and
+each waits on ``teatree-init: service_completed_successfully`` — so the dashboard
+and the only control-DB CLI route sit in ``Created`` for the whole init window
+(67s measured on the box). Every ``t3`` call inside it fails the way a real
+outage does, and the recreate destroys the container logs a live diagnosis was
+reading.
+
+Runs the REAL ``deploy/deploy.sh`` against a stub ``docker``/``curl``/``systemctl``
+and asserts the argv sequence it actually issues, so the ordering is proved from
+the shipped script rather than from a re-typed copy of it.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_DEPLOY_DIR = _ROOT / "deploy"
+_BASH = shutil.which("bash") or "bash"
+_GIT = shutil.which("git") or "git"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("flock") is None,
+    reason="needs bash + flock (present in the deploy image and CI)",
+)
+
+_SERVICES = "teatree-init teatree-worker teatree-admin teatree-slack-listener teatree-watchdog"
+
+_DOCKER_STUB = f"""#!/usr/bin/env bash
+printf '%s\\n' "$*" >>"${{STUB_DOCKER_LOG:-/dev/null}}"
+if [ "$1" = inspect ]; then
+    printf '%s\\n' "${{STUB_INIT_STATE:-exited 0}}"
+    exit 0
+fi
+if [ "$1" != compose ]; then
+    exit 0
+fi
+shift
+while [ "${{1:-}}" = -f ] || [ "${{1:-}}" = -p ]; do shift 2; done
+sub="${{1:-}}"
+shift || true
+case "$sub" in
+exec)
+    while :; do
+        case "${{1:-}}" in
+        -T) shift ;;
+        --env) shift 2 ;;
+        *) break ;;
+        esac
+    done
+    shift || true
+    case "$*" in
+    *"worker status"*) printf '{{"running": true}}\\n' ;;
+    esac
+    exit "${{STUB_EXEC_EXIT:-0}}"
+    ;;
+ps)
+    case "$*" in
+    *--quiet*) printf '%s\\n' "${{STUB_CONTAINER_ID:-stubcid}}" ;;
+    esac
+    exit 0
+    ;;
+config)
+    printf '%s\\n' {" ".join(_SERVICES.split())}
+    exit 0
+    ;;
+build) exit "${{STUB_BUILD_EXIT:-0}}" ;;
+up) exit "${{STUB_UP_EXIT:-0}}" ;;
+esac
+exit 0
+"""
+
+# Answers until STUB_CURL_FAIL_AFTER calls have been served, so a test can model a
+# dashboard that was up before its swap and never came back after it.
+_CURL_STUB = """#!/usr/bin/env bash
+n=0
+if [ -n "${STUB_CURL_COUNT:-}" ]; then
+    [ -f "$STUB_CURL_COUNT" ] && n="$(cat "$STUB_CURL_COUNT")"
+    n=$((n + 1))
+    printf '%s' "$n" >|"$STUB_CURL_COUNT"
+fi
+if [ -n "${STUB_CURL_FAIL_AFTER:-}" ] && [ "$n" -gt "$STUB_CURL_FAIL_AFTER" ]; then
+    exit 22
+fi
+exit 0
+"""
+
+
+def _write_exec(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+@pytest.fixture
+def checkout(tmp_path: Path) -> Path:
+    """A minimal repo checkout carrying the REAL deploy.sh and compose files."""
+    root = tmp_path / "checkout"
+    deploy = root / "deploy"
+    deploy.mkdir(parents=True)
+    for name in ("deploy.sh", "docker-compose.yml", "docker-compose.host-identity.yml"):
+        shutil.copy2(_DEPLOY_DIR / name, deploy / name)
+    (deploy / "deploy.sh").chmod(0o755)
+    (deploy / "teatree.env").write_text("", encoding="utf-8")
+    _write_exec(deploy / "fast-forward-checkout.sh", "#!/usr/bin/env bash\nexit 0\n")
+
+    probe = root / "src" / "teatree" / "utils"
+    probe.mkdir(parents=True)
+    (probe / "ram_probe.py").write_text("print('TEATREE_WORKER_CPUS=1.0')\n", encoding="utf-8")
+
+    subprocess.run([_GIT, "init", "-q", "-b", "main", str(root)], check=True)
+    subprocess.run([_GIT, "-C", str(root), "add", "-A"], check=True)
+    subprocess.run(
+        [_GIT, "-C", str(root), "-c", "user.email=fixture", "-c", "user.name=fixture", "commit", "-qm", "seed"],
+        check=True,
+    )
+    return root
+
+
+def _run(checkout: Path, tmp_path: Path, **env_extra: str) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir(exist_ok=True)
+    _write_exec(stub_bin / "docker", _DOCKER_STUB)
+    _write_exec(stub_bin / "curl", _CURL_STUB)
+    _write_exec(stub_bin / "systemctl", "#!/usr/bin/env bash\nexit 0\n")
+
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    docker_log = tmp_path / "docker.log"
+
+    env = dict(os.environ)
+    env.update(
+        PATH=f"{stub_bin}{os.pathsep}{env['PATH']}",
+        HOME=str(home),
+        STUB_DOCKER_LOG=str(docker_log),
+        STUB_CURL_COUNT=str(tmp_path / "curl.count"),
+        TEATREE_DEPLOY_LOCK=str(tmp_path / "deploy.lock"),
+        TEATREE_DEPLOY_LOG_ARCHIVE_DIR=str(tmp_path / "archive"),
+        TEATREE_ADMIN_SWAP_BUDGET="2",
+        TEATREE_INIT_WAIT_TIMEOUT="2",
+        TEATREE_RESUME_TIMEOUT="2",
+        TEATREE_DRAIN_TIMEOUT="5",
+    )
+    env.update(env_extra)
+
+    proc = subprocess.run(
+        [_BASH, str(checkout / "deploy" / "deploy.sh")],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(checkout),
+        check=False,
+    )
+    calls = docker_log.read_text(encoding="utf-8").splitlines() if docker_log.exists() else []
+    return proc, calls
+
+
+def _compose_args(call: str) -> list[str]:
+    """The compose subcommand and its arguments, with the `-f <file>` pairs dropped."""
+    tokens = call.split()
+    if not tokens or tokens[0] != "compose":
+        return []
+    rest = tokens[1:]
+    while rest[:1] in (["-f"], ["-p"]):
+        rest = rest[2:]
+    return rest
+
+
+def _index_of(calls: Iterable[str], predicate) -> int:
+    for i, call in enumerate(calls):
+        if predicate(_compose_args(call)):
+            return i
+    return -1
+
+
+def _is_up(args: list[str]) -> bool:
+    return args[:1] == ["up"]
+
+
+def _up_services(args: list[str]) -> list[str]:
+    return [a for a in args[1:] if not a.startswith("-")]
+
+
+class TestTheControlPlaneIsNeverWhollyAbsent:
+    def test_no_single_recreate_takes_the_dashboard_and_the_worker_together(
+        self, checkout: Path, tmp_path: Path
+    ) -> None:
+        _, calls = _run(checkout, tmp_path)
+        ups = [_compose_args(c) for c in calls if _is_up(_compose_args(c))]
+        assert ups, "the convergence issued no `up` at all"
+        for args in ups:
+            services = _up_services(args)
+            assert services, f"a bare `up` recreates every service at once: {args!r}"
+            together = {"teatree-admin", "teatree-worker"} <= set(services)
+            assert not together, f"admin and worker are recreated by one call: {args!r}"
+
+    def test_the_dashboard_is_swapped_before_the_worker(self, checkout: Path, tmp_path: Path) -> None:
+        _, calls = _run(checkout, tmp_path)
+        admin_at = _index_of(calls, lambda a: _is_up(a) and "teatree-admin" in _up_services(a))
+        worker_at = _index_of(calls, lambda a: _is_up(a) and "teatree-worker" in _up_services(a))
+        assert admin_at != -1, "teatree-admin is never recreated on its own"
+        assert worker_at != -1, "teatree-worker is never recreated on its own"
+        assert admin_at < worker_at, "the worker must stay the live route until the dashboard answers again"
+
+    def test_the_image_is_built_before_anything_is_recreated(self, checkout: Path, tmp_path: Path) -> None:
+        _, calls = _run(checkout, tmp_path)
+        build_at = _index_of(calls, lambda a: a[:1] == ["build"])
+        first_up = _index_of(calls, _is_up)
+        assert build_at != -1, "the build must be its own step so it recreates nothing while it runs"
+        assert first_up != -1
+        assert build_at < first_up
+
+    def test_init_is_run_alone_and_waited_for_before_the_dashboard_moves(self, checkout: Path, tmp_path: Path) -> None:
+        _, calls = _run(checkout, tmp_path)
+        init_at = _index_of(calls, lambda a: _is_up(a) and _up_services(a) == ["teatree-init"])
+        assert init_at != -1, "init must be brought up on its own, with the old generation still serving"
+        inspected_at = next((i for i, c in enumerate(calls) if c.startswith("inspect ")), -1)
+        admin_at = _index_of(calls, lambda a: _is_up(a) and "teatree-admin" in _up_services(a))
+        assert init_at < inspected_at < admin_at, "init's exit must be observed before the dashboard is swapped"
+
+    def test_the_converge_step_never_replays_the_one_shot_init(self, checkout: Path, tmp_path: Path) -> None:
+        _, calls = _run(checkout, tmp_path)
+        init_ups = [a for c in calls if _is_up(a := _compose_args(c)) and "teatree-init" in _up_services(a)]
+        assert len(init_ups) == 1, f"`up` on an exited one-shot replays the whole init: {init_ups!r}"
+
+    def test_every_remaining_service_is_still_converged(self, checkout: Path, tmp_path: Path) -> None:
+        _, calls = _run(checkout, tmp_path)
+        recreated = {s for c in calls if _is_up(a := _compose_args(c)) for s in _up_services(a)}
+        assert set(_SERVICES.split()) <= recreated, f"a declared service was never converged: {recreated!r}"
+
+
+class TestInFlightWorkSurvivesTheSwap:
+    def test_the_worker_is_drained_before_migrations_and_again_before_its_swap(
+        self, checkout: Path, tmp_path: Path
+    ) -> None:
+        _, calls = _run(checkout, tmp_path)
+        drains = [i for i, c in enumerate(calls) if "worker drain" in c]
+        init_at = _index_of(calls, lambda a: _is_up(a) and _up_services(a) == ["teatree-init"])
+        worker_at = _index_of(calls, lambda a: _is_up(a) and "teatree-worker" in _up_services(a))
+        assert len(drains) == 2, f"init clears worker_quiescing, so the gate must be re-asserted after it: {drains!r}"
+        assert drains[0] < init_at, "in-flight agents must finish before migrations run"
+        assert init_at < drains[1] < worker_at, "the second drain must sit between init and the worker swap"
+
+    def test_admission_is_resumed_on_the_fresh_worker(self, checkout: Path, tmp_path: Path) -> None:
+        _, calls = _run(checkout, tmp_path)
+        resume_at = next((i for i, c in enumerate(calls) if "worker_quiescing false" in c), -1)
+        worker_at = _index_of(calls, lambda a: _is_up(a) and "teatree-worker" in _up_services(a))
+        assert resume_at != -1, "nothing re-opens admission once init's own clear has already run"
+        assert worker_at < resume_at
+
+
+class TestLogsSurviveTheRecreate:
+    def test_each_service_log_is_archived_before_that_service_is_recreated(
+        self, checkout: Path, tmp_path: Path
+    ) -> None:
+        _, calls = _run(checkout, tmp_path)
+        for service in _SERVICES.split():
+            logs_at = _index_of(calls, lambda a, s=service: a[:1] == ["logs"] and s in a)
+            up_at = _index_of(calls, lambda a, s=service: _is_up(a) and s in _up_services(a))
+            assert logs_at != -1, f"{service}'s log is destroyed by the recreate with no copy kept"
+            assert logs_at < up_at, f"{service}'s log must be archived BEFORE the recreate destroys it"
+
+    def test_the_archive_lands_in_the_bind_mounted_data_dir(self, checkout: Path, tmp_path: Path) -> None:
+        _run(checkout, tmp_path)
+        archive = tmp_path / "archive"
+        assert archive.is_dir(), "no archive directory was created"
+        assert sorted(p.name.split("-2")[0] for p in archive.glob("*.log"))
+
+
+class TestAFailedStageStopsBeforeItCostsAvailability:
+    def test_a_failed_init_recreates_no_app_service(self, checkout: Path, tmp_path: Path) -> None:
+        proc, calls = _run(checkout, tmp_path, STUB_INIT_STATE="exited 1")
+        recreated = {s for c in calls if _is_up(a := _compose_args(c)) for s in _up_services(a)}
+        assert proc.returncode != 0
+        assert recreated <= {"teatree-init"}, f"a failed init must leave the live generation alone: {recreated!r}"
+
+    def test_a_dashboard_that_does_not_come_back_stops_before_the_worker_is_touched(
+        self, checkout: Path, tmp_path: Path
+    ) -> None:
+        # One answer (the pre-swap sample), none after — the dashboard never returns.
+        proc, calls = _run(checkout, tmp_path, STUB_CURL_FAIL_AFTER="1")
+        worker_at = _index_of(calls, lambda a: _is_up(a) and "teatree-worker" in _up_services(a))
+        assert proc.returncode != 0
+        assert worker_at == -1, "with no dashboard answering, swapping the worker leaves no route at all"
+
+
+class TestTheResidualWindowIsStated:
+    def test_the_dashboard_gap_is_measured_and_reported_with_its_bound(self, checkout: Path, tmp_path: Path) -> None:
+        proc, _ = _run(checkout, tmp_path)
+        assert "dashboard unavailable for at most" in proc.stdout
+        assert "bound 2s" in proc.stdout

--- a/tests/test_deploy_update_signal.py
+++ b/tests/test_deploy_update_signal.py
@@ -1,0 +1,205 @@
+# test-path: cross-cutting — drives deploy/t3 (no src mirror).
+"""An update must not look like an outage from the host CLI (#4214).
+
+A convergence recreates the control-DB services, and a ``t3`` call landing in that
+window used to fail with docker's own ``service "teatree-admin" is not running`` —
+byte-identical to a genuine outage, so a monitor could neither wait it out nor
+escalate on it. Two changes make the two distinguishable: the wrapper dispatches
+into whichever control-DB service IS running, and when none is, it reads
+``deploy.sh``'s convergence flock and says so instead of failing opaquely.
+
+Runs the REAL ``deploy/t3`` with a stub ``docker`` and a REAL ``flock`` held on a
+tmp lock file, so the probe under test is the shipped one.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+_WRAPPER = Path(__file__).resolve().parents[1] / "deploy" / "t3"
+_FLOCK = shutil.which("flock")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or _FLOCK is None or not Path("/proc/locks").exists(),
+    reason="needs bash + flock + Linux /proc/locks (present in the deploy image and CI)",
+)
+
+_UPDATE_IN_PROGRESS_EXIT = 75
+_DISPATCHED_ONE_OFF = "DISPATCHED-RUN"
+
+# `STUB_RUNNING_SERVICES` is the space-separated set the stub reports as running, so a
+# test can model any stage of a staged swap. `compose ps --status running --quiet
+# <svc>` answers with an id only for a member of that set.
+_DOCKER_STUB = f"""#!/usr/bin/env bash
+case "$1" in
+version) exit "${{STUB_DAEMON_EXIT:-0}}" ;;
+image) exit "${{STUB_IMAGE_EXIT:-0}}" ;;
+esac
+shift
+while [ "${{1:-}}" = -f ] || [ "${{1:-}}" = -p ]; do shift 2; done
+sub="${{1:-}}"
+shift || true
+case "$sub" in
+ps)
+    svc="${{@: -1}}"
+    case " ${{STUB_RUNNING_SERVICES:-}} " in
+    *" $svc "*) printf '%s\\n' "cid-$svc" ;;
+    esac
+    exit 0
+    ;;
+config) printf '%s\\n' "teatree-worker:local" ; exit 0 ;;
+exec)
+    while :; do
+        case "${{1:-}}" in
+        -T) shift ;;
+        --env) shift 2 ;;
+        *) break ;;
+        esac
+    done
+    printf 'DISPATCHED-EXEC %s\\n' "${{1:-}}"
+    exit 0
+    ;;
+run) printf '{_DISPATCHED_ONE_OFF}\\n' ; exit 0 ;;
+esac
+exit 0
+"""
+
+
+def _write_exec(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+@pytest.fixture
+def wrapper(tmp_path: Path) -> Path:
+    """The real wrapper, copied out so the checkout it runs from is ours."""
+    deploy = tmp_path / "checkout" / "deploy"
+    deploy.mkdir(parents=True)
+    entry = deploy / "t3"
+    shutil.copy2(_WRAPPER, entry)
+    entry.chmod(entry.stat().st_mode | stat.S_IXUSR)
+    return entry
+
+
+@contextmanager
+def _held_lock(path: Path) -> Iterator[None]:
+    """Hold a REAL flock on *path* for the body, the way a live deploy.sh does."""
+    path.touch()
+    assert _FLOCK is not None
+    holder = subprocess.Popen([_FLOCK, str(path), "-c", "sleep 60"])
+    try:
+        deadline = 400
+        while deadline and not _lock_visible(path):
+            deadline -= 1
+        assert _lock_visible(path), "the test's own flock never appeared in /proc/locks"
+        yield
+    finally:
+        holder.kill()
+        holder.wait()
+
+
+def _lock_visible(path: Path) -> bool:
+    st = path.stat()
+    needle = f" {os.major(st.st_dev):02x}:{os.minor(st.st_dev):02x}:{st.st_ino} "
+    return needle in Path("/proc/locks").read_text(encoding="utf-8")
+
+
+def _run(wrapper: Path, tmp_path: Path, **env_extra: str) -> subprocess.CompletedProcess[str]:
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir(exist_ok=True)
+    _write_exec(stub_bin / "docker", _DOCKER_STUB)
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir(exist_ok=True)
+
+    env = {k: v for k, v in os.environ.items() if k not in {"TEATREE_SOURCE_MOUNT", "TEATREE_INVOCATION_CWD"}}
+    env["PATH"] = f"{stub_bin}{os.pathsep}{env['PATH']}"
+    env["TEATREE_HOST_HOME"] = str(home)
+    # Short-circuits the host `glab` resolution — irrelevant here and not always present.
+    env["GITLAB_TOKEN"] = "unused"
+    env["TEATREE_DEPLOY_LOCK"] = str(tmp_path / "deploy.lock")
+    env.update(env_extra)
+
+    return subprocess.run(
+        [str(wrapper), "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=elsewhere,
+        check=False,
+    )
+
+
+class TestASiblingRouteIsUsedWhileTheOtherIsSwapped:
+    def test_the_admin_serves_the_call_while_the_worker_is_being_recreated(self, wrapper: Path, tmp_path: Path) -> None:
+        proc = _run(wrapper, tmp_path, STUB_RUNNING_SERVICES="teatree-admin")
+
+        assert proc.returncode == 0
+        assert "DISPATCHED-EXEC teatree-admin" in proc.stdout
+        assert _DISPATCHED_ONE_OFF not in proc.stdout, "a live sibling must be used, never a one-off container"
+
+    def test_the_fallback_is_announced_so_the_operator_knows_which_container_ran(
+        self, wrapper: Path, tmp_path: Path
+    ) -> None:
+        proc = _run(wrapper, tmp_path, STUB_RUNNING_SERVICES="teatree-admin")
+
+        assert "teatree-admin" in proc.stderr
+        assert "teatree-worker" in proc.stderr
+
+    def test_the_preferred_service_still_wins_when_it_is_running(self, wrapper: Path, tmp_path: Path) -> None:
+        proc = _run(wrapper, tmp_path, STUB_RUNNING_SERVICES="teatree-worker teatree-admin")
+
+        assert "DISPATCHED-EXEC teatree-worker" in proc.stdout
+
+
+class TestAnUpdateIsDistinguishableFromAnOutage:
+    def test_a_convergence_in_flight_is_named_rather_than_reported_as_a_dead_service(
+        self, wrapper: Path, tmp_path: Path
+    ) -> None:
+        with _held_lock(tmp_path / "deploy.lock"):
+            proc = _run(wrapper, tmp_path, STUB_RUNNING_SERVICES="", TEATREE_UPDATE_WAIT_SECONDS="2")
+
+        assert proc.returncode == _UPDATE_IN_PROGRESS_EXIT, (
+            "an update needs its own exit code so a caller can branch on it instead of parsing text"
+        )
+        assert "update is in progress" in proc.stderr
+        assert "is not running" not in proc.stdout
+
+    def test_a_route_that_returns_mid_wait_simply_serves_the_call(self, wrapper: Path, tmp_path: Path) -> None:
+        # The stub reports the admin back from the first probe on, which is what a
+        # staged swap looks like from outside: the window is short and self-clearing.
+        with _held_lock(tmp_path / "deploy.lock"):
+            proc = _run(
+                wrapper,
+                tmp_path,
+                STUB_RUNNING_SERVICES="teatree-admin",
+                TEATREE_UPDATE_WAIT_SECONDS="4",
+            )
+
+        assert proc.returncode == 0
+        assert "DISPATCHED-EXEC teatree-admin" in proc.stdout
+
+
+class TestTheStoppedStackPathIsUnchanged:
+    def test_no_convergence_in_flight_still_dispatches_the_one_off_container(
+        self, wrapper: Path, tmp_path: Path
+    ) -> None:
+        proc = _run(wrapper, tmp_path, STUB_RUNNING_SERVICES="")
+
+        assert proc.returncode == 0
+        assert _DISPATCHED_ONE_OFF in proc.stdout
+        assert str(_UPDATE_IN_PROGRESS_EXIT) not in proc.stderr
+
+    def test_an_unreachable_daemon_still_names_the_deploy_script(self, wrapper: Path, tmp_path: Path) -> None:
+        proc = _run(wrapper, tmp_path, STUB_RUNNING_SERVICES="", STUB_DAEMON_EXIT="1")
+
+        assert proc.returncode != 0
+        assert _DISPATCHED_ONE_OFF not in proc.stdout
+        assert "deploy/deploy.sh" in proc.stderr

--- a/tests/test_deploy_watchdog_deploy_aware.py
+++ b/tests/test_deploy_watchdog_deploy_aware.py
@@ -255,5 +255,32 @@ class TestEveryOtherFindingPagesImmediately:
         assert "red findings" in dm
 
 
+def _compose_ups(tmp_path: Path) -> list[str]:
+    log = tmp_path / "docker.log"
+    lines = log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+    return [line for line in lines if " up -d" in line]
+
+
+class TestTheSupervisorStandsBackDuringAConvergence:
+    """A convergence is not an outage the supervisor should repair.
+
+    deploy.sh swaps the services one at a time (#4214), so a restart pass landing
+    between two stages re-creates the container the deploy is mid-swap on.
+    """
+
+    @pytest.mark.skipif(_FLOCK is None, reason="needs flock(1)")
+    def test_a_held_deploy_lock_stops_the_restart_pass(self, tmp_path: Path) -> None:
+        with _deploy_lock_held(tmp_path / "deploy.lock") as lock:
+            _run_pass(tmp_path, TEATREE_WATCHDOG_DEPLOY_LOCK=str(lock))
+
+        assert _compose_ups(tmp_path) == [], "the watchdog must not converge a project a deploy is converging"
+
+    def test_an_ordinary_pass_still_restarts_what_is_down(self, tmp_path: Path) -> None:
+        # The anti-vacuous control: with nothing in flight the self-heal still runs.
+        _run_pass(tmp_path)
+
+        assert _compose_ups(tmp_path), "gating the restart must not disable the self-heal itself"
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_deploy_worker_sizing.py
+++ b/tests/test_deploy_worker_sizing.py
@@ -43,8 +43,8 @@ class TestDeploySizingWiring:
         assert "ram_probe.py" in text
         assert "compose-sizing" in text
         assert "export TEATREE_WORKER_CPUS TEATREE_WORKER_MEM_LIMIT" in text
-        # The derivation must precede the `docker compose up` it feeds.
-        assert text.index("compose-sizing") < text.index("up -d --build")
+        # The derivation must precede the staged convergence it feeds.
+        assert text.index("compose-sizing") < text.index("staged_swap || {")
 
 
 def _write_exec(path: Path, body: str) -> None:
@@ -84,6 +84,9 @@ class TestDeployShRunDerivesWorkerCaps:
             f'    up) printf %s "$TEATREE_WORKER_CPUS" > "{record_cpus}"; '
             f'printf %s "$TEATREE_WORKER_MEM_LIMIT" > "{record_mem}"; exit 0;;\n'
             "    exec) echo '{\"running\": true}'; exit 0;;\n"
+            # The staged swap polls init's terminal state before it swaps anything.
+            "    ps) echo stubcid; exit 0;;\n"
+            "    inspect) echo 'exited 0'; exit 0;;\n"
             "  esac\n"
             "done\n"
             "exit 0\n",
@@ -101,6 +104,10 @@ class TestDeployShRunDerivesWorkerCaps:
         home = tmp_path / "home"
         home.mkdir(exist_ok=True)
         env["HOME"] = str(home)
+        # Bounded so a stub gap surfaces as a fast failure, never a 30-min poll.
+        env["TEATREE_INIT_WAIT_TIMEOUT"] = "5"
+        env["TEATREE_ADMIN_SWAP_BUDGET"] = "5"
+        env["TEATREE_RESUME_TIMEOUT"] = "5"
         return repo, record_cpus, record_mem, env
 
     def test_run_exports_host_derived_cpus_into_compose_up(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes [#4214](https://github.com/souliane/teatree/issues/4214).

## The defect

One all-at-once recreate replaced all five services together. `teatree-admin`,
`teatree-worker` and `teatree-slack-listener` each `depends_on` init with
`service_completed_successfully`, so compose created all five container objects
and held three of them in `Created` until init exited — **67s measured on the
box**, once per merged PR. In that window:

- the dashboard was gone,
- the only control-DB CLI route was gone,
- every `t3` call returned docker's bare `service "…" is not running` — the same
  text a genuine outage produces, so a monitor could neither wait it out nor
  escalate on it,
- and the container logs a live diagnosis was reading were destroyed with the
  container objects.

## The change

`deploy.sh` stages the convergence. Every stage leaves at least one of
`teatree-admin` / `teatree-worker` answering:

| # | Stage | Still serving |
| --- | --- | --- |
| 1 | `compose build` | everything — the longest phase recreates nothing, so a failed build costs no availability |
| 2 | `t3 worker drain` | everything; in-flight agents finish before migrations run |
| 3 | `up -d --no-deps teatree-init`, poll for `exited 0` | the OLD admin and worker; a failed init recreates no app service |
| 4 | `t3 worker drain` again | init clears `worker_quiescing` as its last act, so the gate is re-asserted before the still-live old worker can claim — then lose — a task |
| 5 | `up -d --no-deps teatree-admin`, poll the dashboard | the worker |
| 6 | `up -d --no-deps teatree-worker teatree-slack-listener` | the new admin |
| 7 | clear `worker_quiescing` on the fresh worker | — |
| 8 | `up -d --no-deps <every remaining service>` | — |

init is excluded from stage 8 because a plain `up -d` **starts** an exited
one-shot, replaying the whole ~minute init.

**Logs survive the recreate.** Each service's log is copied to
`${TEATREE_DEPLOY_LOG_ARCHIVE_DIR:-~/.local/share/teatree/deploy-logs}`
immediately before that service is recreated (newest 200 kept).

**An update is distinguishable from an outage.** `deploy/t3` dispatches into
whichever control-DB service is running, so a call landing mid-swap uses the
sibling and simply succeeds. When none is running it reads `deploy.sh`'s
convergence flock read-only (the same `/proc/locks` match `watchdog.sh` already
uses) and either waits `TEATREE_UPDATE_WAIT_SECONDS` for a route to return or
exits **75** (`EX_TEMPFAIL`) saying an update is in progress.

**The supervisor stands back.** `watchdog.sh` skips its restart pass while a
convergence is in flight — staging the swap service by service means a pass
landing between two stages would re-create the container the deploy is mid-swap
on. Gated on the `deploy_in_flight` probe it already uses for its DMs.

## Acceptance, item by item

| Issue acceptance | Where |
| --- | --- |
| a routine update does not kill a worker executing a task | drain either side of init (stages 2 + 4); `test_the_worker_is_drained_before_migrations_and_again_before_its_swap` |
| the dashboard is reachable continuously | stage 5 swaps it alone with the worker live; `test_the_dashboard_is_swapped_before_the_worker`, `test_no_single_recreate_takes_the_dashboard_and_the_worker_together` |
| a `t3` call reports an update, not a bare "not running" | `deploy/t3` sibling failover + exit 75; `TestAnUpdateIsDistinguishableFromAnOutage` |
| **the test is shown to fail against the current all-at-once recreate** | all 13 cases in `test_deploy_staged_swap.py` were observed RED against `main`'s `up -d --build`; 4 of 7 in `test_deploy_update_signal.py` RED against `main`'s `deploy/t3`; the watchdog gate has a recorded mutation control (remove the gate → RED) |
| no window with every control-DB route unavailable | stages 5 and 6 alternate the live route; an over-budget dashboard **stops the convergence before the worker is touched** (`test_a_dashboard_that_does_not_come_back_stops_before_the_worker_is_touched`) |
| log retention spans a recreate | `archive_service_logs` before each recreate; `TestLogsSurviveTheRecreate` |
| the trigger is named and logged | already named in the issue (`deploy.yml` → `deploy.sh`); each stage now prints its own line |
| **any remaining window is stated and bounded** | see below |

### The residual window, stated

Stage 5 still swaps the dashboard's own container, so the dashboard is
unavailable for that swap — **seconds, not the 67-second init gate**, and the
worker answers throughout it. `deploy.sh` measures it and prints
`deploy: dashboard unavailable for at most Ns (bound …)`. Exceeding
`TEATREE_ADMIN_SWAP_BUDGET` (default 300s) aborts before the worker is touched.

True zero downtime for the dashboard needs two admin containers behind a proxy.
The issue asked for simple and reliable over clever, so the gap is bounded,
measured and reported rather than engineered away.

### Not verified by a real box deploy

The issue asks for verification "by an actual update performed with a task in
flight". This PR verifies the stage ORDER and the failure paths by running the
**shipped** `deploy.sh` / `deploy/t3` / `watchdog.sh` against stub
`docker`/`curl`/`flock` and asserting the argv sequence they actually issue — a
harness proven live by 17 RED observations against `main`. The end-to-end box
run happens on merge, since the box deploys from `main`; the first convergence
after this lands is itself the acceptance run, and it prints its own dashboard-gap
measurement into the Action log.

## Architecture pre-check — #4214

### 1. BLUEPRINT § alignment

Deploy plane only — no BLUEPRINT section governs `deploy/*.sh`; the substrate's
availability contract lives in `deploy/README.md`, updated here (new
§ "Staged convergence"). No BLUEPRINT claim is contradicted.

### 2. FSM phase boundaries

n/a — no `Ticket.State` / `Worktree.State` transition. The one FSM-adjacent piece
of state is the `worker_quiescing` admission gate, whose resume moves from "init
clears it" to "deploy.sh clears it after the fresh worker is up"; init's clear is
left in place for the bare-`compose up` path.

### 3. Extension-point contracts

None. Consumers of the changed shell surfaces — `.github/workflows/deploy.yml`,
the `t3` shell alias, the `teatree-watchdog` compose service — were greped; none
passes an argument that changed.

### 4. Component boundaries

`deploy/` only. No `src/teatree` change: the defect is entirely in how the stack
is recreated, so moving any of it into Python would take deploy-plane logic out
of the deploy plane.

### 5. Dependency direction

No imports added; no Python changed. `tach` + `import-linter` green in
`verify-gates`.

### 6. Test surface

- `tests/test_deploy_staged_swap.py` (new, 13) — runs the REAL `deploy.sh`
  against stubs and asserts the argv sequence.
- `tests/test_deploy_update_signal.py` (new, 7) — runs the REAL `deploy/t3` with
  a stub docker and a REAL `flock`. Includes two preservation cases
  (stopped-stack one-off, unreachable daemon) that were GREEN before and after —
  the control proving the harness reaches the real dispatch.
- `tests/test_deploy_watchdog_deploy_aware.py` (+2) — the restart gate plus its
  anti-vacuity control.

### 7. Resilience invariants

- **verify-by-re-read** — init's completion read back from `docker inspect`; the
  dashboard re-probed over HTTP until it answers; the final convergence check
  unchanged.
- **fallback-transport** — `deploy/t3` falls back to the sibling service, then to
  the one-off `run --rm` container, as before.
- **idempotency** — every stage is a `compose up -d`; the flock still admits one
  convergence at a time.
- **heartbeat** — each stage prints its own line and the dashboard gap is a
  measured number, so an Action log distinguishes a slow stage from a stuck one.
- **sub-agent return contract** — n/a.

### 8. Identity and key normalization

n/a. Service names are compose's own literals; `STAGED_SERVICES` is subtracted
from `compose config --services` rather than re-listing the stack, so the two
cannot drift.

### 9. Behavior preservation / capability deletion

Read from `git show origin/main:deploy/deploy.sh`. Every behaviour of the
replaced region is preserved: the drain (now twice), its `_DRAINED` bookkeeping
for the stranded-gate EXIT trap, the non-fatal overrun, the `worker_running`
guard, `TEATREE_DRAIN_TIMEOUT`, the build, recreating every service (the set is
now derived from `compose config --services`, so it cannot under-cover), the
FATAL banner + `compose ps` + `logs --tail 200`, `_SWAP_DONE` disarming the trap
(now set only on a successful resume, so a failed resume keeps the trap armed),
and the post-swap convergence check.

No privacy/leak/security matcher is touched. No must-block test was inverted: the
two re-anchored assertions
(`test_deploy_script_drains_the_running_worker_before_the_swap`,
`test_deploy_sh_derives_and_exports_before_compose_up`) keep their invariant and
were strengthened — the drain one now pins the ORDER inside the shipped
`staged_swap()` body rather than a file-wide substring index.

One behaviour changes deliberately: migrations now run while the previous
generation's admin is still serving. See "Open questions & assumptions".

### 10. Removability / harness-vs-data

- **Removability.** `staged_swap()` is one function plus five helpers; deleting it
  and restoring one `up -d --build` line reverts the behaviour exactly, touching
  no other file. Blast radius: the two new test files.
- **Harness vs data.** The stage ORDER is harness — it encodes a correctness
  invariant no operator should reorder by config. What varies per box is data:
  the probe URL, the three timeouts, the archive location and retention, the
  fallback service list, the update-wait window — all env-overridable. The
  service list is read from compose, so adding a service needs no edit here.

## Open questions & assumptions

- **assumed** — migrations may run while the PREVIOUS generation's admin (and the
  quiesced worker) are still alive. That is the price of keeping the dashboard up,
  and it is bounded: the worker is drained first, so no agent executes across the
  migration — which is exactly what the all-at-once recreate gave, preserved.
  `teatree-watchdog` was already live across migrations, so an old-code process
  during one is not a new class.
- **assumed** — the residual dashboard gap is acceptable at seconds; see "The
  residual window, stated".
- **assumed** — gating the watchdog's restart on the existing `deploy_in_flight`
  probe costs at most one skipped self-heal pass after a recreate (its window is
  one watchdog interval). Pinned by an anti-vacuity control asserting an ordinary
  pass still restarts.
- **assumed** — exit 75 (`EX_TEMPFAIL`) is free for this meaning; no teatree CLI
  path returns it today.
- **open, out of scope** — the durable post-recreate degradation the issue reports
  (`t3 loop slack-answer run` returning `t3-master has no live owner` minutes
  after the swap) is a different root cause — an orphaned owner lease, not the
  recreate. The issue offers to split it out; it is not addressed here.
- **open, not done** — deploy debouncing (the issue's optional item 5). Each merge
  still gets its own convergence; it is now cheap enough that coalescing is a
  throughput question rather than an availability one.
- **open** — `deploy/deploy.sh` is an unclassifiable path to
  `teatree.quality.affected_tests`, so any change to it escalates the local lane
  to FULL. Reference-mapping `deploy/*` the way `dev/*` lane runners are mapped
  would scope it; not done here to keep the diff on the defect.

## Verification

- `t3 tool verify-gates` → **exit 0** (commit AND push stages green).
- Deploy lane: 63 passed across the six deploy test files touched.
- RED-first evidence: 13/13 in `test_deploy_staged_swap.py` and 4/7 in
  `test_deploy_update_signal.py` observed RED against `main` before the change;
  the watchdog gate has a recorded mutation control.
