### PR TITLE
fix(deploy): close the cold-review residuals and re-derive the stranded-quiescing budget from the staged convergence (#4214)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -141,6 +141,17 @@ have been destroyed with the container objects.
 Init is excluded from stage 8 because a plain `up -d` **starts** an exited
 one-shot, replaying the whole ~minute init.
 
+**An aborted convergence fails towards a stall, not a mismatch.** A run that
+drains and then dies before the swap leaves the gate ON, so an EXIT trap clears it
+and admission resumes. Between stages 3 and 6 that clear is deliberately withheld:
+init has migrated the control DB and the live worker is still the pre-migration
+one, so re-opening admission there hands it fresh work to run against a schema its
+code does not match. The `schema_readiness` gate does not cover this direction —
+it refuses when the code is ahead of the DB, and here the DB is ahead of the code.
+Staying quiesced only stalls the box, which is printed, visible in
+`worker_quiescing`, and cleared by the next successful convergence or by
+`t3 teatree config_setting set worker_quiescing false`.
+
 **The residual window, stated rather than implicit.** Stage 5 still swaps the
 dashboard's own container, so the dashboard is unavailable for that swap —
 seconds, not the 67-second init gate, and the worker answers throughout it.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -803,7 +803,13 @@ service is down — exactly the outage it exists to repair.
    any deploy could explain
    ([#3983](https://github.com/souliane/teatree/issues/3983) — a deploy killed
    between its drain and the swap that clears the gate leaves the claim path
-   admitting ZERO work while every other surface stays green).
+   admitting ZERO work while every other surface stays green). That last budget is
+   **summed from the staged convergence's own per-stage timeouts**
+   (`TEATREE_DRAIN_TIMEOUT` + `TEATREE_INIT_WAIT_TIMEOUT` +
+   `TEATREE_ADMIN_SWAP_BUDGET` + `TEATREE_RESUME_TIMEOUT`, plus slack for the untimed
+   `up -d` steps), because stages 2–7 are serial inside one gate-ON window: raise one
+   on the box and the detector widens with it rather than calling a slower-but-legal
+   convergence an outage.
 4. On any **red** finding it DMs the owner via `t3 teatree notify send`, keyed on
    the finding set so an ongoing outage does not re-spam every pass. (The default
    deploy wires no Slack credential; until you add one the DM step no-ops and the

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -61,20 +61,35 @@ if ! flock -n 9; then
 fi
 
 # Fail-safe against a stranded quiescing gate. If this run drains the worker (which
-# sets `worker_quiescing` ON) but then exits BEFORE the image swap that would
-# recreate the worker and clear the gate via its init (a mid-deploy failure under
-# `set -e`), the still-live OLD worker would stay quiesced forever. The EXIT trap
-# clears the gate so admission resumes. A no-op after a successful swap (the fresh
-# init already cleared it) and when no drain ran; best-effort, never fails the run.
-# Safe under the flock: no other convergence is running to own the gate.
+# sets `worker_quiescing` ON) but then exits BEFORE the swap that would recreate the
+# worker and clear the gate (a mid-deploy failure under `set -e`), the still-live
+# worker would stay quiesced forever. The EXIT trap clears the gate so admission
+# resumes. A no-op after a successful resume and when no drain ran; best-effort,
+# never fails the run. Safe under the flock: no other convergence owns the gate.
+#
+# WHICH WAY TO FAIL depends on which worker is live and what schema it faces. init
+# migrates the control DB at stage 3, so a strand between it and the worker swap
+# leaves PRE-migration code live against the NEW schema — the one window where
+# re-opening admission is worse than leaving it shut, because it hands that worker
+# fresh work to run against a database it does not match. A stall is visible and one
+# command from recovery; a mismatched claim is neither. So the clear is withheld
+# there and taken everywhere else, including after the swap, where the live worker is
+# the fresh one and the clear is `resume_admission`'s retry.
 _DRAINED=false
 _SWAP_DONE=false
+_INIT_RAN=false
+_WORKER_SWAPPED=false
 _clear_quiescing_if_stranded() {
     if [ "$_DRAINED" = true ] && [ "$_SWAP_DONE" = false ]; then
         # Say "cleanup", loudly. This runs LAST, so it is the final line in the
         # Action log and reads as the cause to anyone triaging the failure — it is
         # not; the real error is further up. One triage of this run was nearly
         # anchored on this very line.
+        if [ "$_INIT_RAN" = true ] && [ "$_WORKER_SWAPPED" = false ]; then
+            echo "deploy: [cleanup, NOT the failure cause — see the error above] init already migrated the control DB and the worker was never swapped, so the live worker runs pre-migration code against the new schema." >&2
+            echo "        Leaving worker_quiescing ON: the box admits no new work until a convergence completes. Re-run the deploy, or resume deliberately with 't3 teatree config_setting set worker_quiescing false'." >&2
+            return
+        fi
         echo "deploy: [cleanup, NOT the failure cause — see the error above] exiting after a drain but before the swap; clearing worker_quiescing so admission resumes." >&2
         compose exec -T teatree-worker \
             t3 teatree config_setting set worker_quiescing false >/dev/null 2>&1 || true
@@ -390,6 +405,7 @@ staged_swap() {
     archive_service_logs teatree-init
     compose up -d --no-deps teatree-init || return 1
     wait_for_init || return 1
+    _INIT_RAN=true
 
     # init clears worker_quiescing as its last act, so re-assert the gate: without
     # this the still-live old worker resumes admission and can claim — then lose —
@@ -400,6 +416,7 @@ staged_swap() {
 
     archive_service_logs teatree-worker teatree-slack-listener
     compose up -d --no-deps teatree-worker teatree-slack-listener || return 1
+    _WORKER_SWAPPED=true
     resume_admission
 
     local rest

--- a/src/teatree/cli/doctor/self_heal_quiescing.py
+++ b/src/teatree/cli/doctor/self_heal_quiescing.py
@@ -1,29 +1,44 @@
 """Self-heal detector for a ``worker_quiescing`` gate no deploy can still explain (#3983).
 
 Quiescing is a STEP in a sequence that ends in a restart, never a decision on its own:
-``deploy/deploy.sh``'s drain sets the gate and the fresh worker's init clears it. A
-deploy killed in between — an SSH session torn down mid-drain, then SIGKILLed past any
-trap — leaves it ON, after which the claim path admits ZERO new work while already-
-claimed tasks run to completion, loops keep ticking green and ``t3 worker status``
-reports RUNNING. The outage is visible only by reading the flag, which is how one ran
-for roughly six hours across two failed deploys.
+``deploy/deploy.sh``'s stage-2 drain sets the gate and its stage-7 ``resume_admission``
+clears it on the fresh worker. A deploy killed in between — an SSH session torn down
+mid-drain, then SIGKILLed past any trap — leaves it ON, after which the claim path admits
+ZERO new work while already-claimed tasks run to completion, loops keep ticking green and
+``t3 worker status`` reports RUNNING. The outage is visible only by reading the flag,
+which is how one ran for roughly six hours across two failed deploys.
 
 The gate's own age bounds the deploy that could have set it, so aged past that budget
-there is nothing left to explain it and the finding is a hard FAIL.
+there is nothing left to explain it and the finding is a hard FAIL. The budget is summed
+from the deploy's own per-stage timeouts rather than restated, so raising one on the box
+cannot turn a slower-but-legal convergence into a false outage.
 """
 
 import datetime as dt
 import os
+from itertools import starmap
 
 import typer
 
 from teatree.loop.drain import QUIESCING_SETTING
 
-#: The drain grace ``deploy/deploy.sh`` allows (its ``TEATREE_DRAIN_TIMEOUT`` default).
-_DEFAULT_DRAIN_TIMEOUT_SECONDS = 1800
-#: What the deploy still has to do after the drain — build, `up -d`, and the 60x10s
-#: admin health wait — before the fresh worker's init clears the gate.
-_DEPLOY_SWAP_BUDGET_SECONDS = 1200
+#: Every BOUNDED stage ``deploy/deploy.sh`` runs between the drain that sets the gate
+#: and the ``resume_admission`` that clears it, as ``(env var, deploy.sh default)``. The
+#: staged convergence (#4214) runs them SERIALLY inside one gate-ON window: the stage-4
+#: drain re-dates the gate only when init's clear actually landed, so the honest bound
+#: measures from stage 2. Budgeting the drain alone reported a convergence still inside
+#: its own init wait as a dead one — and this finding is not deploy-sensitive in
+#: ``deploy/watchdog.sh``, so it paged on sight, mid-update.
+_DEPLOY_STAGE_BUDGETS: tuple[tuple[str, int], ...] = (
+    ("TEATREE_DRAIN_TIMEOUT", 1800),
+    ("TEATREE_INIT_WAIT_TIMEOUT", 1800),
+    ("TEATREE_ADMIN_SWAP_BUDGET", 300),
+    ("TEATREE_RESUME_TIMEOUT", 300),
+)
+#: Slack for the convergence's UNTIMED steps — one `up -d --no-deps` per stage, plus any
+#: image pull they trigger. Bounded on purpose: the sum has to stay finite, or a genuinely
+#: stranded gate never reddens.
+_UNTIMED_STAGE_SLACK_SECONDS = 600
 
 
 def _now() -> dt.datetime:
@@ -32,11 +47,15 @@ def _now() -> dt.datetime:
     return timezone.now()
 
 
+def _stage_budget(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    return int(raw) if raw.isdigit() else default
+
+
 def quiescing_deploy_budget_seconds() -> int:
     """The widest window in which a set ``worker_quiescing`` is still a live deploy."""
-    raw = os.environ.get("TEATREE_DRAIN_TIMEOUT", "").strip()
-    drain = int(raw) if raw.isdigit() else _DEFAULT_DRAIN_TIMEOUT_SECONDS
-    return drain + _DEPLOY_SWAP_BUDGET_SECONDS
+    staged = sum(starmap(_stage_budget, _DEPLOY_STAGE_BUDGETS))
+    return staged + _UNTIMED_STAGE_SLACK_SECONDS
 
 
 def _gate_age_seconds() -> float | None:

--- a/tests/teatree_cli/doctor/test_self_heal_quiescing.py
+++ b/tests/teatree_cli/doctor/test_self_heal_quiescing.py
@@ -9,6 +9,7 @@ hard-FAILs past it, so the doctor exit code the watchdog keys on turns red.
 
 import datetime as dt
 import io
+import pathlib
 from collections.abc import Callable
 from contextlib import redirect_stdout
 from unittest import mock
@@ -99,16 +100,50 @@ class StrandedQuiescingCheckTest(django.test.TestCase):
         assert ok is False
         assert "worker_quiescing" in out
 
-    def test_the_budget_covers_the_drain_grace_plus_the_swap(self) -> None:
-        with mock.patch.dict("os.environ", {"TEATREE_DRAIN_TIMEOUT": "600"}):
-            assert (
-                self_heal_quiescing.quiescing_deploy_budget_seconds()
-                == 600 + self_heal_quiescing._DEPLOY_SWAP_BUDGET_SECONDS
-            )
+    def test_a_convergence_still_inside_its_init_wait_is_not_reported_stranded(self) -> None:
+        # The staged convergence (#4214) polls init for up to TEATREE_INIT_WAIT_TIMEOUT
+        # AFTER the drain that sets the gate and BEFORE the stage-4 drain that would
+        # re-date it, so both graces are serial inside one gate-ON window. A budget
+        # covering only the drain calls a live deploy a dead one — and the finding is
+        # not deploy-sensitive in watchdog.sh, so it pages on sight, mid-update.
+        set_worker_quiescing(value=True)
+        with mock.patch.dict(
+            "os.environ",
+            {"TEATREE_DRAIN_TIMEOUT": "1800", "TEATREE_INIT_WAIT_TIMEOUT": "1800"},
+        ):
+            _age_the_gate(1700 + 1500)  # a long-but-legal drain, then a legal init wait
 
-    def test_an_unreadable_drain_timeout_falls_back_to_the_deploy_default(self) -> None:
+            ok, out = _echoes(self_heal_quiescing.check_stranded_quiescing_gate)
+
+        assert ok is True, "a convergence inside its own timeouts is an update, not an outage"
+        assert out == ""
+
+    def test_the_budget_covers_every_bounded_stage_between_the_drain_and_the_clear(self) -> None:
+        stages = {"TEATREE_DRAIN_TIMEOUT": 600, "TEATREE_INIT_WAIT_TIMEOUT": 900, "TEATREE_ADMIN_SWAP_BUDGET": 120}
+        with mock.patch.dict("os.environ", {name: str(value) for name, value in stages.items()}):
+            budget = self_heal_quiescing.quiescing_deploy_budget_seconds()
+
+        unset = dict(self_heal_quiescing._DEPLOY_STAGE_BUDGETS)["TEATREE_RESUME_TIMEOUT"]
+
+        assert budget >= sum(stages.values()), "a stage the deploy is allowed to spend cannot read as a strand"
+        assert budget == sum(stages.values()) + unset + self_heal_quiescing._UNTIMED_STAGE_SLACK_SECONDS
+
+    def test_the_budget_stays_finite_so_a_genuine_strand_still_reddens(self) -> None:
+        # The counterweight to widening it: every stage is bounded, so the sum is too.
+        assert self_heal_quiescing.quiescing_deploy_budget_seconds() < 4 * 3600
+
+    def test_an_unreadable_stage_timeout_falls_back_to_that_stages_deploy_default(self) -> None:
         with mock.patch.dict("os.environ", {"TEATREE_DRAIN_TIMEOUT": "not-a-number"}):
-            expected = (
-                self_heal_quiescing._DEFAULT_DRAIN_TIMEOUT_SECONDS + self_heal_quiescing._DEPLOY_SWAP_BUDGET_SECONDS
-            )
-            assert self_heal_quiescing.quiescing_deploy_budget_seconds() == expected
+            polluted = self_heal_quiescing.quiescing_deploy_budget_seconds()
+        with mock.patch.dict("os.environ", {}, clear=True):
+            clean = self_heal_quiescing.quiescing_deploy_budget_seconds()
+
+        assert polluted == clean
+
+    def test_every_bounded_stage_deploy_sh_runs_in_the_window_is_budgeted(self) -> None:
+        # The budget tracks deploy.sh's contract, so drift in either direction — a stage
+        # renamed there, or one budgeted here that the deploy never waits on — is a bug.
+        deploy_sh = (pathlib.Path(__file__).parents[3] / "deploy" / "deploy.sh").read_text(encoding="utf-8")
+
+        for name, default in self_heal_quiescing._DEPLOY_STAGE_BUDGETS:
+            assert f"{name}:-{default}" in deploy_sh, f"{name} default drifted from deploy.sh"

--- a/tests/test_deploy_rolling_drain.py
+++ b/tests/test_deploy_rolling_drain.py
@@ -19,6 +19,7 @@ import signal
 import subprocess
 import time
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 import yaml
@@ -81,9 +82,21 @@ def _fail_safe_block() -> str:
     return _slice(_DEPLOY_SH.read_text(encoding="utf-8"), _FAIL_SAFE_START, _FAIL_SAFE_END, "stranded-gate fail-safe")
 
 
-def _run_fail_safe_under_signal(tmp_path: Path, sig: int, *, fail_safe: str) -> list[str]:
-    """Signal a script carrying *fail_safe* mid-drain; return the `docker` calls it made."""
+class _FailSafeRun(NamedTuple):
+    calls: list[str]
+    stderr: str
+
+
+def _run_fail_safe_under_signal(
+    tmp_path: Path, sig: int, *, fail_safe: str, stage: str = "_DRAINED=true"
+) -> _FailSafeRun:
+    """Signal a script carrying *fail_safe* mid-run; report its `docker` calls and stderr.
+
+    *stage* is the shipped flag assignment naming how far the convergence got, so a test
+    picks the point of death rather than re-implementing the fail-safe's own conditions.
+    """
     docker_log = tmp_path / "docker.log"
+    stderr_log = tmp_path / "stderr.log"
     ready = tmp_path / "ready"
     stub_bin = tmp_path / "bin"
     stub_bin.mkdir()
@@ -96,22 +109,26 @@ def _run_fail_safe_under_signal(tmp_path: Path, sig: int, *, fail_safe: str) -> 
         "#!/usr/bin/env bash\nset -euo pipefail\nCOMPOSE_FILE=/dev/null\nHOST_IDENTITY_FILE=/dev/null\n"
         f"{_compose_helper_block()}"
         f"{fail_safe}\n"
-        f'_DRAINED=true\ntouch "{ready}"\nsleep 5\n',
+        f'{stage}\ntouch "{ready}"\nsleep 5\n',
         encoding="utf-8",
     )
 
     env = {**os.environ, "PATH": f"{stub_bin}{os.pathsep}{os.environ['PATH']}"}
-    proc = subprocess.Popen(["bash", str(script)], env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)  # noqa: S607 — a fixture-authored script under tmp_path
-    try:
-        deadline = time.monotonic() + 10
-        while not ready.exists() and time.monotonic() < deadline:
-            time.sleep(0.01)
-        assert ready.exists(), "the harness never reached its drain"
-        proc.send_signal(sig)
-        proc.wait(timeout=10)
-    finally:
-        proc.kill()
-    return docker_log.read_text(encoding="utf-8").splitlines() if docker_log.exists() else []
+    with stderr_log.open("w", encoding="utf-8") as stderr_sink:
+        proc = subprocess.Popen(["bash", str(script)], env=env, stdout=subprocess.DEVNULL, stderr=stderr_sink)  # noqa: S607 — a fixture-authored script under tmp_path
+        try:
+            deadline = time.monotonic() + 10
+            while not ready.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert ready.exists(), "the harness never reached its drain"
+            proc.send_signal(sig)
+            proc.wait(timeout=10)
+        finally:
+            proc.kill()
+    return _FailSafeRun(
+        calls=docker_log.read_text(encoding="utf-8").splitlines() if docker_log.exists() else [],
+        stderr=stderr_log.read_text(encoding="utf-8"),
+    )
 
 
 def _deploy_workflow() -> dict:
@@ -233,10 +250,10 @@ class TestDrainSurvivesItsTransport:
         # A dropped SSH session kills deploy.sh with one of these, mid-drain and long
         # before the swap. Run deploy.sh's REAL fail-safe under each and prove it
         # clears the gate — otherwise the still-live old worker admits nothing.
-        calls = _run_fail_safe_under_signal(tmp_path, sig, fail_safe=_fail_safe_block())
+        run = _run_fail_safe_under_signal(tmp_path, sig, fail_safe=_fail_safe_block())
 
-        assert any("config_setting set worker_quiescing false" in call for call in calls), (
-            f"a deploy killed by {signal.Signals(sig).name} after its drain must free admission; docker calls={calls}"
+        assert any("config_setting set worker_quiescing false" in call for call in run.calls), (
+            f"a deploy killed by {signal.Signals(sig).name} after its drain must free admission; calls={run.calls}"
         )
 
     @pytest.mark.integration
@@ -244,6 +261,64 @@ class TestDrainSurvivesItsTransport:
         # The control for the parametrised probe above: strip the trap and the same
         # harness must record NO clear, so a green there is evidence and not an artifact.
         without_trap = _fail_safe_block().replace(_FAIL_SAFE_END, "")
-        calls = _run_fail_safe_under_signal(tmp_path, signal.SIGHUP, fail_safe=without_trap)
+        run = _run_fail_safe_under_signal(tmp_path, signal.SIGHUP, fail_safe=without_trap)
 
-        assert calls == []
+        assert run.calls == []
+
+
+class TestAStrandedConvergenceFailsTowardsTheSaferSide:
+    """Which way the fail-safe fails depends on what the still-live worker would run (#4214)."""
+
+    @pytest.mark.integration
+    def test_a_strand_after_init_leaves_admission_closed_rather_than_admitting_on_a_migrated_db(
+        self, tmp_path: Path
+    ) -> None:
+        # init applies migrations at stage 3, so a convergence that dies between it and
+        # the worker swap leaves the OLD worker — pre-migration code — live against the
+        # NEW schema. Re-opening admission there hands it fresh work to run against a
+        # database it does not match; staying quiesced only stalls, which is visible and
+        # recoverable. Fail towards the stall.
+        run = _run_fail_safe_under_signal(
+            tmp_path,
+            signal.SIGTERM,
+            fail_safe=_fail_safe_block(),
+            stage="_DRAINED=true\n_INIT_RAN=true",
+        )
+
+        assert not any("config_setting set worker_quiescing false" in call for call in run.calls), (
+            f"admission must stay closed on the old worker once init has migrated the DB; docker calls={run.calls}"
+        )
+        assert "worker_quiescing" in run.stderr, "the refusal must name the gate it is deliberately leaving ON"
+
+    def test_the_convergence_records_each_stage_the_fail_safe_branches_on(self) -> None:
+        # The trap reads two flags; both are inert unless the shipped stages set them,
+        # and an inert fail-safe silently reverts to always-clear. Pin each assignment
+        # to the stage whose completion it claims.
+        staged = _staged_swap_block(_DEPLOY_SH.read_text(encoding="utf-8"))
+
+        init_ran_at = staged.index("_INIT_RAN=true")
+        assert staged.index("wait_for_init") < init_ran_at < staged.index("up -d --no-deps teatree-worker"), (
+            "_INIT_RAN must be set once init has migrated and while the OLD worker is still the live one"
+        )
+        assert staged.index("up -d --no-deps teatree-worker") < staged.index("_WORKER_SWAPPED=true"), (
+            "_WORKER_SWAPPED must be set only once the fresh worker has actually been created"
+        )
+        assert staged.index("_WORKER_SWAPPED=true") < staged.index("resume_admission"), (
+            "resume_admission's own failure must leave the trap able to retry the clear"
+        )
+
+    @pytest.mark.integration
+    def test_a_strand_after_the_worker_swap_still_retries_the_clear(self, tmp_path: Path) -> None:
+        # Past the swap the live worker is the FRESH one, which matches the migrated
+        # schema — so the trap's retry of a failed `resume_admission` must survive the
+        # refusal above rather than be caught by it.
+        run = _run_fail_safe_under_signal(
+            tmp_path,
+            signal.SIGTERM,
+            fail_safe=_fail_safe_block(),
+            stage="_DRAINED=true\n_INIT_RAN=true\n_WORKER_SWAPPED=true",
+        )
+
+        assert any("config_setting set worker_quiescing false" in call for call in run.calls), (
+            f"a fresh worker must still have admission restored; docker calls={run.calls}"
+        )

--- a/tests/test_deploy_staged_swap.py
+++ b/tests/test_deploy_staged_swap.py
@@ -290,6 +290,22 @@ class TestAFailedStageStopsBeforeItCostsAvailability:
         assert proc.returncode != 0
         assert worker_at == -1, "with no dashboard answering, swapping the worker leaves no route at all"
 
+    def test_that_abort_leaves_admission_shut_because_init_already_migrated_the_db(
+        self, checkout: Path, tmp_path: Path
+    ) -> None:
+        # Same abort, one stage later in its consequences: init has already migrated the
+        # control DB, and the worker still live is the pre-migration one. The EXIT trap
+        # must not re-open admission on it. End-to-end through the shipped script, so a
+        # fail-safe whose flags were never wired into the convergence reads as the
+        # regression it is.
+        proc, calls = _run(checkout, tmp_path, STUB_CURL_FAIL_AFTER="1")
+
+        assert proc.returncode != 0
+        assert not any("worker_quiescing false" in c for c in calls), (
+            f"a convergence stranded after init must leave the gate ON, not admit on a mismatched worker: {calls!r}"
+        )
+        assert "worker_quiescing" in proc.stderr, "the deliberate refusal must be stated, not silent"
+
 
 class TestTheResidualWindowIsStated:
     def test_the_dashboard_gap_is_measured_and_reported_with_its_bound(self, checkout: Path, tmp_path: Path) -> None:

--- a/tests/test_deploy_update_signal.py
+++ b/tests/test_deploy_update_signal.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import stat
 import subprocess
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -36,6 +37,12 @@ _DISPATCHED_ONE_OFF = "DISPATCHED-RUN"
 # `STUB_RUNNING_SERVICES` is the space-separated set the stub reports as running, so a
 # test can model any stage of a staged swap. `compose ps --status running --quiet
 # <svc>` answers with an id only for a member of that set.
+#
+# `STUB_RUNNING_AT` (epoch seconds) additionally withholds every answer until that
+# instant, modelling a route that is genuinely absent for the first seconds of a swap
+# and comes back mid-wait. A wall-clock gate rather than a probe counter: the wrapper
+# probes each candidate service in turn, so a count is an artifact of the candidate
+# list while elapsed time is what the loop actually waits on.
 _DOCKER_STUB = f"""#!/usr/bin/env bash
 case "$1" in
 version) exit "${{STUB_DAEMON_EXIT:-0}}" ;;
@@ -48,6 +55,9 @@ shift || true
 case "$sub" in
 ps)
     svc="${{@: -1}}"
+    if [ -n "${{STUB_RUNNING_AT:-}}" ] && [ "$(date +%s)" -lt "${{STUB_RUNNING_AT}}" ]; then
+        exit 0
+    fi
     case " ${{STUB_RUNNING_SERVICES:-}} " in
     *" $svc "*) printf '%s\\n' "cid-$svc" ;;
     esac
@@ -172,9 +182,9 @@ class TestAnUpdateIsDistinguishableFromAnOutage:
         assert "update is in progress" in proc.stderr
         assert "is not running" not in proc.stdout
 
-    def test_a_route_that_returns_mid_wait_simply_serves_the_call(self, wrapper: Path, tmp_path: Path) -> None:
-        # The stub reports the admin back from the first probe on, which is what a
-        # staged swap looks like from outside: the window is short and self-clearing.
+    def test_a_live_route_serves_the_call_without_ever_waiting(self, wrapper: Path, tmp_path: Path) -> None:
+        # A convergence is in flight AND a route is up — the staged swap's normal shape.
+        # The wait is for the gap between two stages, so a live route must skip it.
         with _held_lock(tmp_path / "deploy.lock"):
             proc = _run(
                 wrapper,
@@ -184,6 +194,26 @@ class TestAnUpdateIsDistinguishableFromAnOutage:
             )
 
         assert proc.returncode == 0
+        assert "DISPATCHED-EXEC teatree-admin" in proc.stdout
+        assert "waiting up to" not in proc.stderr, "a route that is already up must not enter the wait at all"
+
+    def test_a_route_that_returns_mid_wait_simply_serves_the_call(self, wrapper: Path, tmp_path: Path) -> None:
+        # Nothing answers at first, so the wrapper enters the wait; the admin appears a
+        # few seconds in, as it does when its stage of the swap completes. Only a
+        # re-probe INSIDE the loop can see that, which is what this pins: without one
+        # the loop sleeps out its whole budget and reports the update-in-progress exit
+        # even though the substrate came back.
+        with _held_lock(tmp_path / "deploy.lock"):
+            proc = _run(
+                wrapper,
+                tmp_path,
+                STUB_RUNNING_SERVICES="teatree-admin",
+                STUB_RUNNING_AT=str(int(time.time()) + 3),
+                TEATREE_UPDATE_WAIT_SECONDS="30",
+            )
+
+        assert proc.returncode == 0, f"the wrapper must recover mid-wait, not exit {proc.returncode}: {proc.stderr}"
+        assert "waiting up to" in proc.stderr, "the wait must actually have been entered for this to prove anything"
         assert "DISPATCHED-EXEC teatree-admin" in proc.stdout
 
 


### PR DESCRIPTION
Follow-up to [#4329](https://github.com/souliane/teatree/pull/4329) (merged). Closes the two residuals its cold review recorded, plus one defect that review did not reach: a consumer of the deploy's timing contract that #4329 left modelling the sequence it replaced.

Relates to [#4214](https://github.com/souliane/teatree/issues/4214).

## Why

#4329 replaced one all-at-once `compose up -d --build` with an 8-stage convergence. Two things follow that the merged PR did not finish:

1. The convergence now has an interior — a window where init has migrated the control DB and the OLD worker is still live. The stranded-gate EXIT trap re-opened admission there, handing pre-migration code fresh work against the new schema.
2. The convergence is now much LONGER, and one stage's timeout is serial with another's inside a single `worker_quiescing` window. The self-heal detector that watches for a stranded gate ([#3983](https://github.com/souliane/teatree/issues/3983)) still budgeted for the retired sequence, so a healthy update tripped it — which is #4214's own "an update is indistinguishable from an outage" failure mode, reintroduced in the alerting plane by the fix that made the deploy longer.

## What

### 1. A stranded convergence must not admit work on a mismatched worker (`73bdfabf`)

`schema_readiness` does not cover this direction: it refuses when the code is ahead of the DB, and here the DB is ahead of the code, which reads CURRENT. The trap now branches on how far the convergence got — between init and the worker swap the clear is withheld and the reason printed; everywhere else it is taken as before, including after the swap where the live worker is the fresh one and the clear is `resume_admission`'s retry.

A stall is visible in `worker_quiescing`, printed at the point of decision, and cleared by the next successful convergence or by one named command. A mismatched claim is none of those.

### 2. The wrapper's wait-and-recover loop is now pinned (`73bdfabf`)

Gutting the in-loop re-probe in `deploy/t3` left all seven update-signal tests green — the mid-wait test had its stub report the admin running from the FIRST probe, so the loop was never entered and the test's name was not true of it. The stub can now withhold every answer until a wall-clock instant; the wait-skipping case it used to cover is kept as its own test.

### 3. The stranded-quiescing budget tracks the staged convergence (`f54f0c62`)

`quiescing_deploy_budget_seconds()` dated the gate against `TEATREE_DRAIN_TIMEOUT + 1200s`, a budget whose own comment described what #4329 replaced: *"build, `up -d`, and the 60x10s admin health wait — before the fresh worker's init clears the gate"*. None of that is still true — the build now runs BEFORE the drain, and stage 7's `resume_admission` clears the gate, not init.

The reachable failure: stage 2 (`t3 worker drain`, up to `TEATREE_DRAIN_TIMEOUT`) and stage 3 (`wait_for_init`, up to `TEATREE_INIT_WAIT_TIMEOUT`) run SERIALLY inside one gate-ON window — the stage-4 drain re-dates the gate only when init's clear actually landed, so the honest bound measures from stage 2. On the defaults that window is `1800 + 1800 + 300 + 300`s against a budget of `3000`s, so a long-but-legal drain (in-flight agents finishing — the whole point of the drain) followed by a normal init wait reads as a gate "no deploy can still explain". The finding is not one of the three `_deploy_sensitive_token` classes in `deploy/watchdog.sh`, so it is neither gated on the deploy lock nor held for a second observation: it pages the owner on sight, mid-update, asserting no deploy is running while one is.

The budget is now summed from the deploy's own per-stage timeouts, read from the same env vars with the same defaults `deploy.sh` uses, plus bounded slack for the untimed `up -d` steps. Raising one on the box widens the detector with it. Every stage is bounded, so the sum stays finite and a genuine strand still reddens — roughly 73 min rather than 50, against the ~6 h outage #3983 was filed for.

## Proof

- `tests/teatree_cli/doctor/` + the five deploy test files: **668 passed**.
- The doctor file alone: **12 passed**; observed RED before the fix with `AssertionError: a convergence inside its own timeouts is an update, not an outage`.
- Mutants for commit 3, all RED: revert to `drain + 1200`; drop the init-wait stage from the table; ignore the env and always take the default; make the slack unbounded; drift a default away from `deploy.sh`.
- Mutants for commit 1, all RED: refuse without checking whether the worker was swapped; never set `_INIT_RAN`; never set `_WORKER_SWAPPED`; restore the unconditional clear. The mid-wait test is the only one of the eight update-signal tests that catches the gutted re-probe (1 failed / 7 passed).
- `t3 tool verify-gates` → **exit 0** (commit + push stages).
- `uv run tach check` → **exit 0**.
- `bash dev/test-affected.sh` escalates to FULL on `deploy/deploy.sh` (unclassifiable path, fail-safe). The local FULL run was killed by its own 1800s `timeout` under box load — it is **not** a green I can claim. CI's required sharded whole-tree lane is the authority on it.

## Open questions & assumptions

- **assumed** — a stalled box is preferable to admission on a schema-mismatched worker. The stall is bounded by the next convergence and is printed; the mismatch is silent. Stated in `deploy/README.md` so the trade is reviewable rather than implicit.
- **assumed** — `_WORKER_SWAPPED` is the right discriminator rather than `_SWAP_DONE`, which is set only on a SUCCESSFUL resume and so cannot distinguish "the fresh worker exists" from "admission was restored". Pinned by the post-swap retry test.
- **assumed** — measuring the quiescing budget from stage 2 rather than stage 4 is the honest bound. Stage 4 re-writes the row only when init's clear landed, so a run where it did not must not be dated from a write that never happened.
- **assumed** — 600s of slack covers the convergence's untimed `up -d --no-deps` steps and any image pull they trigger. Bounded deliberately: an unbounded budget is a detector that never fires, which the finite-budget test pins.
- **decided-not-to-change** — `deploy/watchdog.sh` still does not classify the stranded-quiescing finding as deploy-sensitive, so it pages on first observation with no in-flight suppression. With the budget correct a convergence inside its timeouts cannot trip it, and one that exceeds a timeout has already aborted (`FATAL`) — so the gate genuinely is stranded and paging on sight is right. Adding the token would delay a real 6 h strand by one watchdog interval for no gain.
- **decided-by-review** — items 1 and 2 were recorded as residuals on a `merge_safe` verdict, not blockers. Closed here rather than deferred to a follow-up ticket.
- **assumed** — this branch was cut fresh from `origin/main` and carries only the two follow-up commits, because #4329 was SQUASH-merged: a PR from the original branch would have re-proposed its 1052 already-landed lines (`git merge-base --is-ancestor b72e224da <old-head>` → false). Tree parity with the original branch was verified byte-identical.
- **open** — the residual dashboard swap window is unchanged — still measured, printed, and bounded by `TEATREE_ADMIN_SWAP_BUDGET`.
- **open** — #4214's acceptance asks for verification by an actual update with a task in flight. This branch, like #4329, is proved at the harness level (stubbed `docker`/`curl`/`t3`) plus base-vs-head anti-vacuity. A real on-box convergence is still the only thing that can close that criterion end to end.

## Architecture pre-check — #4214

**1. BLUEPRINT § alignment** — no BLUEPRINT section governs the deploy plane; the authority is `deploy/README.md` § "the staged convergence", updated in the same commit to state how the detector's budget is derived. No contradiction introduced.

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition is added, moved, or removed. `worker_quiescing` is a config gate, not an FSM state.

**3. Extension-point contracts** — none. No `OverlayBase` hook, scanner registration, hook surface, or `*Backend` Protocol is touched. `check_stranded_quiescing_gate` is consumed only by `src/teatree/cli/doctor/self_heal.py`; `quiescing_deploy_budget_seconds` only by its own tests (`grep -rln` over `src` + `tests` confirms both).

**4. Component boundaries** — the detector stays in `src/teatree/cli/doctor/`, beside the sequence it reads and the `self_heal` runner that calls it. The deploy-side change stays in `deploy/`. No straddle.

**5. Dependency direction** — one stdlib import added (`itertools.starmap`, via `ruff`'s autofix). No new cross-module edge. `uv run tach check` → `✅ All modules validated!`, exit 0.

**6. Test surface** — `tests/teatree_cli/doctor/test_self_heal_quiescing.py`. `test_a_convergence_still_inside_its_init_wait_is_not_reported_stranded` is the behaviour-level assertion that fails if the budget stops covering a serial drain+init window; `test_the_budget_covers_every_bounded_stage_between_the_drain_and_the_clear` pins the per-stage sum; `test_the_budget_stays_finite_so_a_genuine_strand_still_reddens` pins the counterweight; `test_every_bounded_stage_deploy_sh_runs_in_the_window_is_budgeted` reads `deploy/deploy.sh` and turns red if a default drifts in either file.

**7. Resilience invariants** — no external write is added. The change makes an existing *read* honest. Of the five: **verify-by-re-read** n/a (no write); **fallback-transport** unchanged (the finding still surfaces via `t3 doctor check` and the watchdog DM); **idempotency** — the budget is a pure function of env + constants, so repeated evaluation is identical; **heartbeat** unchanged; **sub-agent return contract** n/a.

**8. Identity and key normalization** — the identity is a deploy stage, keyed by the env var name `deploy.sh` reads it from — the fully-qualified form, used verbatim as the table key, the `os.environ` lookup, and the `deploy.sh` drift assertion. No `split`/`strip`/`removeprefix` is used to make a comparison succeed.

**9. Behavior preservation / capability deletion** — this replaces `quiescing_deploy_budget_seconds`'s body, so its prior behaviours are enumerated against `git show <base>:<path>`: (a) reads `TEATREE_DRAIN_TIMEOUT` from env — **preserved**, now one row of the table; (b) falls back to a hardcoded default on a non-numeric/absent value — **preserved** per stage, pinned by `test_an_unreadable_stage_timeout_falls_back_to_that_stages_deploy_default`; (c) returns a finite bound so an aged gate hard-FAILs — **preserved**, pinned by `test_the_budget_stays_finite_...`. Nothing is dropped. The gate is **widened, not narrowed**, and the direction is deliberate: it removes false alarms during a legitimate deploy and keeps every true-strand FAIL, at the cost of ~23 min of extra detection latency on a ~6 h outage class. No must-block test was inverted; both retired constant-level tests were replaced by stricter contract-level ones, and the four behaviour tests that pinned the FAIL path (`test_a_gate_older_than_any_deploy_could_explain_hard_fails`, `..._no_db_row_can_date...`, `..._not_swallowed_by_the_watchdogs_deploy_sensitive_gating`, `..._wired_into_the_self_heal_sequence`) are untouched and still green.

**10. Removability / harness-vs-data** — removable: reverting the module to `drain + 1200` restores the prior behaviour with no other edit (the 5 mutation controls demonstrate exactly that revert). Blast radius is one module plus its mirror test. **Harness vs data:** the varying part — which stages exist and what each is allowed to spend — is data (`_DEPLOY_STAGE_BUDGETS`, overridable per stage by the box's own env), and the harness is the generic sum. The per-stage defaults are duplicated from `deploy.sh` by necessity (a shell script is not importable), which is why the drift test asserts parity against its text rather than trusting the copy.
